### PR TITLE
Cache the spec by default when writing file

### DIFF
--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -139,11 +139,9 @@ class H5SpecWriter(SpecWriter):
         return json.dumps(spec, separators=(',', ':'))
 
     def __write(self, d, name):
-        # do not overwrite existing spec
-        if self.__group.get(name, None) is not None:
-            return
         data = self.stringify(d)
-        dset = self.__group.create_dataset(name, data=data, dtype=self.__str_type)
+        # create spec group if it does not exist. otherwise, do not overwrite existing spec
+        dset = self.__group.require_dataset(name, shape=tuple(), data=data, dtype=self.__str_type)
         return dset
 
     def write_spec(self, spec, path):

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -139,6 +139,9 @@ class H5SpecWriter(SpecWriter):
         return json.dumps(spec, separators=(',', ':'))
 
     def __write(self, d, name):
+        # do not overwrite existing spec
+        if self.__group.get(name, None) is not None:
+            return
         data = self.stringify(d)
         dset = self.__group.create_dataset(name, data=data, dtype=self.__str_type)
         return dset

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -206,7 +206,7 @@ class HDF5IO(HDMFIO):
         dest_file.close()
 
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
-            {'name': 'cache_spec', 'type': bool, 'doc': 'cache specification to file', 'default': False},
+            {'name': 'cache_spec', 'type': bool, 'doc': 'cache specification to file', 'default': True},
             {'name': 'link_data', 'type': bool,
              'doc': 'If not specified otherwise link (True) or copy (False) HDF5 Datasets', 'default': True})
     def write(self, **kwargs):


### PR DESCRIPTION
Fixes #76 

Also, prevent overwriting of spec with same name
e.g. if the group '/specifications/core/2.0.2/' already contains the group 'nwb.base', do not try to create it again when caching the spec.