### PR TITLE
Enhance selection of rows in DynamicTable

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -472,7 +472,7 @@ class DynamicTable(Container):
             arg = key
             if isinstance(arg, slice) or np.issubdtype(type(arg), np.integer):
                 # index with a python slice or single integer to select one or multiple rows
-                data =  OrderedDict()
+                data = OrderedDict()
                 for name in self.colnames:
                     col = self.__df_cols[self.__colids[name]]
                     if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
@@ -522,7 +522,7 @@ class DynamicTable(Container):
         exclude = popargs('exclude', kwargs)
         if exclude is None:
             exclude = set([])
-        data =  OrderedDict()
+        data = OrderedDict()
         for name in self.colnames:
             if name in exclude:
                 continue

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -497,12 +497,12 @@ class DynamicTable(Container):
                     col = self.__df_cols[self.__colids[name]]
                     if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
                         data[name] = [x for x in col[arg]]
-                    elif isinstance(col.data, (Dataset, np.ndarray)):
+                    elif isinstance(col.data, np.ndarray):
                         data[name] = col[arg]
                     else:
                         data[name] = [col[i] for i in arg]
                 id_index = (self.id.data[arg]
-                            if isinstance(self.id.data, (np.ndarray, Dataset))
+                            if isinstance(self.id.data, np.ndarray)
                             else [self.id.data[i] for i in arg])
                 ret = pd.DataFrame(data, index=pd.Index(name=self.id.name, data=id_index), columns=self.colnames)
             else:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -471,6 +471,9 @@ class DynamicTable(Container):
             elif np.issubdtype(type(arg), np.integer):
                 # index by int, return row
                 ret = tuple(col[arg] for col in self.__df_cols)
+            elif isinstance(arg, slice):
+                # index with a python slice to select multiple rows
+                ret = tuple(col[arg] for col in self.__df_cols)
             elif isinstance(arg, (tuple, list, np.ndarray)):
                 # index by a list of ints, return multiple rows
                 if isinstance(arg, np.ndarray):
@@ -479,6 +482,8 @@ class DynamicTable(Container):
                 ret = list()
                 for i in arg:
                     ret.append(tuple(col[i] for col in self.__df_cols))
+            else:
+                raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
 
         return ret
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from ..utils import docval, getargs, ExtenderMeta, call_docval_func, popargs, pystr
 from ..container import Container, Data
+from collections import OrderedDict
 
 from . import register_class
 
@@ -471,7 +472,7 @@ class DynamicTable(Container):
             arg = key
             if isinstance(arg, slice) or np.issubdtype(type(arg), np.integer):
                 # index with a python slice or single integer to select one or multiple rows
-                data = {}
+                data =  OrderedDict()
                 for name in self.colnames:
                     col = self.__df_cols[self.__colids[name]]
                     if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
@@ -487,7 +488,7 @@ class DynamicTable(Container):
                 if isinstance(arg, np.ndarray):
                     if len(arg.shape) != 1:
                         raise ValueError("cannot index DynamicTable with multiple dimensions")
-                data = {}
+                data = OrderedDict()
                 for name in self.colnames:
                     col = self.__df_cols[self.__colids[name]]
                     if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
@@ -521,7 +522,7 @@ class DynamicTable(Container):
         exclude = popargs('exclude', kwargs)
         if exclude is None:
             exclude = set([])
-        data = {}
+        data =  OrderedDict()
         for name in self.colnames:
             if name in exclude:
                 continue

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -692,3 +692,11 @@ class DynamicTableRegion(VectorData):
             return self.table[self.data[key]]
         else:
             raise ValueError("unrecognized argument: '%s'" % key)
+
+    @property
+    def shape(self):
+        """
+        Define the shape, i.e., (num_rows, num_columns) of the selected table region
+        :return: Shape tuple with two integers indicating the number of rows and number of columns
+        """
+        return (len(self.data), len(self.table.columns))

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -486,7 +486,6 @@ class DynamicTable(Container):
                 id_index = self.id.data[arg]
                 if np.isscalar(id_index):
                     id_index = [id_index, ]
-                print(arg, )
                 ret = pd.DataFrame(data, index=pd.Index(name=self.id.name, data=id_index), columns=self.colnames)
             # index by a list of ints, return multiple rows
             elif isinstance(arg, (tuple, list, np.ndarray)):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -276,6 +276,11 @@ class TestDynamicTable(unittest.TestCase):
         for ii, item in enumerate(dynamic_table_region):
             self.assertTrue(table[ii].equals(item))
 
