### PR TITLE
Raise error if expected attribute does not exist on a Container

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -726,14 +726,15 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             return None
         attr_val = self.__get_override_attr(attr_name, container, manager)
         if attr_val is None:
-            # raise error if an expected attribute (based on the spec) does not exist on a Container object
-            if not hasattr(container, attr_name):
+            try:
+                attr_val = getattr(container, attr_name)
+            except AttributeError:
+                # raise error if an expected attribute (based on the spec) does not exist on a Container object
                 msg = "Container '%s' (%s) does not have attribute '%s'" % (container.name, type(container), attr_name)
                 raise Exception(msg)
-
-            attr_val = getattr(container, attr_name, None)
             if attr_val is not None:
                 attr_val = self.__convert_value(attr_val, spec)
+            # else: attr_val is an attribute on the Container and its value is None
         return attr_val
 
     def __convert_value(self, value, spec):

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -726,13 +726,11 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             return None
         attr_val = self.__get_override_attr(attr_name, container, manager)
         if attr_val is None:
-            # TODO: A message like this should be used to warn users when an expected attribute
-            # does not exist on a Container object
-            #
-            # if not hasattr(container, attr_name):
-            #     msg = "Container '%s' (%s) does not have attribute '%s'" \
-            #             % (container.name, type(container), attr_name)
-            #     #warnings.warn(msg)
+            # raise error if an expected attribute (based on the spec) does not exist on a Container object
+            if not hasattr(container, attr_name):
+                msg = "Container '%s' (%s) does not have attribute '%s'" % (container.name, type(container), attr_name)
+                raise Exception(msg)
+
             attr_val = getattr(container, attr_name, None)
             if attr_val is not None:
                 attr_val = self.__convert_value(attr_val, spec)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -252,6 +252,9 @@ class DynamicTable(Container):
         col_dict = dict()
         self.__indices = dict()
         for col in self.columns:
+            if hasattr(self, col.name):
+                raise ValueError("Column name '%s' is not allowed because it is already an attribute" % col.name)
+            setattr(self, col.name, col)
             if isinstance(col, VectorData):
                 existing = col_dict.get(col.name)
                 # if we added this column using its index, ignore this column
@@ -272,10 +275,16 @@ class DynamicTable(Container):
         self.__df_cols = [self.id] + [col_dict[name] for name in self.colnames]
         self.__colids = {name: i+1 for i, name in enumerate(self.colnames)}
         for col in self.__columns__:
-            if col.get('required', False) and col['name'] not in self.__colids:
-                self.add_column(col['name'], col['description'],
-                                index=col.get('index', False),
-                                table=col.get('table', False))
+            if col['name'] not in self.__colids:
+                if col.get('required', False):
+                    self.add_column(col['name'], col['description'],
+                                    index=col.get('index', False),
+                                    table=col.get('table', False))
+
+                else:  # create column name attributes (set to None) on the object even if column is not required
+                    setattr(self, col['name'], None)
+                    if col.get('index', False):
+                        setattr(self, col['name'] + '_index', None)
 
     @staticmethod
     def __build_columns(columns, df=None):
@@ -402,6 +411,7 @@ class DynamicTable(Container):
         col = cls(**ckwargs)
         col.parent = self
         columns = [col]
+        setattr(self, name, col)
 
         # Add index if it's been specified
         if index is not False:
@@ -421,6 +431,7 @@ class DynamicTable(Container):
             # else, the ObjectMapper will create a link from self (parent) to col_index (child with existing parent)
             col = col_index
             self.__indices[col_index.name] = col_index
+            setattr(self, col_index.name, col_index)
 
         if len(col) != len(self.id):
             raise ValueError("column must have the same number of rows as 'id'")

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -217,6 +217,7 @@ class TestNestedContainersSubgroup(TestNestedBase):
         class BucketMapper(ObjectMapper):
             def __init__(self, spec):
                 super(BucketMapper, self).__init__(spec)
