### PR TITLE
Update requirements, drop Python 2.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
 
   miniconda35:
     docker:
-      - image: continuumio/miniconda3:4.6.14
+      - image: continuumio/miniconda3:4.5.12
     environment:
       - CONDA_PYTHON_VER: "3.5"
       - TEST_TOX_ENV: "py35"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ references:
           command: |
             conda config --set always_yes yes --set changeps1 no
             conda config --add channels conda-forge
+            conda install python=$CONDA_PYTHON_VER
             conda install virtualenv==16.0.0
             conda install tox
       - run:
@@ -153,8 +154,9 @@ jobs:
 
   miniconda35:
     docker:
-      - image: continuumio/miniconda3:4.1.11
+      - image: continuumio/miniconda3:4.6.14
     environment:
+      - CONDA_PYTHON_VER: "3.5"
       - TEST_TOX_ENV: "py35"
       - BUILD_TOX_ENV: "build-py35"
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
@@ -162,8 +164,9 @@ jobs:
 
   miniconda36:
     docker:
-      - image: continuumio/miniconda3:4.3.14
+      - image: continuumio/miniconda3:4.6.14
     environment:
+      - CONDA_PYTHON_VER: "3.6"
       - TEST_TOX_ENV: "py36"
       - BUILD_TOX_ENV: "build-py36"
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
@@ -171,8 +174,9 @@ jobs:
 
   miniconda37:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: continuumio/miniconda3:4.6.14
     environment:
+      - CONDA_PYTHON_VER: "3.7"
       - TEST_TOX_ENV: "py37"
       - BUILD_TOX_ENV: "build-py37"
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
 
   miniconda35:
     docker:
-      - image: continuumio/miniconda3:4.5.12
+      - image: continuumio/miniconda3:4.4.10
     environment:
       - CONDA_PYTHON_VER: "3.5"
       - TEST_TOX_ENV: "py35"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
 
   miniconda35:
     docker:
-      - image: continuumio/miniconda3:4.4.10
+      - image: continuumio/miniconda3:4.3.27p0
     environment:
       - CONDA_PYTHON_VER: "3.5"
       - TEST_TOX_ENV: "py35"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,16 +120,6 @@ jobs:
       - run:
           <<: *run-style-check
 
-  python27:
-    docker:
-      - image: circleci/python:2.7.14-jessie
-    environment:
-     - TEST_TOX_ENV: "py27"
-     - COVERAGE_TOX_ENV: "coverage-py27"
-     - BUILD_TOX_ENV: "build-py27"
-     - TEST_WHEELINSTALL_ENV: "wheelinstall-py27"
-    <<: *ci-steps
-
   python35:
     docker:
       - image: circleci/python:3.5.4-jessie
@@ -161,15 +151,6 @@ jobs:
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
     <<: *ci-steps
 
-  miniconda27:
-    docker:
-      - image: continuumio/miniconda:4.6.14
-    environment:
-      - TEST_TOX_ENV: "py27"
-      - BUILD_TOX_ENV: "build-py27"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall-py27"
-    <<: *conda-steps
-
   miniconda35:
     docker:
       - image: continuumio/miniconda3:4.1.11
@@ -196,13 +177,6 @@ jobs:
       - BUILD_TOX_ENV: "build-py37"
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
     <<: *conda-steps
-
-  gallery27:
-    docker:
-      - image: circleci/python:2.7.14-jessie
-    environment:
-     - TEST_TOX_ENV: "gallery-py27"
-    <<: *gallery-steps
 
   gallery35:
     docker:
@@ -278,23 +252,17 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
-      - python27:
-          <<: *no_filters
       - python35:
           <<: *no_filters
       - python36:
           <<: *no_filters
       - python37:
           <<: *no_filters
-      - miniconda27:
-          <<: *no_filters
       - miniconda35:
           <<: *no_filters
       - miniconda36:
           <<: *no_filters
       - miniconda37:
-          <<: *no_filters
-      - gallery27:
           <<: *no_filters
       - gallery35:
           <<: *no_filters
