### PR TITLE
fix MPI support

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -33,7 +33,7 @@ class HDF5IO(HDMFIO):
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
             {'name': 'mode', 'type': str,
              'doc': 'the mode to open the HDF5 file with, one of ("w", "r", "r+", "a", "w-")'},
-            {'name': 'comm', 'type': 'Intracom',
+            {'name': 'comm', 'type': 'Intracomm',
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
             {'name': 'file', 'type': File, 'doc': 'a pre-existing h5py.File object', 'default': None})
     def __init__(self, **kwargs):

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -393,7 +393,11 @@ class HDF5IO(HDMFIO):
     def open(self):
         if self.__file is None:
             open_flag = self.__mode
-            self.__file = File(self.__path, open_flag)
+            if self.comm:
+                kwargs = {'driver': 'mpio', 'comm': self.comm}
+            else:
+                kwargs = {}
+            self.__file = File(self.__path, open_flag, **kwargs)
 
     def close(self):
         if self.__file is not None:


### PR DESCRIPTION
## Motivation

This mirrors a change we made to pynwb to fix interfacing with MPI.
fix https://github.com/NeurodataWithoutBorders/pynwb/issues/362


## How to test the behavior?
```python
from mpi4py import MPI                                                                                                
import h5py                                                                                                           
                                                                                                                      
from dateutil import tz                                                                                               
                                                                                                                      
from pynwb.form.backends.hdf5.h5tools import HDF5IO                                                                   
from pynwb import NWBHDF5IO, NWBFile, TimeSeries                                                                      
from datetime import datetime                                                                                         
                                                                                                                      
start_time = datetime(2018, 4, 25, 2, 30, 3, tzinfo=tz.gettz('US/Pacific'))                                           
                                                                                                                      
fname = 'test_parallel_pynwb.nwb'                                                                                     
                                                                                                                      
rank = MPI.COMM_WORLD.rank  # The process ID (integer 0-3 for 4-process run)                                          
                                                                                                                      
if not rank:                                                                                                          
    nwbfile = NWBFile('aa', 'aa', datetime.now())                                                                     
    nwbfile.add_acquisition(TimeSeries('ts_name', description='desc', data=[0, 0, 0, 0], rate=100., unit='m'))        
    with NWBHDF5IO(fname, 'w') as io:                                                                                 
        io.write(nwbfile)                                                                                             
                                                                                                                      
MPI.COMM_WORLD.Barrier()                                                                                              
                                                                                                                      
with NWBHDF5IO(fname, 'a', comm=MPI.COMM_WORLD) as io:                                                                
        nwbfile = io.read()
        print(rank)                                                                                           
        nwbfile.acquisition['ts_name'].data[rank] = rank
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
