### PR TITLE
Exclude coverage testing of abstract properties, methods

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,8 @@
 branch = True
 source = src/
 omit = src/hdmf/_version.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    @abstract

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1,4 +1,4 @@
-import abc
+from abc import abstractmethod
 from uuid import uuid4
 from six import with_metaclass
 from .utils import docval, getargs, ExtenderMeta
@@ -131,7 +131,8 @@ class Container(with_metaclass(ExtenderMeta, object)):
 
 class Data(Container):
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def data(self):
         '''
         The data that is held by this Container
@@ -144,14 +145,16 @@ class Data(Container):
 
 class DataRegion(Data):
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def data(self):
         '''
         The target data that this region applies to
         '''
         pass
 
-    @abc.abstractproperty
+    @property
+    @abstractmethod
     def region(self):
         '''
         The region that indexes into data e.g. slice or list of indices

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -139,7 +139,9 @@ class Data(Container):
         '''
         pass
 
-    def __nonzero__(self):
+    def __bool__(self):
+        if not hasattr(self.data, '__len__'):
+            raise NotImplementedError('__bool__ must be implemented when data has no __len__')
         return len(self.data) != 0
 
 

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 try:
     from collections.abc import Iterable  # Python 3
 except ImportError:
@@ -83,7 +83,8 @@ class AbstractDataChunkIterator(with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError("recommended_data_shape not implemented for derived class")
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def dtype(self):
         """
         Define the data type of the array
@@ -92,7 +93,8 @@ class AbstractDataChunkIterator(with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError("dtype not implemented for derived class")
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def maxshape(self):
         """
         Property describing the maximum shape of the data array that is being iterated over
@@ -556,11 +558,13 @@ class RegionSlicer(with_metaclass(ABCMeta, DataRegion)):
     def slice(self):
         return self.__slice
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def __getitem__(self, idx):
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def __len__(self):
         pass
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -120,7 +120,7 @@ class TestContainer(unittest.TestCase):
 
 
 class SubData(Data):
-    
+
     def __init__(self, name, data):
         super(SubData, self).__init__(name=name)
         self.__data = data

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,6 +1,6 @@
 import unittest2 as unittest
 
-from hdmf.container import Container
+from hdmf.container import Container, Data
 
 
 class Subcontainer(Container):
@@ -117,6 +117,43 @@ class TestContainer(unittest.TestCase):
     def test_type_hierarchy(self):
         self.assertEqual(Container.type_hierarchy(), (Container, object))
         self.assertEqual(Subcontainer.type_hierarchy(), (Subcontainer, Container, object))
+
+
+class SubData(Data):
+    
+    def __init__(self, name, data):
+        super(SubData, self).__init__(name=name)
+        self.__data = data
+
+    @property
+    def data(self):
+        return self.__data
+
+
+class TestData(unittest.TestCase):
+
+    def test_bool_true(self):
+        """Test that __bool__ method works correctly on data with len
+        """
+        data_obj = SubData('my_data', [1, 2, 3, 4, 5])
+        self.assertTrue(data_obj)
+
+    def test_bool_false(self):
+        """Test that __bool__ method works correctly on empty data
+        """
+        data_obj = SubData('my_data', '')
+        self.assertFalse(data_obj)
+
+        data_obj = SubData('my_data', [])
+        self.assertFalse(data_obj)
+
+    def test_bool_no_len(self):
+        """Test that__bool__ method works correctly on data with no len
+        """
+        data_obj = SubData('my_data', Container(''))
+        err_msg = '__bool__ must be implemented when data has no __len__'
+        with self.assertRaisesRegex(NotImplementedError, err_msg):
+            bool(data_obj)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -533,15 +533,15 @@ class TestHDF5IO(unittest.TestCase):
             os.remove(self.path)
             
         if self.file_obj is not None:
+            fn = self.file_obj.filename
             self.file_obj.close()
-            if os.path.exists(self.file_obj.filename):
-                os.remove(self.file_obj)
+            if os.path.exists(fn):
+                os.remove(fn)
 
     def test_constructor(self):
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             self.assertEquals(io.manager, self.manager)
             self.assertEquals(io.source, self.path)
-            self.assertEquals(io.mode, 'w')
 
     def test_set_file_mismatch(self):
         self.file_obj = File(get_temp_filepath())

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -552,8 +552,8 @@ class TestHDF5IO(unittest.TestCase):
 
     def test_set_file_mismatch(self):
         self.file_obj = File(get_temp_filepath())
-        err_msg = "You argued %s as this object's path, but supplied a file with filename: %s" \
-                  % (self.path, self.file_obj.filename)
+        err_msg = re.escape("You argued %s as this object's path, but supplied a file with filename: %s"
+                            % (self.path, self.file_obj.filename))
         with self.assertRaisesRegex(ValueError, err_msg):
             HDF5IO(self.path, manager=self.manager, mode='w', file=self.file_obj)
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -516,6 +516,41 @@ class TestRoundTrip(unittest.TestCase):
             self.assertListEqual([], read_foofile.buckets[0].foos)
 
 
+class TestHDF5IO(unittest.TestCase):
+    
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        self.foofile = FooFile([foobucket])
+        
+        self.file_obj = None
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+            
+        if self.file_obj is not None:
+            self.file_obj.close()
+            if os.path.exists(self.file_obj.filename):
+                os.remove(self.file_obj)
+
+    def test_constructor(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            self.assertEquals(io.manager, self.manager)
+            self.assertEquals(io.source, self.path)
+            self.assertEquals(io.mode, 'w')
+            
+    def test_set_file_mismatch(self):
+        self.file_obj = File(get_temp_filepath())
+        err_msg = "You argued %s as this object's path, but supplied a file with filename: %s" % 
+                  (self.path, self.file_obj.filename)
+        with self.assertRaisesRegex(ValueError, err_msg):
+            HDF5IO(self.path, manager=self.manager, mode='w', file=self.file_obj)
+            
+            
 class TestCacheSpec(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -542,15 +542,15 @@ class TestHDF5IO(unittest.TestCase):
             self.assertEquals(io.manager, self.manager)
             self.assertEquals(io.source, self.path)
             self.assertEquals(io.mode, 'w')
-            
+
     def test_set_file_mismatch(self):
         self.file_obj = File(get_temp_filepath())
-        err_msg = "You argued %s as this object's path, but supplied a file with filename: %s" % 
-                  (self.path, self.file_obj.filename)
+        err_msg = "You argued %s as this object's path, but supplied a file with filename: %s" \
+                  % (self.path, self.file_obj.filename)
         with self.assertRaisesRegex(ValueError, err_msg):
             HDF5IO(self.path, manager=self.manager, mode='w', file=self.file_obj)
-            
-            
+
+
 class TestCacheSpec(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -517,21 +517,21 @@ class TestRoundTrip(unittest.TestCase):
 
 
 class TestHDF5IO(unittest.TestCase):
-    
+
     def setUp(self):
         self.manager = _get_manager()
         self.path = get_temp_filepath()
-        
+
         foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
         foobucket = FooBucket('test_bucket', [foo1])
         self.foofile = FooFile([foobucket])
-        
+
         self.file_obj = None
 
     def tearDown(self):
         if os.path.exists(self.path):
             os.remove(self.path)
-            
+
         if self.file_obj is not None:
             fn = self.file_obj.filename
             self.file_obj.close()


### PR DESCRIPTION
Codecov dings us for not having tests that cover abstract properties and methods. Let's see if we can exclude those properties and methods from consideration. Trying one solution suggested here: https://stackoverflow.com/questions/9202723/excluding-abstractproperties-from-coverage-reports