### PR TITLE
fix get_class with supplied name

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1400,11 +1400,15 @@ class TypeMap(object):
                     fields.append({'name': f, 'child': True})
                 else:
                     fields.append(f)
+        if 'name' in field_spec:
+            docval_args = filter(lambda x: x['name'] != 'name', docval_args)
 
         @docval(*docval_args)
         def __init__(self, **kwargs):
             pargs, pkwargs = fmt_docval_args(base.__init__, kwargs)
-            super(type(self), self).__init__(*pargs, **pkwargs)
+            if 'name' in field_spec:
+                pargs.insert(0, field_spec['name'])
+            base.__init__(self, *pargs, **pkwargs)
             for f in new_args:
                 setattr(self, f, kwargs.get(f, None))
 

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1372,7 +1372,7 @@ class TypeMap(object):
                 ret = True
         return ret
 
-    def __get_cls_dict(self, base, addl_fields):
+    def __get_cls_dict(self, base, addl_fields, name=None):
         # TODO: fix this to be more maintainable and smarter
         if base is None:
             raise ValueError('cannot generate class without base class')
@@ -1400,14 +1400,14 @@ class TypeMap(object):
                     fields.append({'name': f, 'child': True})
                 else:
                     fields.append(f)
-        if 'name' in field_spec:
+        if name is not None:
             docval_args = filter(lambda x: x['name'] != 'name', docval_args)
 
         @docval(*docval_args)
         def __init__(self, **kwargs):
             pargs, pkwargs = fmt_docval_args(base.__init__, kwargs)
-            if 'name' in field_spec:
-                pargs.insert(0, field_spec['name'])
+            if name is not None:
+                pargs.insert(0, name)
             base.__init__(self, *pargs, **pkwargs)
             for f in new_args:
                 setattr(self, f, kwargs.get(f, None))
@@ -1451,7 +1451,7 @@ class TypeMap(object):
             for k, field_spec in attr_names.items():
                 if not spec.is_inherited_spec(field_spec):
                     fields[k] = field_spec
-            d = self.__get_cls_dict(parent_cls, fields)
+            d = self.__get_cls_dict(parent_cls, fields, spec.name)
             cls = ExtenderMeta(str(name), bases, d)
             self.register_container_type(namespace, data_type, cls)
         return cls


### PR DESCRIPTION
if name is in spec fields, remove from `docval` and add directly to args in `__init__`

## Motivation

fix #48, fix https://github.com/NeurodataWithoutBorders/pynwb/issues/892

## How to test the behavior?
```python
from pynwb import NWBHDF5IO, NWBFile, load_namespaces, get_class
from datetime import datetime
import numpy as np


nwbfile = NWBFile('aa', 'aa', datetime.now().astimezone())

load_namespaces('/Users/bendichter/dev/to_nwb/to_nwb/ndx_single_dataset/spec/single_dataset.namespace.yaml')

sim_meta_data = get_class('SimulationMetaData', 'single_dataset')

meta_data = sim_meta_data(pin=np.random.randn(1000, 12))
nwbfile.add_lab_meta_data(meta_data)

with NWBHDF5IO('test_a.nwb', 'w') as io:
    io.write(nwbfile, cache_spec=True)


with NWBHDF5IO('test_a.nwb', 'r', load_namespaces=True) as io:
    nwb2 = io.read()
    print(nwb2.lab_meta_data)
```
works and 
```python
meta_data = sim_meta_data(name='bad_name_here', pin=np.random.randn(1000, 12))
``` 
correctly throws an error


## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
