### PR TITLE
set builder source correctly when reading HDF5

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -285,7 +285,7 @@ class HDF5IO(HDMFIO):
                         else:
                             builder = self.__read_group(sub_h5obj, builder_name, ignore=ignore)
                         self.__set_built(sub_h5obj.file.filename, target_path, builder)
-                    link_builder = LinkBuilder(builder, k, source=self.__path)
+                    link_builder = LinkBuilder(builder, k, source=h5obj.file.filename)
                     link_builder.written = True
                     kwargs['links'][builder_name] = link_builder
                 else:
@@ -306,7 +306,7 @@ class HDF5IO(HDMFIO):
                 warnings.warn('Broken Link: %s' % os.path.join(h5obj.name, k))
                 kwargs['datasets'][k] = None
                 continue
-        kwargs['source'] = self.__path
+        kwargs['source'] = h5obj.file.filename
         ret = GroupBuilder(name, **kwargs)
         ret.written = True
         return ret
@@ -323,7 +323,7 @@ class HDF5IO(HDMFIO):
 
         if name is None:
             name = str(os.path.basename(h5obj.name))
-        kwargs['source'] = self.__path
+        kwargs['source'] = h5obj.file.filename
         ndims = len(h5obj.shape)
         if ndims == 0:                                       # read scalar
             scalar = h5obj[()]


### PR DESCRIPTION
## Motivation

Properly populate Builder source when reading from HDF5

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
