### PR TITLE
Add container deepcopy

### DIFF
--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 from six import with_metaclass
 from .utils import docval, getargs, ExtenderMeta
 from .query import HDMFDataset
-from .data_utils import DataIO
 from warnings import warn
 from copy import deepcopy
 
@@ -145,10 +144,6 @@ class Container(with_metaclass(ExtenderMeta, object)):
 
         for child in cp.children:
             child.parent = cp
-
-        for k, v in cp.__dict__.items():
-            if isinstance(v, DataIO):
-                setattr(cp, k, v.data)
 
         # resolve HDMFDataset after and separately because DataIO can wrap an HDMFDataset
         for k, v in cp.__dict__.items():

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -2,6 +2,8 @@ import abc
 from uuid import uuid4
 from six import with_metaclass
 from .utils import docval, getargs, ExtenderMeta
+from .query import HDMFDataset
+from .data_utils import DataIO
 from warnings import warn
 from copy import deepcopy
 
@@ -143,6 +145,15 @@ class Container(with_metaclass(ExtenderMeta, object)):
 
         for child in cp.children:
             child.parent = cp
+
+        for k, v in cp.__dict__.items():
+            if isinstance(v, DataIO):
+                setattr(cp, k, v.data)
+
+        # resolve HDMFDataset after and separately because DataIO can wrap an HDMFDataset
+        for k, v in cp.__dict__.items():
+            if isinstance(v, HDMFDataset):
+                setattr(cp, k, v.dataset)
 
         return cp
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -139,6 +139,7 @@ class Container(with_metaclass(ExtenderMeta, object)):
         cp.__parent = None
         cp.__container_source = None
         cp.__object_id = str(uuid4())
+        cp.__modified = True
 
         for child in cp.children:
             child.parent = cp

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from six import with_metaclass
 from .utils import docval, getargs, ExtenderMeta
 from warnings import warn
+from copy import deepcopy
 
 
 class Container(with_metaclass(ExtenderMeta, object)):
@@ -125,6 +126,24 @@ class Container(with_metaclass(ExtenderMeta, object)):
             if isinstance(parent_container, Container):
                 parent_container.__children.append(self)
                 parent_container.set_modified()
+
+    def __deepcopy__(self, memo):
+        ''' Create a deep copy of this Container
+        Reset the root parent to None, set all container_source to None, and set new object_id value
+        '''
+        deepcopy_method = self.__deepcopy__
+        self.__deepcopy__ = None
+        cp = deepcopy(self, memo)
+        self.__deepcopy__ = deepcopy_method
+
+        cp.__parent = None
+        cp.__container_source = None
+        cp.__object_id = str(uuid4())
+
+        for child in cp.children:
+            child.parent = cp
+
+        return cp
 
 
 class Data(Container):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -5,9 +5,9 @@ except ImportError:
     from collections import Iterable  # Python 2.7
 
 from operator import itemgetter
-
 import numpy as np
 from six import with_metaclass, text_type, binary_type
+from copy import deepcopy
 
 from .container import Data, DataRegion
 from .utils import docval, getargs, popargs, docval_macro, get_data_shape
@@ -511,6 +511,9 @@ class DataIO(with_metaclass(ABCMeta, object)):
     # Delegate iteration interface to data object:
     def __iter__(self):
         return self.data.__iter__()
+
+    def __deepcopy__(self, memo):
+        return deepcopy(self.data)
 
 
 class RegionSlicer(with_metaclass(ABCMeta, DataRegion)):

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,6 +1,9 @@
 import unittest2 as unittest
 
+from tests.unit.test_utils import Foo
 from hdmf.container import Container
+from hdmf.query import HDMFDataset
+from hdmf.data_utils import DataIO
 from copy import deepcopy
 
 
@@ -148,6 +151,21 @@ class TestContainer(unittest.TestCase):
         child_copy = deepcopy(child_obj)
         self.assertIsNone(child_copy.parent)
 
