### PR TITLE
Downgrade virtualenv for conda tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ references:
           command: |
             conda config --set always_yes yes --set changeps1 no
             conda config --add channels conda-forge
-            conda install virtualenv
+            conda install virtualenv==16.0.0
             conda install tox
       - run:
           name: Run the tests
@@ -163,7 +163,7 @@ jobs:
 
   miniconda27:
     docker:
-      - image: continuumio/miniconda:4.3.14
+      - image: continuumio/miniconda:4.6.14
     environment:
       - TEST_TOX_ENV: "py27"
       - BUILD_TOX_ENV: "build-py27"


### PR DESCRIPTION
Fix #105 broken miniconda python2.7 tests on CircleCI. See https://github.com/NeurodataWithoutBorders/pynwb/pull/1017 for more details.