+                self.unmap(spec.get_group('foo_holder'))
                 self.map_spec('foos', spec.get_group('foo_holder').get_data_type('Foo'))
 
         return BucketMapper
@@ -253,6 +254,8 @@ class TestNestedContainersSubgroupSubgroup(TestNestedBase):
         class BucketMapper(ObjectMapper):
             def __init__(self, spec):
                 super(BucketMapper, self).__init__(spec)
+                self.unmap(spec.get_group('foo_holder_holder'))
+                self.unmap(spec.get_group('foo_holder_holder').get_group('foo_holder'))
                 self.map_spec('foos', spec.get_group('foo_holder_holder').get_group('foo_holder').get_data_type('Foo'))
 
         return BucketMapper

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -150,6 +150,13 @@ class TestTypeMap(unittest.TestCase):
         self.assertIsInstance(mapper, MyMap)
 
 
+class BarMapper(ObjectMapper):
+    def __init__(self, spec):
+        super(BarMapper, self).__init__(spec)
+        data_spec = spec.get_dataset('data')
+        self.map_spec('attr2', data_spec.get_attribute('attr2'))
+
+
 class TestMapStrings(unittest.TestCase):
 
     def customSetUp(self, bar_spec):
@@ -170,7 +177,7 @@ class TestMapStrings(unittest.TestCase):
                                                        'attr2', 'an example integer attribute', 'int')])],
                              attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
         type_map = self.customSetUp(bar_spec)
-        type_map.register_map(Bar, ObjectMapper)
+        type_map.register_map(Bar, BarMapper)
         bar_inst = Bar('my_bar', ['a', 'b', 'c', 'd'], 'value1', 10)
         builder = type_map.build(bar_inst)
         self.assertEqual(builder.get('data').data, ['a', 'b', 'c', 'd'])
@@ -183,7 +190,7 @@ class TestMapStrings(unittest.TestCase):
                                                        'attr2', 'an example integer attribute', 'int')])],
                              attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
         type_map = self.customSetUp(bar_spec)
-        type_map.register_map(Bar, ObjectMapper)
+        type_map.register_map(Bar, BarMapper)
         bar_inst = Bar('my_bar', ['a', 'b', 'c', 'd'], 'value1', 10)
         builder = type_map.build(bar_inst)
         self.assertEqual(builder.get('data').data, "['a', 'b', 'c', 'd']")
@@ -196,7 +203,7 @@ class TestMapStrings(unittest.TestCase):
                                                        'attr2', 'an example integer attribute', 'int')])],
                              attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
         type_map = self.customSetUp(bar_spec)
-        type_map.register_map(Bar, ObjectMapper)
+        type_map.register_map(Bar, BarMapper)
         bar_inst = Bar('my_bar', H5DataIO(['a', 'b', 'c', 'd'], chunks=True), 'value1', 10)
         builder = type_map.build(bar_inst)
         self.assertIsInstance(builder.get('data').data, H5DataIO)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -654,7 +654,9 @@ def _get_manager():
     class BucketMapper(ObjectMapper):
         def __init__(self, spec):
             super(BucketMapper, self).__init__(spec)
-            foo_spec = spec.get_group('foo_holder').get_data_type('Foo')
+            foo_holder_spec = spec.get_group('foo_holder')
+            self.unmap(foo_holder_spec)
+            foo_spec = foo_holder_spec.get_data_type('Foo')
             self.map_spec('foos', foo_spec)
 
     file_spec = GroupSpec("A file of Foos contained in FooBuckets",


### PR DESCRIPTION
Currently, if a custom class is written for a spec, and the class does not have a field that corresponds to a group or dataset or attribute in the spec, no error or warning is thrown; the class writer would not be aware of their missing mapping. Since this missing field is almost certainly a bug, check for the missing field and throw an exception. 

This has caught the missing Container fields for `NWBFile/general/intracellular_ephys/filtering` and `TimeSeries/sync`.