### PR TITLE
add shape constraint to generated docval

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1318,6 +1318,8 @@ class TypeMap(object):
         for f, field_spec in addl_fields.items():
             dtype = self.__get_type(field_spec)
             docval_arg = {'name': f, 'type': dtype, 'doc': field_spec.doc}
+            if hasattr(field_spec, 'shape') and field_spec.shape is not None:
+                docval_arg.update(shape=field_spec.shape)
             if not field_spec.required:
                 docval_arg['default'] = getattr(field_spec, 'default_value', None)
             docval_args.append(docval_arg)


### PR DESCRIPTION
fix #28

---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

## How to test the behavior?
```python
from pynwb.spec import NWBDatasetSpec, NWBGroupSpec, NWBNamespaceBuilder

name = 'test_shape'
ns_path = name + ".namespace.yaml"
ext_source = name + ".extensions.yaml"


test_type = NWBGroupSpec(
    neurodata_type_def='TestType',
    datasets=[
        NWBDatasetSpec(name='int_var', dtype='int', doc='doc', quantity='?', shape=(2, 2))
    ],
    doc='doc')


ns_builder = NWBNamespaceBuilder(name + ' extensions', name)
ns_builder.add_spec(ext_source, test_type)
ns_builder.export(ns_path)


from pynwb import load_namespaces, get_class

load_namespaces(ns_path)
test_type = get_class('TestType', name)

test_type(name='test_name', int_var=[1,2,3])
```

now gives the following error (correctly):
```python
Traceback (most recent call last):
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1741, in <module>
    main()
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1735, in main
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py", line 1135, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm CE.app/Contents/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/bendichter/Library/Preferences/PyCharmCE2019.1/scratches/scratch_22.py", line 26, in <module>
    test_type(name='test_name', int_var=[1,2,3])
  File "/Users/bendichter/dev/hdmf/src/hdmf/utils.py", line 379, in func_call
    raise_from(ExceptionType(msg), None)
  File "<string>", line 3, in raise_from
ValueError: incorrect shape for 'int_var' (got '(3,), expected '[2, 2]')
```

and 

```python
test_type(name='test_name', int_var=[[1,1],[1,1]])
```
runs without error.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
