### PR TITLE
Enhance error checking for szip H5DataIO settings

### DIFF
--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -441,7 +441,7 @@ class H5IOTest(unittest.TestCase):
                             compression='gzip')
             self.assertEqual(len(w), 0)
             self.assertEqual(dset.io_settings['compression'], 'gzip')
-        # Make sure no warning is issued when using szip (if installed)
+        # Make sure a warning is issued when using szip (even if installed)
         if "szip" in h5py_filters.encode:
             with warnings.catch_warnings(record=True) as w:
                 dset = H5DataIO(np.arange(30),
@@ -452,7 +452,7 @@ class H5IOTest(unittest.TestCase):
         else:
             with self.assertRaises(ValueError):
                 H5DataIO(np.arange(30), compression='szip', compression_opts=('ec', 16))
-        # Make sure no warning is issued when using lzf
+        # Make sure a warning is issued when using lzf compression
         with warnings.catch_warnings(record=True) as w:
             dset = H5DataIO(np.arange(30),
                             compression='lzf')
@@ -494,6 +494,12 @@ class H5IOTest(unittest.TestCase):
         # Make sure we warn if szip with gzip compression option is used
         with self.assertRaises(ValueError):
             H5DataIO(np.arange(30), compression='szip', compression_opts=4)
+        # Make sure szip raises a ValueError if bad options are used (odd compression option)
+        with self.assertRaises(ValueError):
+            H5DataIO(np.arange(30), compression='szip', compression_opts=('ec', 3))
+        # Make sure szip raises a ValueError if bad options are used (bad methos)
+        with self.assertRaises(ValueError):
+            H5DataIO(np.arange(30), compression='szip', compression_opts=('bad_method', 16))
 
     def test_warning_on_linking_of_regular_array(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
## Motivation

Enhance error checking for SZIP parameters in H5DataIO and address suggestions from @rly in #167 that did not make it in before that PR was merged

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
