### PR TITLE
Enh/h5dataio to array

### DIFF
--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -474,7 +474,23 @@ class DataIO(with_metaclass(ABCMeta, object)):
         return len(self.__data)
 
     def __getattr__(self, attr):
+        """Delegate attribute lookup to data object"""
         return getattr(self.data, attr)
+
+    def __array__(self):
+        """
+        Support conversion of DataIO.data to a numpy array. This function is
+        provided to improve transparent interoperability of DataIO with numpy.
+
+        :return: An array instance of self.data
+        """
+        if hasattr(self.data, '__array__'):
+            return self.data.__array__()
+        elif isinstance(self.data, DataChunkIterator):
+            raise NotImplementedError("Conversion of DataChunkIterator to array not supported")
+        else:
+            # NOTE this may result in a copy of the array
+            return np.asarray(self.data)
 
     # Delegate iteration interface to data object:
     def __next__(self):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -311,6 +311,25 @@ class H5IOTest(unittest.TestCase):
                      fillvalue=100)
             self.assertEqual(len(w), 7)
 
+    def test_h5dataio_array_conversion_numpy(self):
+        # Test that H5DataIO.__array__ is working when wrapping an ndarray
+        test_speed = np.array([10., 20.])
+        data = H5DataIO((test_speed))
+        self.assertTrue(np.all(np.isfinite(data)))  # Force call of H5DataIO.__array__
+
+    def test_h5dataio_array_conversion_list(self):
+        # Test that H5DataIO.__array__ is working when wrapping a python list
+        test_speed = [10., 20.]
+        data = H5DataIO(test_speed)
+        self.assertTrue(np.all(np.isfinite(data)))  # Force call of H5DataIO.__array__
+
+    def test_h5dataio_array_conversion_datachunkiterator(self):
+        # Test that H5DataIO.__array__ is working when wrapping a python list
+        test_speed = DataChunkIterator(data=[10., 20.])
+        data = H5DataIO(test_speed)
+        with self.assertRaises(NotImplementedError):
+            np.isfinite(data)  # Force call of H5DataIO.__array__
+
     #############################################
     #  Copy/Link h5py.Dataset object
     #############################################


### PR DESCRIPTION
## Motivation

np.isfinite was not working correctly for H5DataIO when wrapping a Python List. See https://github.com/NeurodataWithoutBorders/pynwb/issues/807

## Change

To fix the issue I added the ``__array__`` function similar to numpy to the DataIO class. This allows numpy to cast H5DataIO to an array when a list is being wrapped (as well as when a numpy array is being wrapped). 

## How to test the behavior?
```
import numpy as np
from hdmf.data_utils import H5DataIO
data = H5DataIO(np.array([10., 20.]))
np.isfinite(data)  # Already worked because of the forwarding of attributes in DataIO.__getattr__
data = H5DataIO([10., 20.])
np.isfinite(data)  # Used to fail
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
