### PR TITLE
Update order of keys in YAML spec

### DIFF
--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -70,8 +70,8 @@ class YAMLSpecWriter(SpecWriter):
         yaml.representer.RoundTripRepresenter.add_representer(type(None), my_represent_none)
 
         order = ['neurodata_type_def', 'neurodata_type_inc', 'name', 'default_name',
-             'dtype', 'target_type', 'dims', 'shape', 'default_value', 'value', 'doc',
-             'required', 'quantity', 'attributes', 'datasets', 'groups', 'links']
+            'dtype', 'target_type', 'dims', 'shape', 'default_value', 'value', 'doc',
+            'required', 'quantity', 'attributes', 'datasets', 'groups', 'links']
         if isinstance(obj, dict):
             keys = list(obj.keys())
             for k in order[::-1]:

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -69,16 +69,20 @@ class YAMLSpecWriter(SpecWriter):
             return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
         yaml.representer.RoundTripRepresenter.add_representer(type(None), my_represent_none)
 
-        order = ['neurodata_type_def', 'neurodata_type_inc', 'name', 'dtype', 'doc',
-                 'attributes', 'datasets', 'groups']
+        order = ['neurodata_type_def', 'neurodata_type_inc', 'name', 'default_name',
+             'dtype', 'target_type', 'dims', 'shape', 'default_value', 'value', 'doc',
+             'required', 'quantity', 'attributes', 'datasets', 'groups', 'links']
         if isinstance(obj, dict):
             keys = list(obj.keys())
             for k in order[::-1]:
                 if k in keys:
                     keys.remove(k)
                     keys.insert(0, k)
+            if 'neurodata_type_def' not in keys and 'name' in keys:
+                keys.remove('name')
+                keys.insert(0, 'name')
             return yaml.comments.CommentedMap(
-                yaml.compat.ordereddict([(k, self.sort_keys(obj[k])) for k in keys])
+                yaml.compat.ordereddict([(k,self.sort_keys(obj[k])) for k in keys])
             )
         elif isinstance(obj, list):
             return [self.sort_keys(v) for v in obj]

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -82,7 +82,7 @@ class YAMLSpecWriter(SpecWriter):
                 keys.remove('name')
                 keys.insert(0, 'name')
             return yaml.comments.CommentedMap(
-                yaml.compat.ordereddict([(k,self.sort_keys(obj[k])) for k in keys])
+                yaml.compat.ordereddict([(k, self.sort_keys(obj[k])) for k in keys])
             )
         elif isinstance(obj, list):
             return [self.sort_keys(v) for v in obj]

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -70,8 +70,8 @@ class YAMLSpecWriter(SpecWriter):
         yaml.representer.RoundTripRepresenter.add_representer(type(None), my_represent_none)
 
         order = ['neurodata_type_def', 'neurodata_type_inc', 'name', 'default_name',
-            'dtype', 'target_type', 'dims', 'shape', 'default_value', 'value', 'doc',
-            'required', 'quantity', 'attributes', 'datasets', 'groups', 'links']
+                 'dtype', 'target_type', 'dims', 'shape', 'default_value', 'value', 'doc',
+                 'required', 'quantity', 'attributes', 'datasets', 'groups', 'links']
         if isinstance(obj, dict):
             keys = list(obj.keys())
             for k in order[::-1]:

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -59,7 +59,7 @@ class YAMLSpecWriter(SpecWriter):
         same path.
         """
         with open(path, 'rb') as fd_read:
-            data = yaml.load(fd_read, Loader=yaml.loader.RoundTripLoader)
+            data = yaml.load(fd_read, Loader=yaml.loader.RoundTripLoader, preserve_quotes=True)
         self.write_spec(data, path)
 
     def sort_keys(self, obj):


### PR DESCRIPTION
Fixes NeurodataWithoutBorders/nwb-schema#274 for writing schema YAML files. See also https://github.com/NeurodataWithoutBorders/pynwb/pull/978

Ordering of keys in YAML files is now:
```
neurodata_type_def
neurodata_type_inc
name
default_name
dtype
target_type
dims
shape
value
default_value
doc
required
quantity
attributes
datasets
groups
links
```
except where `neurodata_type_def` is not used, in which case name goes before `neurodata_type_inc`.