### PR TITLE
add support for uint as datatype

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -366,6 +366,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         "uint32": np.uint32,
         "uint16": np.uint16,
         "uint8": np.uint8,
+        "uint": np.uint32
     }
 
     __no_convert = set()


### PR DESCRIPTION
fix https://github.com/NeurodataWithoutBorders/nwb-schema/issues/254

---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

## Motivation

`int` maps to `int32`, so it stands to reason that `uint` should map to `uint32`.

## How to test the behavior?
testing this is pretty elaborate, as it would require you to create an extension that uses uint, then construct a file, then write it.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
