### PR TITLE
add a check for DataChunkIterator that skips type inference

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -11,7 +11,7 @@ from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args, 
 from ..container import Container, Data, DataRegion
 from ..spec import Spec, AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NAME_WILDCARD, NamespaceCatalog, RefSpec,\
                    SpecReader
-from ..data_utils import DataIO, AbstractDataChunkIterator
+from ..data_utils import DataIO, AbstractDataChunkIterator, DataChunkIterator
 from ..spec.spec import BaseStorageSpec
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, RegionBuilder, BaseBuilder
 from .warnings import OrphanContainerWarning, MissingRequiredWarning
@@ -415,6 +415,8 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                  The value is returned as the function may convert the input value to comply
                  with the dtype specified in the schema.
         """
+        if isinstance(value, DataChunkIterator):
+            return value, None
         ret, ret_dtype = cls.__check_edgecases(spec, value)
         if ret is not None or ret_dtype is not None:
             return ret, ret_dtype


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

## Motivation

fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1011

Previously, using a `DataChunkIterator` only worked when the data type was unspecified. Now it works for all datatypes, however it does not verify the data type against the spec.

## How to test the behavior?
see https://github.com/NeurodataWithoutBorders/pynwb/pull/1012

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