+    def test_dynamic_table_region_shape(self):
+        table = self.with_columns_and_data()
+        dynamic_table_region = DynamicTableRegion('dtr', [0, 1, 2, 3, 4], 'desc', table=table)
+        self.assertTupleEqual(dynamic_table_region.shape, (5,3))
+
     def test_nd_array_to_df(self):
         data = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])
         col = VectorData(name='data', description='desc', data=data)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -279,7 +279,7 @@ class TestDynamicTable(unittest.TestCase):
     def test_dynamic_table_region_shape(self):
         table = self.with_columns_and_data()
         dynamic_table_region = DynamicTableRegion('dtr', [0, 1, 2, 3, 4], 'desc', table=table)
-        self.assertTupleEqual(dynamic_table_region.shape, (5,3))
+        self.assertTupleEqual(dynamic_table_region.shape, (5, 3))
 
     def test_nd_array_to_df(self):
         data = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -6,6 +6,7 @@ from . import base
 
 import pandas as pd
 import numpy as np
+from collections import OrderedDict
 
 
 class TestDynamicTable(unittest.TestCase):
@@ -191,13 +192,17 @@ class TestDynamicTable(unittest.TestCase):
 
     def test_to_dataframe(self):
         table = self.with_columns_and_data()
-        expected_df = pd.DataFrame({
-            'foo': [1, 2, 3, 4, 5],
-            'bar': [10.0, 20.0, 30.0, 40.0, 50.0],
-            'baz': ['cat', 'dog', 'bird', 'fish', 'lizard']
-        })
+        data = OrderedDict()
+        for name in table.colnames:
+            if name == 'foo':
+                data[name] = [1, 2, 3, 4, 5]
+            elif name == 'bar':
+                data[name] = [10.0, 20.0, 30.0, 40.0, 50.0]
+            elif name == 'baz':
+                data[name] = ['cat', 'dog', 'bird', 'fish', 'lizard']
+        expected_df = pd.DataFrame(data)
         obtained_df = table.to_dataframe()
