### PR TITLE
Cache builders by h5py object id not name

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -66,10 +66,10 @@ class HDF5IO(HDMFIO):
         self.__path = path
         self.__file = file_obj
         super().__init__(manager, source=path)
-        self.__built = dict()       # keep track of which files have been read
-        self.__read = dict()        # keep track of each builder for each dataset/group/link
+        self.__built = dict()       # keep track of each builder for each dataset/group/link for each file
+        self.__read = dict()        # keep track of which files have been read. Key is the filename value is the builder
         self.__ref_queue = deque()  # a queue of the references that need to be added
-        self.__dci_queue = deque()       # a queue of DataChunkIterators that need to be exhausted
+        self.__dci_queue = deque()  # a queue of DataChunkIterators that need to be exhausted
         ObjectMapper.no_convert(Dataset)
 
     @property

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -313,9 +313,29 @@ class HDF5IO(HDMFIO):
         return f_builder
 
     def __set_built(self, fpath, id, builder):
+        """
+        Update self.__built to cache the given builder for the given file and id.
+
+        :param fpath: Path to the HDF5 file containing the object
+        :type fpath: str
+        :param id: ID of the HDF5 object in the path
+        :type id: h5py GroupID object
+        :param builder: The builder to be cached
+        """
         self.__built.setdefault(fpath, dict()).setdefault(id, builder)
 
     def __get_built(self, fpath, id):
+        """
+        Look up a builder for the given file and id in self.__built cache
+
+        :param fpath: Path to the HDF5 file containing the object
+        :type fpath: str
+        :param id: ID of the HDF5 object in the path
+        :type id: h5py GroupID object
+
+        :return: Builder in the self.__built cache or None
+        """
+
         fdict = self.__built.get(fpath)
         if fdict:
             return fdict.get(id)
@@ -325,6 +345,11 @@ class HDF5IO(HDMFIO):
     @docval({'name': 'h5obj', 'type': (Dataset, Group),
              'doc': 'the HDF5 object to the corresponding Builder object for'})
     def get_builder(self, **kwargs):
+        """
+        Get the builder for the corresponding h5py Group or Dataset
+
+        :raises ValueError: When no builder has been constructed yet for the given h5py object
+        """
         h5obj = getargs('h5obj', kwargs)
         fpath = h5obj.file.filename
         builder = self.__get_built(fpath, h5obj.id)
@@ -336,6 +361,11 @@ class HDF5IO(HDMFIO):
     @docval({'name': 'h5obj', 'type': (Dataset, Group),
              'doc': 'the HDF5 object to the corresponding Container/Data object for'})
     def get_container(self, **kwargs):
+        """
+        Get the container for the corresponding h5py Group or Dataset
+
+        :raises ValueError: When no builder has been constructed yet for the given h5py object
+        """
         h5obj = getargs('h5obj', kwargs)
         builder = self.get_builder(h5obj)
         container = self.manager.construct(builder)


### PR DESCRIPTION
## Motivation

When reading tables with references we see performance issues due to the resolution of references to builders.  After some profiling as part of https://github.com/oruebel/ndx-icephys-meta/issues/17 it appears that looking up the ``name`` of h5py objects takes a lot of time. Specifically, the ``name`` is used in the [HDF5IO.__set_built](https://github.com/hdmf-dev/hdmf/blob/aeaf1502dfcde889d0e0a999d519362f6eb55147/src/hdmf/backends/hdf5/h5tools.py#L315) and [HDF5IO.__get_built](https://github.com/hdmf-dev/hdmf/blob/aeaf1502dfcde889d0e0a999d519362f6eb55147/src/hdmf/backends/hdf5/h5tools.py#L318) functions as a key to cache the builders for specific HDF5 objects. In contrast, looking up the ``id`` of h5py objects appears to be significantly faster than looking up the ``name``.  To cache the objects we really just need a unique identifier for the objects sousing the ``id`` instead of the ``name`` should be fine.

## Impact

Since the actual caching of builders happens on read, I would expect that this PR should also improve the performance of the first read of files, not just the resolution of references later on, but I need to do more profiling to confirm this. 

## Results 

Using the ``id`` instead of the ``name`` of HDF5 objects in this PR,  loading the intracellular recordings table via ``nwbfile.intracellular_recordings[:]`` takes ~1s compared to ~80s with the current dev branch of HDMF. As we can see from the profiling results below, using the current dev branch, the majority of the time (i.e., 77.89s of 79.4s) is spent on looking up names, whereas with the changes in this PR that time is effectively eliminated.

**Profile with https://github.com/hdmf-dev/hdmf/pull/235**
```
1667108 function calls (1515204 primitive calls) in 0.973 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
134880/13488    0.123    0.000    0.268    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/copy.py:132(deepcopy)
    13488    0.093    0.000    0.237    0.000 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/utils.py:120(__parse_args)
     3372    0.072    0.000    0.086    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/group.py:253(__getitem__)
   320350    0.066    0.000    0.066    0.000 {method 'get' of 'dict' objects}
     6744    0.057    0.000    0.080    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/files.py:307(__init__)
     2248    0.037    0.000    0.644    0.000 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/backends/hdf5/h5_utils.py:155(__get_ref)
....
```

**Profile with HDMF dev**

```
 1677009 function calls (1525241 primitive calls) in 79.471 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3372   77.897    0.023   77.916    0.023 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/base.py:223(name)
134880/13488    0.157    0.000    0.373    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/copy.py:132(deepcopy)
    13488    0.147    0.000    0.381    0.000 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/utils.py:120(__parse_args)
     3372    0.127    0.000    0.145    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/group.py:253(__getitem__)
     6744    0.106    0.000    0.141    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/files.py:307(__init__)
13488/3372    0.072    0.000   79.010    0.023 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/utils.py:436(func_call)
     2248    0.069    0.000   54.663    0.024 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/backends/hdf5/h5_utils.py:155(__get_ref)
     6744    0.048    0.000    0.218    0.000 /Users/oruebel/anaconda3/envs/py4nwb/lib/python3.7/site-packages/h5py/_hl/base.py:216(file)
33720/13488    0.047    0.000    0.094    0.000 /Users/oruebel/Devel/nwb/hdmf/src/hdmf/utils.py:25(__type_okay)
....
```










## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
