### PR TITLE
fix adding datasets to get_class

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from copy import copy
 from datetime import datetime
 from six import with_metaclass, raise_from, text_type, binary_type, integer_types
+from inspect import isclass
 
 from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args, call_docval_func
 from ..container import Container, Data, DataRegion
@@ -1335,7 +1336,9 @@ class TypeMap(object):
                 docval_args.append(docval_arg)
                 if f not in existing_args:
                     new_args.append(f)
-                if issubclass(dtype, (Container, Data, DataRegion)):
+                if not isinstance(dtype, tuple):
+                    dtype = (dtype,)
+                if any(isclass(x) and issubclass(x, (Container, Data, DataRegion)) for x in dtype):
                     fields.append({'name': f, 'child': True})
                 else:
                     fields.append(f)


### PR DESCRIPTION
fix adding field with multiple possible types and where types are not resolved and remain strings (e.g. 'array')

fix https://github.com/NeurodataWithoutBorders/pynwb/issues/912

## Motivation

get_class now works when you add a dataset to a neurodata_type
## How to test the behavior?
```python
from pynwb.spec import NamespaceBuilder, NWBGroupSpec
import os

name = 'single_dataset'
doc = 'example extension for single dataset'

ns_builder = NamespaceBuilder(doc=doc, name=name, version='0.1',
                              author=['author'],
                              contact='email')

ns_builder.include_type('NWBData', namespace='core')
ns_builder.include_type('LabMetaData', namespace='core')

meta_data = NWBGroupSpec(neurodata_type_inc='LabMetaData', neurodata_type_def='SimulationMetaData', doc='doc',
                         name='simulation_metadata')
meta_data.add_attribute(name='help', doc='doc', dtype='text', default_value='help text here')
dataset = meta_data.add_dataset(name='pin', doc='doc', dtype='float', shape=(None, 12), dims=('runs', 'params'))
dataset.add_attribute(name='help', doc='doc', dtype='text', default_value='help text here')


ns_path = name + '.namespace.yaml'
ext_source = name + '.extensions.yaml'

# Export
for neurodata_type in [meta_data]:
    ns_builder.add_spec(ext_source, neurodata_type)
ns_builder.export(ns_path)
```

```python
from pynwb import NWBHDF5IO, NWBFile, load_namespaces, get_class
from datetime import datetime
import numpy as np


nwbfile = NWBFile('aa', 'aa', datetime.now().astimezone())

load_namespaces('/Users/bendichter/dev/to_nwb/to_nwb/ndx_single_dataset/spec/single_dataset.namespace.yaml')

sim_meta_data = get_class('SimulationMetaData', 'single_dataset')

meta_data = sim_meta_data(name='simulation_settings', pin=np.random.randn(1000, 12))
nwbfile.add_lab_meta_data(meta_data)

with NWBHDF5IO('test_a.nwb', 'w') as io:
    io.write(nwbfile)


with NWBHDF5IO('test_a.nwb', 'r') as io:
    nwb2 = io.read()
    print(nwb2.lab_meta_data['simulation_metadata'].pin[:])
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
