### PR TITLE
RF: git submodule to subtree for src/hdmf/common/hdmf-common-schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ references:
   ci-steps: &ci-steps
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
       - run:
           <<: *initialize-venv
       - run:
@@ -67,8 +65,6 @@ references:
   conda-steps: &conda-steps
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
       - run:
           name: Configure conda
           command: |
@@ -93,8 +89,6 @@ references:
   gallery-steps: &gallery-steps
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
       - restore_cache:
           keys:
             - ophys-data-cache
@@ -261,8 +255,6 @@ jobs:
       - image: circleci/python:3.7.0-stretch
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
       - run:
           <<: *initialize-venv
       - run:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/hdmf/common/hdmf-common-schema"]
-	path = src/hdmf/common/hdmf-common-schema
-	url = https://github.com/hdmf-dev/hdmf-common-schema.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# hdmf-common
+Specifications for pre-defined data structures of HDMF
+
+The HDMF common provides the following data structures:
+- DynamicTable : a column-based table structure that stores one-to-one and one-to-many relationships
+  - VectorData : a data structure for representing a column
+  - VectorIndex : a data structure for indexing a VectorData. This is used to store one-to-many relationships
+  - ElementIdentifiers : a 1D array for storing primary identifiers for elements of a table
+- CSRMatrix : a compressed sparse row matrix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,6 @@ jobs:
   steps:
 
   - checkout: self
-    submodules: true
 
   - task: UsePythonVersion@0
     inputs:

--- a/common/namespace.yaml
+++ b/common/namespace.yaml
@@ -1,0 +1,21 @@
+namespaces:
+- name: hdmf-common
+  doc: Common data structures provided by HDMF
+  author:
+  - Andrew Tritt
+  - Oliver Ruebel
+  - Ryan Ly
+  - Ben Dichter
+  contact:
+  - ajtritt@lbl.gov
+  - oruebel@lbl.gov
+  - rly@lbl.gov
+  - bdichter@lbl.gov
+  full_name: HDMF Common
+  schema:
+  - doc: data types for a column-based table
+    source: table.yaml
+    title: Table data types
+  - doc: data types for different types of sparse matrices
+    source: sparse.yaml
+  version: 1.0.0

--- a/common/sparse.yaml
+++ b/common/sparse.yaml
@@ -1,0 +1,24 @@
+groups:
+- doc: a compressed sparse row matrix
+  attributes:
+  - name: shape
+    dtype: int
+    shape:
+    - 2
+    doc: the shape of this sparse matrix
+  datasets:
+  - name: indices
+    dtype: int
+    shape:
+    - null
+    doc: column indices
+  - name: indptr
+    dtype: int
+    shape:
+    - null
+    doc: index pointer
+  - name: data
+    shape:
+    - null
+    doc: values in the matrix
+  data_type_def: CSRMatrix

