### PR TITLE
rmv datetime64 from supported dtype strings

### DIFF
--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -37,7 +37,7 @@ class DtypeHelper():
             'object': ['object'],
             'region': ['region'],
             'numeric': ['numeric'],
-            'isodatetime': ["isodatetime", "datetime", "datetime64"]
+            'isodatetime': ["isodatetime", "datetime"]
         }
 
     # List of recommended primary dtype strings. These are the keys of primary_dtype_string_synonyms


### PR DESCRIPTION
## Motivation

"datetime64" is currently defined as a synonym for "isodatetime" in `hdmf.spec`, but is not a supported type in the schema-language document. We could add it to the schema language, as I am currently proposing for "bytes", "short", "uint64", and "datetime" [here](https://github.com/NeurodataWithoutBorders/nwb-schema/pull/382), but in this case I would rather remove it. `datetime64` is a numpy datatype for representing datetimes. To me it does not make sense to have this be synonymous with the standardized ISO date-time string. As far as I can tell we are not using this type, so it would require no other changes.