### PR TITLE
Fix wrong dict being used for get_carg_spec

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -667,7 +667,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
     def get_carg_spec(self, **kwargs):
         """ Return the Spec for a given constructor argument """
         carg_name = getargs('carg_name', kwargs)
-        return self.__attr2spec.get(carg_name)
+        return self.__carg2spec.get(carg_name)
 
     @docval({"name": "const_arg", "type": str, "doc": "the name of the constructor argument to map"},
             {"name": "spec", "type": Spec, "doc": "the spec to map the attribute to"})


### PR DESCRIPTION
Although `ObjectMapper.get_carg_spec` does not appear to be used anywhere in HDMF or PyNWB, it is clear from the code and documentation that the wrong dict is referenced in the function. This should be fixed in case the function gets used.