### PR TITLE
Remove __pycache__ and .pyc, .pyo files on release and pre-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,7 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub pre-release
           command: |
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install -U scikit-ci-addons
@@ -257,6 +258,7 @@ jobs:
           name: Deploy release
           command: |
             echo "Deploy release"
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install twine
@@ -265,6 +267,7 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub release
           command: |
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install githubrelease


### PR DESCRIPTION
After tox runs tests, `__pycache__` directories are created in `tests/`. This change removes those directories to fix #109. This is a live test.