### PR TITLE
write from DataChunkIterators all at once

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -69,6 +69,7 @@ class HDF5IO(HDMFIO):
         self.__built = dict()       # keep track of which files have been read
         self.__read = dict()        # keep track of each builder for each dataset/group/link
         self.__ref_queue = deque()  # a queue of the references that need to be added
+        self.__dci_queue = dequeu()       # a queue of DataChunkIterators that need to be exhausted
         ObjectMapper.no_convert(Dataset)
 
     @property
@@ -506,6 +507,7 @@ class HDF5IO(HDMFIO):
             self.write_link(self.__file, lbldr)
         self.set_attributes(self.__file, f_builder.attributes)
         self.__add_refs()
+        self.__exhaust_dcis()
 
     def __add_refs(self):
         '''
@@ -526,6 +528,12 @@ class HDF5IO(HDMFIO):
                     raise RuntimeError('Unable to resolve reference')
                 failed.add(id(call))
                 self.__ref_queue.append(call)
+
+    def __exhaust_dcis(self):
+        while len(self.__dci_queue) > 0:
+            dset, data = self.__dci_queue.popleft()
+            if self.__write_chunk__(dset, data):
+                self.__dci_queue.append((dset, data))
 
     @classmethod
     def get_type(cls, data):
@@ -709,7 +717,7 @@ class HDF5IO(HDMFIO):
         """ Write a dataset to HDF5
 
         The function uses other dataset-dependent write functions, e.g,
-        __scalar_fill__, __list_fill__ and __chunked_iter_fill__ to write the data.
+        __scalar_fill__, __list_fill__ and __setup_chunked_dset__ to write the data.
         """
         parent, builder, link_data = getargs('parent', 'builder', 'link_data', kwargs)
         if builder.written:
@@ -843,7 +851,8 @@ class HDF5IO(HDMFIO):
                 dset = self.__scalar_fill__(parent, name, data, options)
             # Iterative write of a data chunk iterator
             elif isinstance(data, AbstractDataChunkIterator):
-                dset = self.__chunked_iter_fill__(parent, name, data, options)
+                dset = self.__setup_chunked_dset__(parent, name, data, options)
+                self.__dci_queue.append((dset, data))
             # Write a regular in memory array (e.g., numpy array, list etc.)
             elif hasattr(data, '__len__'):
                 dset = self.__list_fill__(parent, name, data, options)
@@ -892,7 +901,7 @@ class HDF5IO(HDMFIO):
         return dset
 
     @classmethod
-    def __chunked_iter_fill__(cls, parent, name, data, options=None):
+    def __setup_chunked_dset__(cls, parent, name, data, options=None):
         """
         Write data to a dataset one-chunk-at-a-time based on the given DataChunkIterator
 
@@ -929,7 +938,12 @@ class HDF5IO(HDMFIO):
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:
             raise_from(Exception("Could not create dataset %s in %s" % (name, parent.name)), exc)
-        for chunk_i in data:
+        return dset
+
+    @classmethod
+    def __write_chunk__(cls, dset, data):
+        try:
+            chunk_i = next(data)
             # Determine the minimum array dimensions to fit the chunk selection
             max_bounds = cls.__selection_max_bounds__(chunk_i.selection)
             if not hasattr(max_bounds, '__len__'):
@@ -943,7 +957,9 @@ class HDF5IO(HDMFIO):
                 dset.resize(new_shape)
             # Process and write the data
             dset[chunk_i.selection] = chunk_i.data
-        return dset
+        except StopIteration:
+            return False
+        return True
 
     @classmethod
     def __list_fill__(cls, parent, name, data, options=None):

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -35,7 +35,9 @@ class HDMFIO(with_metaclass(ABCMeta, object)):
         container = self.__manager.construct(f_builder)
         return container
 
-    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'})
+    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
+            {'name': 'exhaust_dci', 'type': bool,
+             'doc': 'exhaust DataChunkIterators one at a time. If False, exhaust them concurrently', 'default': True})
     def write(self, **kwargs):
         container = popargs('container', kwargs)
         f_builder = self.__manager.build(container, source=self.__source)
@@ -48,7 +50,9 @@ class HDMFIO(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the Container'})
+    @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the Container'},
+            {'name': 'exhaust_dci', 'type': bool,
+             'doc': 'exhaust DataChunkIterators one at a time. If False, exhaust them concurrently', 'default': True})
     def write_builder(self, **kwargs):
         ''' Write a GroupBuilder representing an Container object '''
         pass

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -265,7 +265,29 @@ class H5IOTest(unittest.TestCase):
         dset = self.f['test_dataset']
         self.assertListEqual(dset[:].tolist(), a.tolist())
 
-    def test_write_multi_dci(self):
+    def test_write_multi_dci_oaat(self):
+        """
+        Test writing multiple DataChunkIterators, one at a time
+        """
+        a = np.arange(30).reshape(5, 2, 3)
+        b = np.arange(30, 60).reshape(5, 2, 3)
+        aiter = iter(a)
+        biter = iter(b)
+        daiter1 = DataChunkIterator.from_iterable(aiter, buffer_size=2)
+        daiter2 = DataChunkIterator.from_iterable(biter, buffer_size=2)
+        builder = GroupBuilder("root")
+        builder.add_dataset('test_dataset1', daiter1, attributes={})
+        builder.add_dataset('test_dataset2', daiter2, attributes={})
+        self.io.write_builder(builder)
+        dset1 = self.f['test_dataset1']
+        self.assertListEqual(dset1[:].tolist(), a.tolist())
+        dset2 = self.f['test_dataset2']
+        self.assertListEqual(dset2[:].tolist(), b.tolist())
+
+    def test_write_multi_dci_conc(self):
+        """
+        Test writing multiple DataChunkIterators, concurrently
+        """
         a = np.arange(30).reshape(5, 2, 3)
         b = np.arange(30, 60).reshape(5, 2, 3)
         aiter = iter(a)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -265,6 +265,22 @@ class H5IOTest(unittest.TestCase):
         dset = self.f['test_dataset']
         self.assertListEqual(dset[:].tolist(), a.tolist())
 
+    def test_write_multi_dci(self):
+        a = np.arange(30).reshape(5, 2, 3)
+        b = np.arange(30, 60).reshape(5, 2, 3)
+        aiter = iter(a)
+        biter = iter(b)
+        daiter1 = DataChunkIterator.from_iterable(aiter, buffer_size=2)
+        daiter2 = DataChunkIterator.from_iterable(biter, buffer_size=2)
+        builder = GroupBuilder("root")
+        builder.add_dataset('test_dataset1', daiter1, attributes={})
+        builder.add_dataset('test_dataset2', daiter2, attributes={})
+        self.io.write_builder(builder)
+        dset1 = self.f['test_dataset1']
+        self.assertListEqual(dset1[:].tolist(), a.tolist())
+        dset2 = self.f['test_dataset2']
+        self.assertListEqual(dset2[:].tolist(), b.tolist())
+
     def test_write_dataset_iterable_multidimensional_array_compression(self):
         a = np.arange(30).reshape(5, 2, 3)
         aiter = iter(a)


### PR DESCRIPTION
## Motivation

DataChunkIterators get read/written one at a time. This modification causes DataChunkIterators to be exhausted in a round-robin fashion, allowing DataChunkIterators to be read/written "in parallel"

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```