### PR TITLE
[CI] Ignore running pynwb test when merging to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,4 +347,6 @@ workflows:
             branches:
               ignore: /.*/
       - pynwb-dev-python37:
-          <<: *no_filters
+          filters:
+            branches:
+              ignore: dev


### PR DESCRIPTION
When PRs are merged to dev, all CI runs again, including the "pynwb-dev-python37" job. This pynwb test job only needs to run on PRs and not on merge. This PR tries to restrict that job running to only PRs but it can only be tested by merging this PR.