@@ -305,15 +273,12 @@ workflows:
       - deploy-dev:
           requires:
             - flake8
-            - python27
             - python35
             - python36
             - python37
-            - miniconda27
             - miniconda35
             - miniconda36
             - miniconda37
-            - gallery27
             - gallery35
             - gallery36
             - gallery37
@@ -323,15 +288,12 @@ workflows:
       - deploy-release:
           requires:
             - flake8
-            - python27
             - python35
             - python36
             - python37
-            - miniconda27
             - miniconda35
             - miniconda36
             - miniconda37
-            - gallery27
             - gallery35
             - gallery36
             - gallery37

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,28 +1,28 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us fix a bug
 title: ''
 labels: bug
 assignees: ''
 
 ---
 
-1) Bug
+## Description
 
-If you are reporting a bug please provide the following:
-Steps to Reproduce
+<!--Please provide the following in your bug report:-->
 
-Provide a minimal code snippet here to reproduce this error.
+## Steps to Reproduce
 
-Environment
+<!--Provide a minimal code snippet here to reproduce this error.-->
 
-Please describe your environment according to the following bullet points.
+## Environment
+
+<!--Please describe your environment according to the following bullet points.-->
 
     Python Executable: Conda or Python
-    Python Version: Python 2.7 or Python 3.6
+    Python Version: Python 3.5, 3.6, or 3.7
     Operating System: Windows, macOS or Linux
     HDMF Version: Version of HDMF used
-
 
 ## Checklist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,10 @@ matrix:
         - BUILD_TOX_ENV=build-py35
         - TEST_WHEELINSTALL_ENV=wheelinstall-py35
 
-    - os: osx
-      language: generic
-      env:
-        - TRAVIS_PYTHON_VERSION=2.7.14
-        - TEST_TOX_ENV=py27
-        - COVERAGE_TOX_ENV=coverage-py27
-        - BUILD_TOX_ENV=build-py27
-        - TEST_WHEELINSTALL_ENV=wheelinstall-py27
-
 cache:
   directories:
     - $HOME/.pyenv/versions/3.6.3
     - $HOME/.pyenv/versions/3.5.4
-    - $HOME/.pyenv/versions/2.7.14
 
 before_install:
   - export PATH=$HOME/.pyenv/versions/$TRAVIS_PYTHON_VERSION/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,6 @@ branches:
 environment:
   matrix:
 
-    - PYTHON_VERSION: 2.7
-      PYTHON: C:\\Python27-x64
-      TEST_TOX_ENV: py27
-      COVERAGE_TOX_ENV: coverage-py27
-      BUILD_TOX_ENV: build-py27
-      TEST_WHEELINSTALL_ENV: wheelinstall-py27
-
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
       TEST_TOX_ENV: py36

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Dependencies
 
 HDMF has the following minimum requirements, which must be installed before you can get started using HDMF.
 
-#. Python 2.7, Python 3.5 or Python 3.6
+#. Python 3.5, 3.6, or 3.7
 #. pip
 
 ------------
@@ -32,6 +32,7 @@ This will automatically install the following required dependencies:
  #. requests
  #. ruamel.yaml
  #. six
