### PR TITLE
Ignore setting parent when parent adds child with existing parent

### DIFF
--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -45,12 +45,12 @@ class Container(with_metaclass(ExtenderMeta, object)):
     def add_child(self, **kwargs):
         child = getargs('child', kwargs)
         if child is not None:
-            self.__children.append(child)
-            self.set_modified()
-
             # if child.parent is a Container, then the mismatch between child.parent and parent
             # is used to make a soft/external link from the parent to a child elsewhere
+            # if child.parent is not a Container, it is either None or a Proxy and should be set to self
             if not isinstance(child.parent, Container):
+                self.__children.append(child)
+                self.set_modified()
                 child.parent = self
         else:
             warn('Cannot add None as child to a container %s' % self.name)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -16,11 +16,7 @@ class Container(with_metaclass(ExtenderMeta, object)):
         if '/' in name:
             raise ValueError("name '" + name + "' cannot contain '/'")
         self.__name = name
-
         self.__parent = getargs('parent', kwargs)
-        if self.parent is not None:
-            self.parent.add_child(self)
-
         self.__container_source = getargs('container_source', kwargs)
         self.__children = list()
         self.__modified = True

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -51,7 +51,11 @@ class Container(with_metaclass(ExtenderMeta, object)):
         if child is not None:
             self.__children.append(child)
             self.set_modified()
-            child.parent = self
+
+            # if child.parent is a Container, then the mismatch between child.parent and parent
+            # is used to make a soft/external link from the parent to a child elsewhere
+            if not isinstance(child.parent, Container):
+                child.parent = self
         else:
             warn('Cannot add None as child to a container %s' % self.name)
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -72,7 +72,7 @@ class TestContainer(unittest.TestCase):
         parent_obj.add_child(child_obj)
         self.assertIs(child_obj.parent, parent_obj)
         self.assertTrue(parent_obj.modified)
-        
+
     def test_add_child_none(self):
         """Test that add child does nothing if child is none
         """

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -10,14 +10,14 @@ class Subcontainer(Container):
 class TestContainer(unittest.TestCase):
 
     def test_constructor(self):
-        """Test that constructor properly sets parent and parent knows its child
+        """Test that constructor properly sets parent. Note that parent does not know its child.
         """
         parent_obj = Container('obj1')
         child_obj = Container('obj2', parent_obj)
         self.assertIs(child_obj.parent, parent_obj)
 
     def test_set_parent(self):
-        """Test that parent setter properly sets parent
+        """Test that parent setter properly sets parent. Note that parent does not know its child.
         """
         parent_obj = Container('obj1')
         child_obj = Container('obj2')
@@ -36,17 +36,6 @@ class TestContainer(unittest.TestCase):
                                      'Cannot reassign parent to Container: %s. Parent is already: %s.'
                                      % (repr(child_obj), repr(child_obj.parent))):
             child_obj.parent = another_obj
-        self.assertIs(child_obj.parent, parent_obj)
-
-    def test_add_child_overwrite_parent(self):
-        """Test that a parent adding a child with an existing parent is allowed
-        """
-        parent_obj = Container('obj1')
-        child_obj = Container('obj2')
-        parent_obj.add_child(child_obj)
-
-        another_obj = Container('obj3')
-        another_obj.add_child(child_obj)
         self.assertIs(child_obj.parent, parent_obj)
 
     def test_set_parent_overwrite_proxy(self):
@@ -83,7 +72,7 @@ class TestContainer(unittest.TestCase):
         parent_obj.add_child(child_obj)
         self.assertIs(child_obj.parent, parent_obj)
         self.assertTrue(parent_obj.modified)
-
+        
     def test_add_child_none(self):
         """Test that add child does nothing if child is none
         """
@@ -95,7 +84,7 @@ class TestContainer(unittest.TestCase):
         self.assertFalse(parent_obj.modified)
 
     def test_add_child_exists(self):
-        """Test that add child on the same child does nothing
+        """Test that adding an existing child does nothing
         """
         parent_obj = Container('obj1')
         child_obj = Container('obj2')
@@ -104,6 +93,19 @@ class TestContainer(unittest.TestCase):
         parent_obj.add_child(child_obj)
         parent_obj.add_child(child_obj3)
         self.assertEqual(len(parent_obj.children), 2)
+
+    def test_add_child_overwrite_parent(self):
+        """Test that a parent adding a child with an existing parent is allowed but does nothing
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        parent_obj.add_child(child_obj)
+
+        another_obj = Container('obj3')
+        another_obj.add_child(child_obj)
+        self.assertIs(child_obj.parent, parent_obj)
+        self.assertIs(len(parent_obj.children), 1)
+        self.assertIs(len(another_obj.children), 0)
 
     def test_reassign_container_source(self):
         """Test that reassign container source throws error

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -40,17 +40,14 @@ class TestContainer(unittest.TestCase):
         self.assertIs(child_obj.parent, parent_obj)
 
     def test_add_child_overwrite_parent(self):
-        """Test that parent setter properly blocks overwriting
+        """Test that a parent adding a child with an existing parent is allowed
         """
         parent_obj = Container('obj1')
         child_obj = Container('obj2')
         parent_obj.add_child(child_obj)
 
         another_obj = Container('obj3')
-        with self.assertRaisesRegexp(ValueError,
-                                     'Cannot reassign parent to Container: %s. Parent is already: %s.'
-                                     % (repr(child_obj), repr(child_obj.parent))):
-            another_obj.add_child(child_obj)
+        another_obj.add_child(child_obj)
         self.assertIs(child_obj.parent, parent_obj)
 
     def test_set_parent_overwrite_proxy(self):

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -94,6 +94,17 @@ class TestContainer(unittest.TestCase):
         self.assertEqual(len(parent_obj.children), 0)
         self.assertFalse(parent_obj.modified)
 
+    def test_add_child_exists(self):
+        """Test that add child on the same child does nothing
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj3 = Container('obj3')
+        parent_obj.add_child(child_obj)
+        parent_obj.add_child(child_obj)
+        parent_obj.add_child(child_obj3)
+        self.assertEqual(len(parent_obj.children), 2)
+
     def test_reassign_container_source(self):
         """Test that reassign container source throws error
         """

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -15,7 +15,6 @@ class TestContainer(unittest.TestCase):
         parent_obj = Container('obj1')
         child_obj = Container('obj2', parent_obj)
         self.assertIs(child_obj.parent, parent_obj)
-        self.assertIs(parent_obj.children[0], child_obj)
 
     def test_set_parent(self):
         """Test that parent setter properly sets parent


### PR DESCRIPTION
Hotfix to fix #87. Also fixes the issue for making soft (internal) links. 