+    def test_deepcopy_data(self):
+        parent_obj = Foo('obj1', HDMFDataset([1, 2, 3, 4, 5]), 'a string', 10)
+        parent_obj.container_source = 'a file'
+        parent_obj.set_modified(False)
+        child_obj = Foo('obj2', DataIO(HDMFDataset([1, 2, 3, 4, 5])), 'a string2', 20)
+        child_obj.parent = parent_obj
+        child_obj.container_source = 'a file'
+
+        parent_copy = deepcopy(parent_obj)
+        self.assertListEqual(parent_copy.my_data, [1, 2, 3, 4, 5])
+        self.assertEqual(parent_copy.attr1, 'a string')
+        self.assertEqual(parent_copy.attr2, 10)
+        self.assertListEqual(parent_copy.children[0].my_data, [1, 2, 3, 4, 5])
+
+        # TODO test deepcopy with references and H5Dataset
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,6 +1,7 @@
 import unittest2 as unittest
 
 from hdmf.container import Container
+from copy import deepcopy
 
 
 class Subcontainer(Container):
@@ -117,6 +118,35 @@ class TestContainer(unittest.TestCase):
     def test_type_hierarchy(self):
         self.assertEqual(Container.type_hierarchy(), (Container, object))
         self.assertEqual(Subcontainer.type_hierarchy(), (Subcontainer, Container, object))
+
+    def test_deepcopy(self):
+        parent_obj = Container('obj1')
+        parent_obj.container_source = 'a file'
+        parent_obj.set_modified(False)
+        child_obj = Container('obj2')
+        child_obj.parent = parent_obj
+        child_obj.container_source = 'a file'
+        child_obj.set_modified(False)
+        child_child_obj = Container('obj3')
+        child_child_obj.parent = child_obj
+        child_child_obj.container_source = 'a file'
+
+        parent_copy = deepcopy(parent_obj)
+        self.assertEqual(parent_copy.name, 'obj1')
+        self.assertEqual(parent_copy.children[0].name, 'obj2')
+        self.assertEqual(parent_copy.children[0].children[0].name, 'obj3')
+        self.assertNotEqual(parent_copy.object_id, parent_obj.object_id)
+        self.assertNotEqual(parent_copy.children[0].object_id, child_obj.object_id)
+        self.assertNotEqual(parent_copy.children[0].children[0].object_id, child_child_obj.object_id)
+        self.assertIsNone(parent_copy.container_source)
+        self.assertIsNone(parent_copy.children[0].container_source)
+        self.assertIsNone(parent_copy.children[0].children[0].container_source)
+        self.assertTrue(parent_copy.modified)
+        self.assertTrue(parent_copy.children[0].modified)
+        self.assertTrue(parent_copy.children[0].children[0].modified)
+
+        child_copy = deepcopy(child_obj)
+        self.assertIsNone(child_copy.parent)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -167,5 +167,6 @@ class TestContainer(unittest.TestCase):
 
         # TODO test deepcopy with references and H5Dataset
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,7 +8,7 @@ CORE_NAMESPACE = 'test_core'
 class Foo(Container):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this Foo'},
-            {'name': 'my_data', 'type': 'array_data', 'doc': 'some data'},
+            {'name': 'my_data', 'type': ('array_data', 'data'), 'doc': 'some data'},
             {'name': 'attr1', 'type': str, 'doc': 'an attribute'},
             {'name': 'attr2', 'type': int, 'doc': 'another attribute'},
             {'name': 'attr3', 'type': float, 'doc': 'a third attribute', 'default': 3.14})


### PR DESCRIPTION
Fix #65 and adds generally useful functionality

This adds a `Container.__deepcopy__ function` which:
1) resets the `parent` to None
2) resets the `container_source` to None
3) sets a new `object_id`
4) sets `modified` to True
5) sets all children's `parent` to itself