### PR TITLE
Allow search of ids in ElementIdentifiers

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -85,6 +85,27 @@ class ElementIdentifiers(Data):
     def __init__(self, **kwargs):
         call_docval_func(super(ElementIdentifiers, self).__init__, kwargs)
 
+    @docval({'name': 'other', 'type': (Data, np.ndarray, list, tuple, int),
+             'doc': 'List of ids to search for in this ElementIdentifer object'},
+            rtype=np.ndarray,
+            returns='Array with the list of indices where the elements in the list where found.'
+                    'Note, the elements in the returned list are ordered in increasing index'
+                    'of the found elements, rather than in the order in which the elements'
+                    'where given for the search. Also the length of the result may be different from the length'
+                    'of the input array. E.g., if our ids are [1,2,3] and we are search for [3,1,5] the '
+                    'result would be [0,2] and NOT [2,0,None]')
+    def __eq__(self, other):
+        """
+        Given a list of ids return the indices in the ElementIdentifiers array where the
+        indices are found.
+        """
+        # Determin the ids we want to find
+        search_ids = other if not isinstance(other, Data) else other.data
+        if isinstance(search_ids, int):
+            search_ids = [search_ids]
+        # Find all matching locations
+        return np.in1d(self.data, search_ids).nonzero()[0]
+
 
 @register_class('DynamicTable')
 class DynamicTable(Container):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -99,7 +99,7 @@ class ElementIdentifiers(Data):
         Given a list of ids return the indices in the ElementIdentifiers array where the
         indices are found.
         """
-        # Determin the ids we want to find
+        # Determine the ids we want to find
         search_ids = other if not isinstance(other, Data) else other.data
         if isinstance(search_ids, int):
             search_ids = [search_ids]

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -198,6 +198,13 @@ class TestDynamicTable(unittest.TestCase):
         except ValueError as e:
             self.fail("add row with non unique id raised error %s" % str(e))
 
+    def test_bad_id_type_error(self):
+        table = self.with_spec()
+        with self.assertRaises(TypeError):
+            table.add_row(id=10.1, data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=True)
+        with self.assertRaises(TypeError):
+            table.add_row(id='str', data={'foo': 1, 'bar': 10.0, 'baz': 'cat'}, enforce_unique_id=True)
+
     def test_extra_columns(self):
         table = self.with_spec()
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -226,6 +226,20 @@ class TestDynamicTable(unittest.TestCase):
                            index=pd.Index(name='id', data=[0, 1, 2]))
         pd.testing.assert_frame_equal(df, df2)
 
+    def test_id_search(self):
+        table = self.with_spec()
+        data = [{'foo': 1, 'bar': 10.0, 'baz': 'cat'},
+                {'foo': 2, 'bar': 20.0, 'baz': 'dog'},
+                {'foo': 3, 'bar': 30.0, 'baz': 'bird'},
+                {'foo': 4, 'bar': 40.0, 'baz': 'fish'},
+                {'foo': 5, 'bar': 50.0, 'baz': 'lizard'}]
+        for i in data:
+            table.add_row(i)
+        res = table[table.id == [2, 4]]
+        self.assertEqual(len(res), 2)
+        self.assertTupleEqual(res[0], (2, 3, 30.0, 'bird'))
+        self.assertTupleEqual(res[1], (4, 5, 50.0, 'lizard'))
+
 
 class TestDynamicTableRoundTrip(base.TestMapRoundTrip):
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -258,3 +258,43 @@ class TestDynamicTableRoundTrip(base.TestMapRoundTrip):
                 'b': ['4', '5', '6']
             }), 'test_table', table_description='the expected table', column_descriptions=coldesc)
         self.assertContainerEqual(expected, received)
+
+
+class TestElementIdentifiers(unittest.TestCase):
+
+    def test_identifier_search_single_list(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == [1])
+        np.testing.assert_array_equal(a, [1])
+
+    def test_identifier_search_single_int(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == 2)
+        np.testing.assert_array_equal(a, [2])
+
+    def test_identifier_search_single_list_not_found(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == [10])
+        np.testing.assert_array_equal(a, [])
+
+    def test_identifier_search_single_int_not_found(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == 10)
+        np.testing.assert_array_equal(a, [])
+
+    def test_identifier_search_single_list_all_match(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == [1, 2, 3])
+        np.testing.assert_array_equal(a, [1, 2, 3])
+
+    def test_identifier_search_single_list_partial_match(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == [1, 2, 10])
+        np.testing.assert_array_equal(a, [1, 2])
+        a = (e == [-1, 2, 10])
+        np.testing.assert_array_equal(a, [2, ])
+
+    def test_identifier_search_with_element_identifier(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        a = (e == ElementIdentifiers('ids', [1, 2, 10]))
+        np.testing.assert_array_equal(a, [1, 2])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -319,3 +319,10 @@ class TestElementIdentifiers(unittest.TestCase):
         e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
         a = (e == ElementIdentifiers('ids', [1, 2, 10]))
         np.testing.assert_array_equal(a, [1, 2])
+
+    def test_identifier_search_with_bad_ids(self):
+        e = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
+        with self.assertRaises(TypeError):
+            _ = (e == 0.1)
+        with self.assertRaises(TypeError):
+            _ = (e == 'test')


### PR DESCRIPTION
## Motivation

This is to allow us to address https://github.com/oruebel/ndx-icephys-meta/issues/9  When creating references to DynamicTable we often don't know the indices of the rows we need but only the list of ids. With this we can now do:

```
dst = DynamicTable(.....)
rows_with_ids = dst[ dst.id == [0,10] ]
````

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