+ #. chardet
 
 Install release from Conda-forge
 --------------------------------

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -70,8 +70,8 @@ Versioning and Releasing
 
 HDMF uses versioneer_ for versioning source and wheel distributions. Versioneer creates a semi-unique release
 name for the wheels that are created. It requires a version control system (git in HDMF's case) to generate a release name.
-After all the tests pass, circleci creates both wheels(*.whl) and source distribution(*.tgz) for both Python 2 and Python 3
-and uploads them back to github as a release_. Versioneer makes it possible to get the source distribution from github and create
+After all the tests pass, CircleCI creates both wheels(*.whl) and source distribution(*.tgz) for Python 3
+and uploads them back to GitHub as a release_. Versioneer makes it possible to get the source distribution from GitHub and create
 wheels directly without having to use a version control system because it hardcodes versions in the source distribution.
 
 .. _versioneer: https://github.com/warner/python-versioneer

--- a/docs/source/update_requirements.rst
+++ b/docs/source/update_requirements.rst
@@ -37,7 +37,7 @@ the following script:
 requirements-(dev|doc).txt
 ==========================
 
-Any of these requirements files can be updated updated using
+Any of these requirements files can be updated using
 the following scripts:
 
 .. code::
@@ -63,5 +63,3 @@ the following scripts:
 
    deactivate
    rmvirtualenv hdmf-requirements
-
-Note: If you create requirements files using Python 2.x, you should manually remove any entries for the `enum34` package before committing. This package is only required for versions of Python < 3.4, and should not be installed in later versions. Since our requirements files are shared across Python 2 and 3 we instead rely on `pip` to install this package only when it is required. (See `issue #677 <https://github.com/hdmf-dev/hdmf/issues/677>`_ for discussion.) 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 certifi==2019.6.16
 chardet==3.0.4
 codecov==2.0.15
-configparser==3.7.4
-coverage==4.5.3
-flake8==3.7.7
+configparser==3.8.0
+coverage==4.5.4
+flake8==3.7.8
 idna==2.8
 linecache2==1.0.0
 mccabe==0.6.1
@@ -13,8 +13,8 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 requests==2.22.0
 six==1.12.0
-tox==3.12.1
+tox==3.13.2
 traceback2==1.4.0
 unittest2==1.1.0
 urllib3==1.25.3
-virtualenv==16.6.1
+virtualenv==16.7.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 certifi==2019.6.16
 chardet==3.0.4
 codecov==2.0.15
-configparser==3.8.0
+configparser==3.7.4
 coverage==4.5.4
 flake8==3.7.8
 idna==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-certifi==2019.6.16
 chardet==3.0.4
 h5py==2.9.0
-idna==2.8
-numpy==1.16.4
+numpy==1.17.0
+pandas==0.25.0
 python-dateutil==2.8.0
-requests==2.22.0
-ruamel.yaml==0.15.97
+ruamel.yaml==0.16.0
 six==1.12.0
-urllib3==1.25.3
-pandas==0.24.2

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,15 @@ setup_args = {
         'ruamel.yaml',
         'python-dateutil',
         'six',
-        'requests'
+        'chardet'
     ],
     'packages': pkgs,
     'package_dir': {'': 'src'},
     'classifiers': [
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: BSD License",
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py35, py36, py37
 
 [testenv]
 usedevelop = True
@@ -33,10 +33,6 @@ commands =
     python setup.py sdist
     python setup.py bdist_wheel
 
-[testenv:build-py27]
-basepython = python2.7
-commands = {[testenv:build]commands}
-
 [testenv:build-py35]
 basepython = python3.5
 commands = {[testenv:build]commands}
@@ -56,11 +52,6 @@ commands =
     coverage report -m
     codecov -X fix
 
-[testenv:coverage-py27]
-passenv = CODECOV_TOKEN
-basepython = python2.7
-commands = {[testenv:coverage]commands}
-
 [testenv:coverage-py35]
 passenv = CODECOV_TOKEN
 basepython = python3.5
@@ -77,10 +68,6 @@ basepython = python3.7
 commands = {[testenv:coverage]commands}
 
 # Envs that will test installation from a wheel
-[testenv:wheelinstall-py27]
-deps = null
-commands = python -c "import hdmf"
-
 [testenv:wheelinstall-py35]
 deps = null
 commands = python -c "import hdmf"
@@ -105,12 +92,6 @@ deps =
 
 commands =
     python test.py --example
-
-[testenv:gallery-py27]
-basepython = python2.7
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
 
 [testenv:gallery-py35]
 basepython = python3.5


### PR DESCRIPTION
This PR:
- drops continuous integration testing for Python 2.7
- updates documentation
- updates pinned versions of required packages
- update GitHub template for bug reports 