### PR TITLE
Minor fixes: expose name attr, clean up msgs, improve Container and add tests

### DIFF
--- a/src/hdmf/backends/hdf5/__init__.py
+++ b/src/hdmf/backends/hdf5/__init__.py
@@ -1,7 +1,5 @@
 # flake8: noqa: F401
-from . import h5_utils
-from .h5tools import HDF5IO
+from . import h5_utils, h5tools
+
+from .h5tools import HDF5IO, H5SpecWriter, H5SpecReader
 from .h5_utils import H5RegionSlicer, H5DataIO
-from . import h5tools
-from .h5tools import H5SpecWriter
-from .h5tools import H5SpecReader

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -871,7 +871,7 @@ class HDF5IO(HDMFIO):
             dset = parent.create_dataset(name, shape=data_shape, dtype=dtype, **io_settings)
         except Exception as exc:
             msg = "Could not create dataset %s in %s with shape %s, dtype %s, and iosettings %s. %s" % \
-                  (name, parent.name, str(data_shape), str(dtype), str(**io_settings), str(exc))
+                  (name, parent.name, str(data_shape), str(dtype), str(io_settings), str(exc))
             raise_from(Exception(msg), exc)
         # Write the data
         if len(data) > dset.shape[0]:

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from ..build import BuildManager
-from ..build import GroupBuilder
+from ..build import BuildManager, GroupBuilder
 from ..utils import docval, getargs, popargs
 from ..container import Container
 from six import with_metaclass

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -967,7 +967,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             attr_value = self.get_attr_value(spec, container, build_manager)
             if self.__is_empty(attr_value):
                 if spec.required:
-                    msg = "dataset '%s' for '%s' of type (%s)"\
+                    msg = "empty dataset '%s' for '%s' of type (%s)"\
                                   % (spec.name, builder.name, self.spec.data_type_def)
                     warnings.warn(msg, MissingRequiredWarning)
                 if attr_value is None:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -3,6 +3,7 @@ from six import with_metaclass
 from .utils import docval, getargs, ExtenderMeta
 from warnings import warn
 
