### PR TITLE
Fix/get_cls default name

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1383,6 +1383,15 @@ class TypeMap(object):
                 ret = True
         return ret
 
+    @staticmethod
+    def __set_default_name(docval_args, default_name):
+        new_docval_args = []
+        for x in docval_args:
+            if x['name'] == 'name':
+                x['default'] = default_name
+            new_docval_args.append(x)
+        return new_docval_args
+
     def __get_cls_dict(self, base, addl_fields, name=None, default_name=None):
         # TODO: fix this to be more maintainable and smarter
         if base is None:
@@ -1397,14 +1406,8 @@ class TypeMap(object):
                 continue
             docval_args.append(arg)
 
-        # set default name
         if default_name is not None:
-            new_docval_args = []
-            for x in docval_args:
-                if x['name'] == 'name':
-                    x['default'] = default_name
-                new_docval_args.append(x)
-            docval_args = new_docval_args
+            docval_args = self.__set_default_name(docval_args, default_name)
 
         for f, field_spec in addl_fields.items():
             if not f == 'help':

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1383,7 +1383,7 @@ class TypeMap(object):
                 ret = True
         return ret
 
-    def __get_cls_dict(self, base, addl_fields, name=None):
+    def __get_cls_dict(self, base, addl_fields, name=None, default_name=None):
         # TODO: fix this to be more maintainable and smarter
         if base is None:
             raise ValueError('cannot generate class without base class')
@@ -1396,6 +1396,16 @@ class TypeMap(object):
             if arg['name'] in addl_fields:
                 continue
             docval_args.append(arg)
+
+        # set default name
+        if default_name is not None:
+            new_docval_args = []
+            for x in docval_args:
+                if x['name'] == 'name':
+                    x['default'] = default_name
+                new_docval_args.append(x)
+            docval_args = new_docval_args
+
         for f, field_spec in addl_fields.items():
             if not f == 'help':
                 dtype = self.__get_type(field_spec)
@@ -1468,7 +1478,7 @@ class TypeMap(object):
                 if not spec.is_inherited_spec(field_spec):
                     fields[k] = field_spec
             try:
-                d = self.__get_cls_dict(parent_cls, fields, spec.name)
+                d = self.__get_cls_dict(parent_cls, fields, spec.name, spec.default_name)
             except TypeDoesNotExistError as e:
                 name = spec.get('data_type_def', 'Unknown')
                 raise ValueError("Cannot dynamically generate class for type '%s'. " % name

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -173,6 +173,13 @@ class TestDynamicContainer(unittest.TestCase):
         self.assertEqual(cls.__name__, 'Baz')
         self.assertTrue(issubclass(cls, Bar))
 
+    def test_dynamic_container_default_name(self):
+        baz_spec = GroupSpec('doc', default_name='bingo', data_type_def='Baz')
+        self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
+        cls = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz')
+        inst = cls()
+        self.assertEqual(inst.name, 'bingo')
+
     def test_dynamic_container_creation_defaults(self):
         baz_spec = GroupSpec('A test extension with no Container class',
                              data_type_def='Baz', data_type_inc=self.bar_spec,


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

## Motivation

`get_class` now detects `default_name`

## How to test the behavior?
```python
baz_spec = GroupSpec('doc', default_name='bingo', data_type_def='Baz')
self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
cls = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz')
inst = cls()
self.assertEqual(inst.name, 'bingo'))
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
