### PR TITLE
correctly infer dtype

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -999,7 +999,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                     builder.set_link(LinkBuilder(rendered_obj, name, builder))
                 elif isinstance(spec, DatasetSpec):
                     if rendered_obj.dtype is None and spec.dtype is not None:
-                        val, dtype = self.convert_dtype(spec, None)
+                        val, dtype = self.convert_dtype(spec, rendered_obj.data)
                         rendered_obj.dtype = dtype
                     builder.set_dataset(rendered_obj)
                 else:


### PR DESCRIPTION
## Motivation

fix #32

Address https://github.com/NeurodataWithoutBorders/pynwb/pull/885#issuecomment-482863204

https://github.com/NeurodataWithoutBorders/pynwb/pull/885

## How to test the behavior?
```python
from pynwb import NWBFile, NWBHDF5IO
from datetime import datetime
from dateutil.tz import tzlocal

start_time = datetime(2019, 1, 1, 11, tzinfo=tzlocal())

nwbfile = NWBFile('aa', 'TSD', start_time)

nwbfile.add_trial(start_time=3.4, stop_time=5.5)
with NWBHDF5IO('/Users/bendichter/dev/pynwb/test_precision.nwb', 'w') as io:
    io.write(nwbfile)

with NWBHDF5IO('/Users/bendichter/dev/pynwb/test_precision.nwb', 'r') as io:
    print(type(io.read().trials['start_time'].data[0]))
```

Should print:
```python
<class 'numpy.float64'>
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