+
 class Container(with_metaclass(ExtenderMeta, object)):
 
     _fieldsname = '__fields__'

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -279,9 +279,10 @@ class AttributeSpec(Spec):
 
 _attrbl_args = [
         {'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},
-        {'name': 'name', 'type': str, 'doc': 'the name of this base storage container', 'default': None},
+        {'name': 'name', 'type': str, 'doc': 'the name of this base storage container, '
+         + 'allowed only if quantity is not \'%s\' or \'%s\'' % (ONE_OR_MANY, ZERO_OR_MANY), 'default': None},
         {'name': 'default_name', 'type': str,
-         'doc': 'The default name of this base storage container', 'default': None},
+         'doc': 'The default name of this base storage container, used only if name is None', 'default': None},
         {'name': 'attributes', 'type': list, 'doc': 'the attributes on this group', 'default': list()},
         {'name': 'linkable', 'type': bool, 'doc': 'whether or not this group can be linked', 'default': True},
         {'name': 'quantity', 'type': (str, int), 'doc': 'the required number of allowed instance', 'default': 1},

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -200,6 +200,10 @@ class NamespaceBuilder(object):
         namespace = SpecNamespace.build_namespace(**ns_args)
         writer.write_namespace(namespace, ns_path)
 
+    @property
+    def name(self):
+        return self.__ns_args['name']
+
 
 class SpecFileBuilder(dict):
 

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -181,3 +181,6 @@ class TestYAMLSpecWrite(unittest.TestCase):
             self.assertTrue("source: mylab.specs.yaml\n" in nsstr)
             self.assertTrue("title: Extensions for my lab\n" in nsstr)
             self.assertTrue("version: 0.0.1\n" in nsstr)
+
+    def test_get_name(self):
+        self.assertEquals(self.ns_name, self.ns_builder.name)

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -2,50 +2,104 @@ import unittest2 as unittest
 
 from hdmf.container import Container
 
+class Subcontainer(Container):
+    pass
 
-class MyTestClass(Container):
-
-    def __init__(self, src, name, parent=None):
-        super(MyTestClass, self).__init__(src, name, parent=parent)
-
-    def basic_add(self, **kwargs):
-        return kwargs
-
-    def basic_add2(self, **kwargs):
-        return kwargs
-
-    def basic_add2_kw(self, **kwargs):
-        return kwargs
-
-
-class MyTestSubclass(MyTestClass):
-
-    def basic_add(self, **kwargs):
-        return kwargs
-
-    def basic_add2_kw(self, **kwargs):
-        return kwargs
-
-
-class TestNWBContainer(unittest.TestCase):
+class TestContainer(unittest.TestCase):
 
     def test_constructor(self):
-        """Test that constructor properly sets parent
+        """Test that constructor properly sets parent and parent knows its child
         """
-        parent_obj = MyTestClass('test source', 'obj1')
-        child_obj = MyTestSubclass('test source', 'obj2', parent=parent_obj)
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2', parent_obj)
         self.assertIs(child_obj.parent, parent_obj)
+        self.assertIs(parent_obj.children[0], child_obj)
 
-    def test_set_parent_parent(self):
-        """Test that parent setter  properly sets parent
+    def test_set_parent(self):
+        """Test that parent setter properly sets parent
         """
-        parent_obj = MyTestClass('test source', 'obj1')
-        child_obj = MyTestSubclass('test source', 'obj2')
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
         child_obj.parent = parent_obj
         self.assertIs(child_obj.parent, parent_obj)
 
+    def test_set_parent_overwrite(self):
+        """Test that parent setter properly blocks overwriting
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj.parent = parent_obj
+
+        another_obj = Container('obj3')
+        with self.assertRaisesRegexp(Exception, 'cannot reassign parent'):
+            child_obj.parent = another_obj
+        self.assertIs(child_obj.parent, parent_obj)
+
+    def test_set_parent_overwrite_proxy(self):
+        """Test that parent setter properly blocks overwriting with proxy/object
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj.parent = object()
+
+        with self.assertRaisesRegex(Exception, \
+                r"got None for parent of '[^/]+' - cannot overwrite Proxy with NoneType"):
+            child_obj.parent = None
+
     def test_slash_restriction(self):
         self.assertRaises(ValueError, Container, 'bad/name')
+
+    def test_set_modified_parent(self):
+        """Test that set modified properly sets parent modified
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj.parent = parent_obj
+        parent_obj.set_modified(False)
+        child_obj.set_modified(False)
+        self.assertFalse(child_obj.parent.modified)
+        child_obj.set_modified()
+        self.assertTrue(child_obj.parent.modified)
+
+    def test_add_child(self):
+        """Test that add child and properly sets child's parent and modified
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        parent_obj.set_modified(False)
+        parent_obj.add_child(child_obj)
+        self.assertIs(child_obj.parent, parent_obj)
+        self.assertTrue(parent_obj.modified)
+
+    def test_add_child_none(self):
+        """Test that add child does nothing if child is none
+        """
+        parent_obj = Container('obj1')
+        parent_obj.set_modified(False)
+        with self.assertWarnsRegex(UserWarning, r'cannot add None as child to a container .+'):
+            parent_obj.add_child(None)
+        self.assertEqual(len(parent_obj.children), 0)
+        self.assertFalse(parent_obj.modified)
+
+    def test_reassign_container_source(self):
+        """Test that reassign container source throws error
+        """
+        parent_obj = Container('obj1', container_source='a source')
+        with self.assertRaisesRegex(Exception, 'cannot reassign container_source'):
+            parent_obj.container_source = 'some other source'
+
+        another_obj = Container('obj2')
+        another_obj.container_source = 'a source'
+        with self.assertRaisesRegex(Exception, 'cannot reassign container_source'):
+            another_obj.container_source = 'some other source'
+
+    def test_repr(self):
+        parent_obj = Container('obj1')
+        self.assertRegex(str(parent_obj), r"<Container 'obj1' at 0x\d+>")
+
+    def test_type_hierarchy(self):
+        self.assertEqual(Container.type_hierarchy(), (Container, object))
+        self.assertEqual(Subcontainer.type_hierarchy(), (Subcontainer, Container, object))
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -2,8 +2,10 @@ import unittest2 as unittest
 
 from hdmf.container import Container
 
+
 class Subcontainer(Container):
     pass
+
 
 class TestContainer(unittest.TestCase):
 
@@ -38,12 +40,11 @@ class TestContainer(unittest.TestCase):
     def test_set_parent_overwrite_proxy(self):
         """Test that parent setter properly blocks overwriting with proxy/object
         """
-        parent_obj = Container('obj1')
         child_obj = Container('obj2')
         child_obj.parent = object()
 
-        with self.assertRaisesRegex(Exception, \
-                r"got None for parent of '[^/]+' - cannot overwrite Proxy with NoneType"):
+        with self.assertRaisesRegex(Exception,
+                                    r"got None for parent of '[^/]+' - cannot overwrite Proxy with NoneType"):
             child_obj.parent = None
 
     def test_slash_restriction(self):


### PR DESCRIPTION
1. expose NamespaceBuilder `name` - fixes #64 
2. clean up some exception and docs messages
3. add child to parent Container automatically and add unit tests