### PR TITLE
Fix default ObjectMapping bug for DynamicTableRegion columns

### DIFF
--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -37,6 +37,8 @@ class DynamicTableMap(ObjectMapper):
                     attr_value = attr_value.target
             elif spec.data_type_inc == 'DynamicTableRegion':
                 attr_value = container[spec.name]
+                if isinstance(attr_value, VectorIndex):
+                    attr_value = attr_value.target
                 if attr_value.table is None:
                     msg = "empty or missing table for DynamicTableRegion '%s' in DynamicTable '%s'" %\
                           (attr_value.name, container.name)


### PR DESCRIPTION
## Motivation

The default mapping for DynamicTableRegion columns in the DynamicTable has a bug where we try to read the ``.table`` attribute from the ``VectorIndex`` instead of the ``VectorData`` dataset. 

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
