### PR TITLE
Revert "fix get_class with supplied name"

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1372,7 +1372,7 @@ class TypeMap(object):
                 ret = True
         return ret
 
-    def __get_cls_dict(self, base, addl_fields, name=None):
+    def __get_cls_dict(self, base, addl_fields):
         # TODO: fix this to be more maintainable and smarter
         if base is None:
             raise ValueError('cannot generate class without base class')
@@ -1400,15 +1400,11 @@ class TypeMap(object):
                     fields.append({'name': f, 'child': True})
                 else:
                     fields.append(f)
-        if name is not None:
-            docval_args = filter(lambda x: x['name'] != 'name', docval_args)
 
         @docval(*docval_args)
         def __init__(self, **kwargs):
             pargs, pkwargs = fmt_docval_args(base.__init__, kwargs)
-            if name is not None:
-                pargs.insert(0, name)
-            base.__init__(self, *pargs, **pkwargs)
+            super(type(self), self).__init__(*pargs, **pkwargs)
             for f in new_args:
                 setattr(self, f, kwargs.get(f, None))
 
@@ -1451,7 +1447,7 @@ class TypeMap(object):
             for k, field_spec in attr_names.items():
                 if not spec.is_inherited_spec(field_spec):
                     fields[k] = field_spec
-            d = self.__get_cls_dict(parent_cls, fields, spec.name)
+            d = self.__get_cls_dict(parent_cls, fields)
             cls = ExtenderMeta(str(name), bases, d)
             self.register_container_type(namespace, data_type, cls)
         return cls


### PR DESCRIPTION
Reverts hdmf-dev/hdmf#51

This change creates the following errors in pynwb:
```
======================================================================
ERROR: test_roundtrip (ui_write.test_ecephys.FeatureExtractionConstructor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1205, in construct
    obj = cls(**kwargs)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 389, in func_call
    raise_from(ExceptionType(msg), None)
  File "<string>", line 3, in raise_from
TypeError: incorrect type for 'description' (got 'Dataset', expected 'list, tuple, ndarray or DataChunkIterator')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 181, in test_roundtrip
    self.read_container = self.roundtripContainer()
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 170, in roundtripContainer
    read_nwbfile = self.reader.read()
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\backends\io.py", line 33, in read
    container = self.__manager.construct(f_builder)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 200, in construct
    result = self.__type_map.construct(builder, self)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1650, in construct
    return attr_map.construct(builder, build_manager)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1181, in construct
    subspecs = self.__get_subspec_values(builder, self.spec, manager)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1125, in __get_subspec_values
    self.__get_sub_builders(groups, spec.groups, manager, ret)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1163, in __get_sub_builders
    ret.update(self.__get_subspec_values(sub_builder, subspec, manager))
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1125, in __get_subspec_values
    self.__get_sub_builders(groups, spec.groups, manager, ret)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1155, in __get_sub_builders
    sub_builder = self.__flatten(sub_builder, subspec, manager)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1168, in __flatten
    tmp = [manager.construct(b) for b in sub_builder]
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1168, in <listcomp>
    tmp = [manager.construct(b) for b in sub_builder]
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 200, in construct
    result = self.__type_map.construct(builder, self)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1650, in construct
    return attr_map.construct(builder, build_manager)
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\utils.py", line 391, in func_call
    return func(self, **parsed['args'])
  File "c:\users\ryan\documents\nwb\hdmf\src\hdmf\build\map.py", line 1209, in construct
    raise_from(Exception(msg), ex)
  File "<string>", line 3, in raise_from
Exception: Could not construct FeatureExtraction object

======================================================================
ERROR: test_roundtrip (ui_write.test_ophys.ImageMaskRoundtrip) (container_type='ImageSeries', nwbfield='external_file')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 128, in assertContainerEqual
    npt.assert_almost_equal(f1, f2)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 572, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 1007, in assert_array_almost_equal
    precision=decimal)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 781, in assert_array_compare
    val = comparison(x, y)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 998, in compare
    z = abs(x - y)
TypeError: unsupported operand type(s) for -: 'str' and 'str'

======================================================================
ERROR: test_roundtrip (ui_write.test_ophys.MaskRoundTrip) (container_type='ImageSeries', nwbfield='external_file')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 128, in assertContainerEqual
    npt.assert_almost_equal(f1, f2)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 572, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 1007, in assert_array_almost_equal
    precision=decimal)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 781, in assert_array_compare
    val = comparison(x, y)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 998, in compare
    z = abs(x - y)
TypeError: unsupported operand type(s) for -: 'str' and 'str'

======================================================================
ERROR: test_roundtrip (ui_write.test_ophys.PixelMaskRoundtrip) (container_type='ImageSeries', nwbfield='external_file')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 128, in assertContainerEqual
    npt.assert_almost_equal(f1, f2)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 572, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 1007, in assert_array_almost_equal
    precision=decimal)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 781, in assert_array_compare
    val = comparison(x, y)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 998, in compare
    z = abs(x - y)
TypeError: unsupported operand type(s) for -: 'str' and 'str'

======================================================================
ERROR: test_roundtrip (ui_write.test_ophys.TestPlaneSegmentation) (container_type='ImageSeries', nwbfield='external_file')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Ryan\Documents\NWB\pynwb\tests\integration\ui_write\base.py", line 128, in assertContainerEqual
    npt.assert_almost_equal(f1, f2)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 572, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 1007, in assert_array_almost_equal
    precision=decimal)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 781, in assert_array_compare
    val = comparison(x, y)
  File "C:\Users\Ryan\Anaconda3\envs\ext-sub\lib\site-packages\numpy-1.16.3-py3.7-win-amd64.egg\numpy\testing\_private\utils.py", line 998, in compare
    z = abs(x - y)
TypeError: unsupported operand type(s) for -: 'str' and 'str'

----------------------------------------------------------------------
Ran 148 tests in 18.922s

FAILED (errors=5, skipped=87)
======================================================================
```