### PR TITLE
__builddoc: Create sphinx style links for clickable links

### DIFF
--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -429,7 +429,13 @@ def __builddoc(func, validator, docstring_fmt, arg_fmt, ret_fmt=None, returns=No
     '''Generate a Spinxy docstring'''
     def to_str(argtype):
         if isinstance(argtype, type):
-            return argtype.__name__
+            module = argtype.__module__
+            name = argtype.__name__
+
+            if module.startswith("h5py") or module.startswith("pandas") or module.startswith("builtins"):
+                return ":py:class:`~{name}`".format(name=name)
+            else:
+                return ":py:class:`~{module}.{name}`".format(name=name, module=module)
         return argtype
 
     def __sphinx_arg(arg):


### PR DESCRIPTION
The function __builddoc is responsible for creating the python docstrings
from the docval contents. This docstrings are then converted using
sphinx.ext.napoleon to a format sphinx understands.

On that route it turns out that only links to basic python types are
linked to their respective documentation source.

This is pretty ugly to browse.

We fix that by creating a sphinx style references for known types.

The actual object we currently create the docstring for can not be linked
with this approach. And also NWBContainer does not work.