### PR TITLE
Update docs to say clone with submodules

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -72,9 +72,9 @@ For development an editable install is recommended.
    $ pip install -U virtualenv
    $ virtualenv ~/hdmf
    $ source ~/hdmf/bin/activate
-   $ git clone git@github.com:hdmf-dev/hdmf.git
+   $ git clone --recurse-submodules git@github.com:hdmf-dev/hdmf.git
    $ cd hdmf
-   $ pip install -r requirements.txt -r requirements-dev.txt
+   $ pip install -r requirements.txt
    $ pip install -e .
 
 
@@ -88,7 +88,7 @@ For running the tests, it is required to install the development requirements.
    $ pip install -U virtualenv
    $ virtualenv ~/hdmf
    $ source ~/hdmf/bin/activate
-   $ git clone git@github.com:hdmf-dev/hdmf.git
+   $ git clone  --recurse-submodules git@github.com:hdmf-dev/hdmf.git
    $ cd hdmf
    $ pip install -r requirements.txt -r requirements-dev.txt
    $ pip install -e .

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -92,7 +92,7 @@ PyPI: Step-by-step
 
   .. code::
 
-    $ cd /tmp && git clone git@github.com:hdmf-dev/hdmf && cd hdmf
+    $ cd /tmp && git clone --recurse-submodules git@github.com:hdmf-dev/hdmf && cd hdmf
 
 
 5. Tag the release


### PR DESCRIPTION
Analogous to https://github.com/NeurodataWithoutBorders/pynwb/pull/1078

The docs say to install pynwb from GitHub using git clone [repo].git. This should be updated to say git clone --recurse-submodules [repo].git.