### PR TITLE
add bool type to _type_map dict

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1333,6 +1333,7 @@ class TypeMap(object):
         'float64': float,
         'int': int,
         'int32': int,
+        'bool': bool,
         'uint64': np.uint64,
         'isodatetime': datetime
     }
@@ -1399,6 +1400,7 @@ class TypeMap(object):
             if not f == 'help':
                 dtype = self.__get_type(field_spec)
                 if dtype is None:
+                    import pdb; pdb.set_trace()
                     raise(ValueError("Got \"None\" for field specification: {}".format(field_spec)))
 
                 docval_arg = {'name': f, 'type': dtype, 'doc': field_spec.doc}

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1400,7 +1400,6 @@ class TypeMap(object):
             if not f == 'help':
                 dtype = self.__get_type(field_spec)
                 if dtype is None:
-                    import pdb; pdb.set_trace()
                     raise(ValueError("Got \"None\" for field specification: {}".format(field_spec)))
 
                 docval_arg = {'name': f, 'type': dtype, 'doc': field_spec.doc}


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

## Motivation

previously get_class would break if given a neurodata_type with an attribute that is of type bool. This fixes is.

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
