### PR TITLE
downgrade urllib3 to 1.24.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,5 +16,5 @@ six==1.11.0
 tox==3.0.0
 traceback2==1.4.0
 unittest2==1.1.0
-urllib3==1.25.2
+urllib3==1.24.3
 virtualenv==15.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ python-dateutil==2.7.2
 requests==2.20.0
 ruamel.yaml==0.15.85
 six==1.11.0
-urllib3==1.25.2
+urllib3==1.24.3
 pandas==0.23.4


### PR DESCRIPTION
Use urllib3 1.24.3 instead of 1.25.

## Motivation
See https://github.com/NeurodataWithoutBorders/pynwb/issues/921. There was a dependency conflict between urllib3 and requests. This downgrades urllib3 to 1.24.3 (which includes a security fix that was initially added to 1.25).