--- a/common/table.yaml
+++ b/common/table.yaml
@@ -1,0 +1,114 @@
+datasets:
+- data_type_def: Data
+  doc: An abstract data type for a dataset.
+
+- data_type_def: Index
+  data_type_inc: Data
+  doc: Pointers that index data values.
+  attributes:
+  - name: target
+    dtype:
+      target_type: Data
+      reftype: object
+    doc: Target dataset that this index applies to.
+
+- data_type_def: VectorData
+  data_type_inc: Data
+  doc: A 1-dimensional dataset. This can be indexed using a VectorIndex to
+    encode a 2-dimensional ragged array in 1 dimension. The first vector
+    is at VectorData[0:VectorIndex(0)+1]. The second vector is at
+    VectorData[VectorIndex(0)+1:VectorIndex(1)+1]. And so on.
+  attributes:
+  - name: description
+    dtype: text
+    doc: Description of what these vectors represent.
+
+- data_type_def: VectorIndex
+  data_type_inc: Index
+  doc: An array of indices into the first dimension of the target VectorData.
+    Can be used with VectorData to encode a 2-dimensional ragged array in 1 dimension.
+  attributes:
+  - name: target
+    dtype:
+      target_type: VectorData
+      reftype: object
+    doc: Reference to the target dataset that this index applies to.
+
+- data_type_def: ElementIdentifiers
+  data_type_inc: Data
+  default_name: element_id
+  dtype: int
+  dims:
+  - num_elements
+  shape:
+  - null
+  doc: A list of unique identifiers for values within a dataset, e.g. rows of a DynamicTable.
+
+- data_type_def: DynamicTableRegion
+  data_type_inc: VectorData
+  dtype: int
+  doc: A region/index into a DynamicTable.
+  attributes:
+  - name: table
+    dtype:
+      target_type: DynamicTable
+      reftype: object
+    doc: Reference to the DynamicTable object that this region applies to.
+  - name: description
+    dtype: text
+    doc: Description of what this table region points to.
+
+groups:
+- data_type_def: Container
+  doc: An abstract data type for a generic container storing collections of data and
+    metadata. Base type for all data and metadata containers.
+
+- data_type_def: DynamicTable
+  data_type_inc: Container
+  doc: A group containing multiple datasets that are aligned on the first dimension
+    (Currently, this requirement if left up to APIs to check and enforce). Apart from
+    a column that contains unique identifiers for each row there are no other required
+    datasets. Users are free to add any number of VectorData objects here. Table functionality
+    is already supported through compound types, which is analogous to storing an
+    array-of-structs. DynamicTable can be thought of as a struct-of-arrays. This provides
+    an alternative structure to choose from when optimizing storage for anticipated
+    access patterns. Additionally, this type provides a way of creating a table without
+    having to define a compound type up front. Although this convenience may be attractive,
+    users should think carefully about how data will be accessed. DynamicTable is
+    more appropriate for column-centric access, whereas a dataset with a compound
+    type would be more appropriate for row-centric access. Finally, data size should
+    also be taken into account. For small tables, performance loss may be an acceptable
+    trade-off for the flexibility of a DynamicTable. For example, DynamicTable was
+    originally developed for storing trial data and spike unit metadata. Both of these
+    use cases are expected to produce relatively small tables, so the spatial locality
+    of multiple datasets present in a DynamicTable is not expected to have a significant
+    performance impact. Additionally, requirements of trial and unit metadata tables
+    are sufficiently diverse that performance implications can be overlooked in favor
+    of usability.
+  attributes:
+  - name: colnames
+    dtype: ascii
+    dims:
+    - num_columns
+    shape:
+    - null
+    doc: The names of the columns in this table. This should be used to specify
+      an order to the columns.
+  - name: description
+    dtype: text
+    doc: Description of what is in this dynamic table.
+  datasets:
+  - name: id
+    data_type_inc: ElementIdentifiers
+    dtype: int
+    dims:
+    - num_rows
+    shape:
+    - null
+    doc: Array of unique identifiers for the rows of this dynamic table.
+  - data_type_inc: VectorData
+    doc: Vector columns of this dynamic table.
+    quantity: '*'
+  - data_type_inc: VectorIndex
+    doc: Indices for the vector columns of this dynamic table.
+    quantity: '*'

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -72,7 +72,7 @@ For development an editable install is recommended.
    $ pip install -U virtualenv
    $ virtualenv ~/hdmf
    $ source ~/hdmf/bin/activate
-   $ git clone --recurse-submodules git@github.com:hdmf-dev/hdmf.git
+   $ git clone git@github.com:hdmf-dev/hdmf.git
    $ cd hdmf
    $ pip install -r requirements.txt
    $ pip install -e .
@@ -88,7 +88,7 @@ For running the tests, it is required to install the development requirements.
    $ pip install -U virtualenv
    $ virtualenv ~/hdmf
    $ source ~/hdmf/bin/activate
-   $ git clone  --recurse-submodules git@github.com:hdmf-dev/hdmf.git
+   $ git clone git@github.com:hdmf-dev/hdmf.git
    $ cd hdmf
    $ pip install -r requirements.txt -r requirements-dev.txt
    $ pip install -e .

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -92,7 +92,7 @@ PyPI: Step-by-step
 
   .. code::
 
-    $ cd /tmp && git clone --recurse-submodules git@github.com:hdmf-dev/hdmf && cd hdmf
+    $ cd /tmp && git clone git@github.com:hdmf-dev/hdmf && cd hdmf
 
 
 5. Tag the release


### PR DESCRIPTION
As hinted in https://github.com/NeurodataWithoutBorders/pynwb/issues/1076#issuecomment-536796896 , IMHO git subtree mechanism should be a better fit than submodule for inclusion of `src/hdmf/common/hdmf-common-schema`.

Benefits
- no need for any additional `git submodule` manipulations (so no need for custom procedures to get perspective contributors to read the docs)
- switching between different states/branches of the project with different state of that subtree would not require any additional command

I have used the https://gist.githubusercontent.com/Nikita240/0c98cea8f53a15e69699cd8bc40657c4/raw/84c4020fe9384a0eafd79bf853745af0ded902ed/subtrees.sh helper mentioned on [SO](https://stackoverflow.com/a/44407172) to do that, and then only adjusted CI/docs.

Remaining TODOs (in case you decide to go this route):
- [ ] check if any existing branch needs the same dance and do it there as well
- [ ] extend DOCs on how to update that subtree whenever needed

Feel free to ignore / close.  I just thought to propose  ;)