-        assert expected_df.equals(obtained_df)
+        self.assertTrue(expected_df.equals(obtained_df))
 
     def test_from_dataframe(self):
         df = pd.DataFrame({

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -163,7 +163,7 @@ class TestDynamicTable(unittest.TestCase):
         self.add_rows(table)
         row = table[[0, 2, 4]]
         self.assertEqual(len(row), 3)
-        self.assertTupleEqual(tuple(row.loc[0]), (1, 10.0, 'cat'))
+        self.assertTupleEqual(tuple(row.iloc[0]), (1, 10.0, 'cat'))
         self.assertTupleEqual(tuple(row.iloc[1]), (3, 30.0, 'bird'))
         self.assertTupleEqual(tuple(row.iloc[2]), (5, 50.0, 'lizard'))
 
@@ -172,6 +172,12 @@ class TestDynamicTable(unittest.TestCase):
         self.add_rows(table)
         val = table[2, 'bar']
         self.assertEqual(val, 30.0)
+
+    def test_getitem_point_idx(self):
+        table = self.with_spec()
+        self.add_rows(table)
+        row = table[2]
+        self.assertTupleEqual(tuple(row.iloc[0]), (3, 30.0, 'bird'))
 
     def test_getitem_point_idx_colidx(self):
         table = self.with_spec()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -117,6 +117,30 @@ class TestDynamicTable(unittest.TestCase):
         self.assertEqual(row[2], 30.0)
         self.assertEqual(row[3], 'bird')
 
+    def test_getitem_row_slice(self):
+        table = self.with_spec()
+        self.add_rows(table)
+        rows = table[1:3]
+        self.assertEqual(len(rows), 4)
+        for i in rows:
+            self.assertEqual(len(i), 2)
+        self.assertEqual(rows[0][1], 2)
+        self.assertEqual(rows[1][1], 3)
+        self.assertEqual(rows[2][1], 30.0)
+        self.assertEqual(rows[3][1], 'bird')
+
+    def test_getitem_row_slice_with_step(self):
+        table = self.with_spec()
+        self.add_rows(table)
+        rows = table[0:5:2]
+        self.assertEqual(len(rows), 4)
+        for i in rows:
+            self.assertEqual(len(i), 3)
+        self.assertEqual(rows[0][2], 4)
+        self.assertEqual(rows[1][2], 5)
+        self.assertEqual(rows[2][2], 50.0)
+        self.assertEqual(rows[3][2], 'lizard')
+
     def test_getitem_column(self):
         table = self.with_spec()
         self.add_rows(table)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -142,7 +142,10 @@ class TestDynamicTable(unittest.TestCase):
         self.assertEqual(rows[3][2], 'lizard')
 
     def test_getitem_invalid_keytype(self):
-        pass
+        table = self.with_spec()
+        self.add_rows(table)
+        with self.assertRaises(KeyError):
+            rows = table[0.1]
 
     def test_getitem_col_select_and_row_slice(self):
         table = self.with_spec()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -141,6 +141,17 @@ class TestDynamicTable(unittest.TestCase):
         self.assertEqual(rows[2][2], 50.0)
         self.assertEqual(rows[3][2], 'lizard')
 
+    def test_getitem_invalid_keytype(self):
+        pass
+
+    def test_getitem_col_select_and_row_slice(self):
+        table = self.with_spec()
+        self.add_rows(table)
+        col = table[1:3, 'bar']
+        self.assertEqual(len(col), 2)
+        self.assertEqual(col[0], 20.0)
+        self.assertEqual(col[1], 30.0)
+
     def test_getitem_column(self):
         table = self.with_spec()
         self.add_rows(table)

--- a/tests/unit/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/utils_test/test_core_ShapeValidator.py
@@ -1,6 +1,7 @@
 import unittest
 
 from hdmf.data_utils import ShapeValidatorResult, DataChunkIterator, assertEqualShape
+from hdmf.common.table import DynamicTable, DynamicTableRegion, VectorData
 import numpy as np
 
 
@@ -165,6 +166,40 @@ class ShapeValidatorTests(unittest.TestCase):
         self.assertTupleEqual(res.shape2, (2, 5))
         self.assertTupleEqual(res.axes1, (0, 1))
         self.assertTupleEqual(res.axes2, (0, 1))
+
+    def test_DynamicTableRegion_shape_validation(self):
+        # Create a test DynamicTable
+        dt_spec = [
+            {'name': 'foo', 'description': 'foo column'},
+            {'name': 'bar', 'description': 'bar column'},
+            {'name': 'baz', 'description': 'baz column'},
+        ]
+        dt_data = [
+            [1, 2, 3, 4, 5],
+            [10.0, 20.0, 30.0, 40.0, 50.0],
+            ['cat', 'dog', 'bird', 'fish', 'lizard']
+        ]
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(dt_spec, dt_data)
+        ]
+        dt = DynamicTable("with_columns_and_data",
+                          "a test table", columns=columns)
+        # Create test DynamicTableRegion
+        dtr = DynamicTableRegion('dtr', [1, 2, 2], 'desc', table=dt)
+        # Confirm that the shapes match
+        res = assertEqualShape(dtr, np.arange(9).reshape(3,3))
+        self.assertTrue(res.result)
+
+    def with_table_columns(self):
+        cols = [VectorData(**d) for d in self.spec]
+        table = DynamicTable("with_table_columns", 'a test table', columns=cols)
+        return table
+
+    def with_columns_and_data(self):
+
+        return
+
 
 
 class ShapeValidatorResultTests(unittest.TestCase):

--- a/tests/unit/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/utils_test/test_core_ShapeValidator.py
@@ -188,7 +188,7 @@ class ShapeValidatorTests(unittest.TestCase):
         # Create test DynamicTableRegion
         dtr = DynamicTableRegion('dtr', [1, 2, 2], 'desc', table=dt)
         # Confirm that the shapes match
-        res = assertEqualShape(dtr, np.arange(9).reshape(3,3))
+        res = assertEqualShape(dtr, np.arange(9).reshape(3, 3))
         self.assertTrue(res.result)
 
     def with_table_columns(self):
@@ -199,7 +199,6 @@ class ShapeValidatorTests(unittest.TestCase):
     def with_columns_and_data(self):
 
         return
-
 
 
 class ShapeValidatorResultTests(unittest.TestCase):


### PR DESCRIPTION
## Motivation

The goal is to enhance selection of rows from a DynamicTable. This PR makes the following changes:

* Add support for selecting rows in a DynamicTable via ``slice`` and add corresponding tests
* Return Pandas DataFrame when selecting full rows from a DynamicTable and add/update unit tests accordingly
* Use OrderedDict when converting to Pandas to ensure consistent ordering on columns

The matching PR that updates the tests in PyNWB is https://github.com/NeurodataWithoutBorders/pynwb/pull/1106

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
