### PR TITLE
Remove warning for building empty datasets

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -955,29 +955,13 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 continue
             self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
-    def __is_empty(self, val):
-        if val is None:
-            return True
-        if isinstance(val, DataIO):
-            val = val.data
-        if isinstance(val, AbstractDataChunkIterator):
-            return False
-        else:
-            if (hasattr(val, '__len__') and len(val) == 0):
-                return True
-            else:
-                return False
-
     def __add_datasets(self, builder, datasets, container, build_manager, source):
         for spec in datasets:
             attr_value = self.get_attr_value(spec, container, build_manager)
-            if self.__is_empty(attr_value):
-                if spec.required:
-                    msg = "empty dataset '%s' for '%s' of type (%s)"\
-                                  % (spec.name, builder.name, self.spec.data_type_def)
-                    warnings.warn(msg, MissingRequiredWarning)
-                if attr_value is None:
-                    continue
+            if attr_value is None:
+                continue
+            if isinstance(attr_value, DataIO) and attr_value.data is None:
+                continue
             if isinstance(attr_value, Builder):
                 builder.set_builder(attr_value)
             elif spec.data_type_def is None and spec.data_type_inc is None:

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -5,7 +5,6 @@ from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNa
 from hdmf.build import GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager, TypeMap
 from hdmf import Container
 from hdmf.utils import docval, getargs, get_docval
-from hdmf.build.warnings import MissingRequiredWarning
 
 from abc import ABCMeta
 from six import with_metaclass
@@ -378,8 +377,7 @@ class TestObjectMapperNoNesting(TestObjectMapper):
     def test_build_empty(self):
         ''' Test default mapping functionality when no attributes are nested '''
         container = Bar('my_bar', [], 'value1', 10)
-        with self.assertWarnsRegex(MissingRequiredWarning, re.escape("dataset 'data' for 'my_bar' of type (Bar)")):
-            builder = self.mapper.build(container, self.manager)
+        builder = self.mapper.build(container, self.manager)
         expected = GroupBuilder('my_bar', datasets={'data': DatasetBuilder('data', [])},
                                 attributes={'attr1': 'value1', 'attr2': 10})
         self.assertDictEqual(builder, expected)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -486,8 +486,7 @@ class TestRoundTrip(unittest.TestCase):
     def test_roundtrip_basic(self):
         # Setup all the data we need
         foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
-        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
-        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        foobucket = FooBucket('test_bucket', [foo1])
         foofile = FooFile([foobucket])
 
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
@@ -497,13 +496,10 @@ class TestRoundTrip(unittest.TestCase):
             read_foofile = io.read()
             self.assertListEqual(foofile.buckets[0].foos[0].my_data,
                                  read_foofile.buckets[0].foos[0].my_data[:].tolist())
-            self.assertListEqual(foofile.buckets[0].foos[1].my_data,
-                                 read_foofile.buckets[0].foos[1].my_data[:].tolist())
 
     def test_roundtrip_empty_dataset(self):
         foo1 = Foo('foo1', [], "I am foo1", 17, 3.14)
-        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
-        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        foobucket = FooBucket('test_bucket', [foo1])
         foofile = FooFile([foobucket])
 
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
@@ -512,8 +508,6 @@ class TestRoundTrip(unittest.TestCase):
         with HDF5IO(self.path, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
             self.assertListEqual([], read_foofile.buckets[0].foos[0].my_data[:].tolist())
-            self.assertListEqual(foofile.buckets[0].foos[1].my_data,
-                                 read_foofile.buckets[0].foos[1].my_data[:].tolist())
 
     def test_roundtrip_empty_group(self):
         foobucket = FooBucket('test_bucket', [])

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -468,6 +468,65 @@ def _get_manager():
     return manager
 
 
+class TestRoundTrip(unittest.TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.test_temp_file = tempfile.NamedTemporaryFile()
+        self.test_temp_file.close()
+        # On Windows h5py cannot truncate an open file in write mode.
+        # The temp file will be closed before h5py truncates it
+        # and will be removed during the tearDown step.
+        self.path = self.test_temp_file.name
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_roundtrip_basic(self):
+        # Setup all the data we need
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        with HDF5IO(self.path, manager=self.manager, mode='r') as io:
+            read_foofile = io.read()
+            self.assertListEqual(foofile.buckets[0].foos[0].my_data,
+                                 read_foofile.buckets[0].foos[0].my_data[:].tolist())
+            self.assertListEqual(foofile.buckets[0].foos[1].my_data,
+                                 read_foofile.buckets[0].foos[1].my_data[:].tolist())
+
+    def test_roundtrip_empty_dataset(self):
+        foo1 = Foo('foo1', [], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        with HDF5IO(self.path, manager=self.manager, mode='r') as io:
+            read_foofile = io.read()
+            self.assertListEqual([], read_foofile.buckets[0].foos[0].my_data[:].tolist())
+            self.assertListEqual(foofile.buckets[0].foos[1].my_data,
+                                 read_foofile.buckets[0].foos[1].my_data[:].tolist())
+
+    def test_roundtrip_empty_group(self):
+        foobucket = FooBucket('test_bucket', [])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        with HDF5IO(self.path, manager=self.manager, mode='r') as io:
+            read_foofile = io.read()
+            self.assertListEqual([], read_foofile.buckets[0].foos)
+
+
 class TestCacheSpec(unittest.TestCase):
 
     def setUp(self):
@@ -749,9 +808,8 @@ class HDF5IOReadData(unittest.TestCase):
         bucket1 = FooBucket('test_bucket1', [foo1])
         self.foofile1 = FooFile('test_foofile1', buckets=[bucket1])
 
-        temp_io = HDF5IO(self.path, manager=_get_manager(), mode='w')
-        temp_io.write(self.foofile1)
-        temp_io.close()
+        with HDF5IO(self.path, manager=_get_manager(), mode='w') as temp_io:
+            temp_io.write(self.foofile1)
         self.io = None
 
     def tearDown(self):


### PR DESCRIPTION
Fixes #75 and finishes fixes for https://github.com/NeurodataWithoutBorders/pynwb/issues/881 (which somehow got resolved except for the warning being thrown). 