### PR TITLE
Bug/register container

### DIFF
--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -39,6 +39,10 @@ class H5Dataset(HDMFDataset):
     def ref(self):
         return self.dataset.ref
 
+    @property
+    def shape(self):
+        return self.dataset.shape
+
 
 class H5TableDataset(H5Dataset):
 

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -104,6 +104,10 @@ if os.path.exists(__resources['namespace_path']):
     from . import table  # noqa: F401,E402
     from . import sparse  # noqa: F401,E402
 
+    from .. import Data, Container
+    __TYPE_MAP.register_container_type(CORE_NAMESPACE, 'Container', Container)
+    __TYPE_MAP.register_container_type(CORE_NAMESPACE, 'Data', Data)
+
 else:
     raise RuntimeError("Unable to load a TypeMap - no namespace file found")
 

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -31,6 +31,8 @@ def get_shape(data):
     """
     if isinstance(data, dict):
         return None
+    elif hasattr(data, 'shape'):
+        return data.shape
     elif hasattr(data, '__len__') and not isinstance(data, (text_type, binary_type)):
         return __get_shape_helper(data)
     else:

--- a/tests/unit/common/test_common.py
+++ b/tests/unit/common/test_common.py
@@ -12,4 +12,3 @@ class TestCommonTypeMap(unittest.TestCase):
         self.assertIs(cls, Container)
         cls = tm.get_container_cls('hdmf-common', 'Data')
         self.assertIs(cls, Data)
-

--- a/tests/unit/common/test_common.py
+++ b/tests/unit/common/test_common.py
@@ -1,0 +1,15 @@
+import unittest2 as unittest
+
+from hdmf import Data, Container
+from hdmf.common import get_type_map
+
+
+class TestCommonTypeMap(unittest.TestCase):
+
+    def test_base_types(self):
+        tm = get_type_map()
+        cls = tm.get_container_cls('hdmf-common', 'Container')
+        self.assertIs(cls, Container)
+        cls = tm.get_container_cls('hdmf-common', 'Data')
+        self.assertIs(cls, Data)
+

--- a/tests/unit/test_io_hdf5.py
+++ b/tests/unit/test_io_hdf5.py
@@ -5,6 +5,7 @@ from six import text_type
 
 from hdmf.backends.hdf5 import HDF5IO
 from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder
+from hdmf.data_utils import get_shape
 
 from numbers import Number
 
@@ -230,4 +231,13 @@ class TestHDF5Writer(GroupBuilderTestCase):
         builder = io.read_builder()
         with self.assertRaisesRegex(ValueError, "cannot change written to not written"):
             builder.written = False
+        io.close()
+
+    def test_dataset_shape(self):
+        self.maxDiff = None
+        io = HDF5IO(self.path, manager=self.manager, mode='a')
+        io.write_builder(self.builder)
+        builder = io.read_builder()
+        dset = builder['test_bucket']['foo_holder']['foo1']['my_data'].data
+        self.assertEqual(get_shape(dset), (10,))
         io.close()


### PR DESCRIPTION
## Motivation

`hdmf.data_utils.get_shape` always infers shape on its own. Use specified shape if it is there.

This is needed to fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1082