### PR TITLE
Allow enforcing unique ids on DynamicTable

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -298,12 +298,14 @@ class DynamicTable(Container):
 
     @docval({'name': 'data', 'type': dict, 'doc': 'the data to put in this row', 'default': None},
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},
+            {'name': 'enforce_unique_id', 'type': bool, 'doc': 'enforce that the id in the table must be unique',
+             'default': False},
             allow_extra=True)
     def add_row(self, **kwargs):
         '''
         Add a row to the table. If *id* is not provided, it will auto-increment.
         '''
-        data, row_id = popargs('data', 'id', kwargs)
+        data, row_id, enforce_unique_id = popargs('data', 'id', 'enforce_unique_id', kwargs)
         data = data if data is not None else kwargs
 
         extra_columns = set(list(data.keys())) - set(list(self.__colids.keys()))
@@ -327,11 +329,13 @@ class DynamicTable(Container):
                     'and were missing {} keys: {}'.format(len(missing_columns), missing_columns)
                 ])
             )
-
         if row_id is None:
             row_id = data.pop('id', None)
         if row_id is None:
             row_id = len(self)
+        if enforce_unique_id:
+            if row_id in self.id:
+                raise ValueError("id %i already in the table" % row_id)
         self.id.append(row_id)
 
         for colname, colnum in self.__colids.items():

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -181,9 +181,22 @@ class TestDynamicTable(unittest.TestCase):
 
     def test_missing_columns(self):
         table = self.with_spec()
-
         with self.assertRaises(ValueError):
             table.add_row({'bar': 60.0, 'foo': [6]}, None)
+
+    def test_enforce_unique_id_error(self):
+        table = self.with_spec()
+        table.add_row(id=10, data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=True)
+        with self.assertRaises(ValueError):
+            table.add_row(id=10, data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=True)
+
+    def test_not_enforce_unique_id_error(self):
+        table = self.with_spec()
+        table.add_row(id=10, data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=False)
+        try:
+            table.add_row(id=10, data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=False)
+        except ValueError as e:
+            self.fail("add row with non unique id raised error %s" % str(e))
 
     def test_extra_columns(self):
         table = self.with_spec()


### PR DESCRIPTION
## Motivation

Allow us to enforce the requirement for unique row ids in the DynamicTable when adding rows. This is related to https://github.com/oruebel/ndx-icephys-meta/issues/8

