### PR TITLE
Updated DynamicTableRegion.__getitem__ to return dict with table name…

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -618,13 +618,15 @@ class DynamicTableRegion(VectorData):
     def __getitem__(self, key):
         # treat the list of indices as data that can be indexed. then pass the
         # result to the table to get the data
+        re = None
         if isinstance(key, tuple):
             arg1 = key[0]
             arg2 = key[1]
-            return self.table[self.data[arg1], arg2]
+            re = self.table[self.data[arg1], arg2]
         elif isinstance(key, (int, slice)):
             if isinstance(key, int) and key >= len(self.data):
                 raise IndexError('index {} out of bounds for data of length {}'.format(key, len(self.data)))
-            return self.table[self.data[key]]
+            re = self.table[self.data[key]]
         else:
             raise ValueError("unrecognized argument: '%s'" % key)
+        return {self.table.name: re}

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -208,7 +208,7 @@ class TestDynamicTable(unittest.TestCase):
         table = self.with_columns_and_data()
 
         dynamic_table_region = DynamicTableRegion('dtr', [0, 1, 1], 'desc', table=table)
-        fetch_ids = [x[1] for x in dynamic_table_region[:3]]
+        fetch_ids = [x[1] for x in dynamic_table_region[:3][table.name]]
         self.assertEqual(fetch_ids, [1, 2, 2])
 
     def test_dynamic_table_iteration(self):
@@ -216,7 +216,7 @@ class TestDynamicTable(unittest.TestCase):
 
         dynamic_table_region = DynamicTableRegion('dtr', [0, 1, 2, 3, 4], 'desc', table=table)
         for ii, item in enumerate(dynamic_table_region):
-            self.assertEqual(table[ii], item)
+            self.assertEqual(table[ii], item[table.name])
 
     def test_nd_array_to_df(self):
         data = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])


### PR DESCRIPTION
## Motivation

Currently, in a DynamicTableRegion column in a DynamicTable the references are resolved directly to the selected rows of the table. For the user, this looses the information about the table the the column points to. This is not a big problem when we only have a single level of referencing, but gets complicated when we have a hierarchy of tables. As such, I propose here to instead of returning the ``rows``, to return a dict with ``{'table_name': rows}``.

For example, in the context of https://github.com/oruebel/ndx-icephys-meta we have a hierarchical set of tables for Conditions, Runs, .... etc. Currently this results in the following for the Conditions table:

<img width="333" alt="Screen Shot 2019-10-25 at 9 24 29 AM" src="https://user-images.githubusercontent.com/10999845/67588231-78353f80-f70a-11e9-91af-491c23138585.png">

With this change, this will look like this instead

<img width="348" alt="Screen Shot 2019-10-25 at 9 25 41 AM" src="https://user-images.githubusercontent.com/10999845/67588300-a9ae0b00-f70a-11e9-9deb-0baf592a49c4.png">

I.e., instead of a hierarchical list without any information about where each nesting came from, we'd have a hierarchical dict where the key indicates name of the table and the values are the selected rows. I think from a user perspective this would be more usable.

I'm sure this will also require some changes in PyNWB, but I wanted to put this out as a proposal to see what you think @rly @bendichter @ajtritt . I put the PR in draft mode, mainly because it should not be merged until we have a matching PR on PyNWB.

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
