### PR TITLE
Refactor use of deepcopy by docval

### DIFF
--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1,6 +1,6 @@
 import numpy as np
 from collections import OrderedDict
-from copy import copy, deepcopy
+from copy import copy
 from datetime import datetime
 
 from ..utils import docval, getargs, ExtenderMeta, get_docval, call_docval_func, fmt_docval_args
@@ -449,7 +449,7 @@ class TypeMap:
         fields = list()
 
         # copy docval args from superclass
-        for arg in deepcopy(get_docval(base.__init__)):
+        for arg in get_docval(base.__init__):
             existing_args.add(arg['name'])
             if arg['name'] in addl_fields:
                 continue

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from copy import deepcopy, copy
+from copy import copy
 import ruamel.yaml as yaml
 import os.path
 import string
@@ -36,7 +36,7 @@ class SpecNamespace(dict):
 
     __types_key = 'data_types'
 
-    @docval(*deepcopy(_namespace_args))
+    @docval(*_namespace_args)
     def __init__(self, **kwargs):
         doc, full_name, name, version, date, author, contact, schema, catalog = \
             popargs('doc', 'full_name', 'name', 'version', 'date', 'author', 'contact', 'schema', 'catalog', kwargs)

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -297,7 +297,7 @@ class BaseStorageSpec(Spec):
     __type_key = 'data_type'
     __id_key = 'object_id'
 
-    @docval(*deepcopy(_attrbl_args))
+    @docval(*_attrbl_args)
     def __init__(self, **kwargs):
         name, doc, parent, quantity, attributes, linkable, data_type_def, data_type_inc =\
              getargs('name', 'doc', 'parent', 'quantity', 'attributes',
@@ -477,7 +477,7 @@ class BaseStorageSpec(Spec):
         ''' The number of times the object being specified should be present '''
         return self.get('quantity', DEF_QUANTITY)
 
-    @docval(*deepcopy(_attr_args))
+    @docval(*_attr_args)
     def add_attribute(self, **kwargs):
         ''' Add an attribute to this specification '''
         pargs, pkwargs = fmt_docval_args(AttributeSpec.__init__, kwargs)
@@ -618,7 +618,7 @@ class DatasetSpec(BaseStorageSpec):
     To specify a table-like dataset i.e. a compound data type.
     '''
 
-    @docval(*deepcopy(_dataset_args))
+    @docval(*_dataset_args)
     def __init__(self, **kwargs):
         doc, shape, dims, dtype, default_value = popargs('doc', 'shape', 'dims', 'dtype', 'default_value', kwargs)
         if shape is not None:
@@ -811,7 +811,7 @@ class GroupSpec(BaseStorageSpec):
     ''' Specification for groups
     '''
 
-    @docval(*deepcopy(_group_args))
+    @docval(*_group_args)
     def __init__(self, **kwargs):
         doc, groups, datasets, links = popargs('doc', 'groups', 'datasets', 'links', kwargs)
         self.__data_types = dict()
@@ -1095,7 +1095,7 @@ class GroupSpec(BaseStorageSpec):
         ''' The links specificed in this GroupSpec '''
         return tuple(self.get('links', tuple()))
 
-    @docval(*deepcopy(_group_args))
+    @docval(*_group_args)
     def add_group(self, **kwargs):
         ''' Add a new specification for a subgroup to this group specification '''
         doc = kwargs.pop('doc')
@@ -1127,7 +1127,7 @@ class GroupSpec(BaseStorageSpec):
         name = getargs('name', kwargs)
         return self.__groups.get(name, self.__links.get(name))
 
-    @docval(*deepcopy(_dataset_args))
+    @docval(*_dataset_args)
     def add_dataset(self, **kwargs):
         ''' Add a new specification for a dataset to this group specification '''
         doc = kwargs.pop('doc')

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -225,7 +225,7 @@ def __parse_args(validator, args, kwargs, enforce_type=True, enforce_shape=True,
                 ret[argname] = args[argsi]
                 argsi += 1
             else:
-                ret[argname] = arg['default']
+                ret[argname] = _copy.copy(arg['default'])
             argval = ret[argname]
             if enforce_type:
                 if not __type_okay(argval, arg['type'], arg['default'] is None):
@@ -411,7 +411,6 @@ def docval(*validator, **options):
     rtype = options.pop('rtype', None)
     is_method = options.pop('is_method', True)
     allow_extra = options.pop('allow_extra', False)
-    val_copy = __sort_args(_copy.deepcopy(validator))
 
     def dec(func):
         _docval = _copy.copy(options)
@@ -420,7 +419,7 @@ def docval(*validator, **options):
         func.__doc__ = _docval.get('doc', func.__doc__)
         pos = list()
         kw = list()
-        for a in val_copy:
+        for a in validator:
             try:
                 a['type'] = __resolve_type(a['type'])
             except Exception as e:
@@ -436,7 +435,7 @@ def docval(*validator, **options):
             def func_call(*args, **kwargs):
                 self = args[0]
                 parsed = __parse_args(
-                            _copy.deepcopy(loc_val),
+                            loc_val,
                             args[1:],
                             kwargs,
                             enforce_type=enforce_type,
@@ -453,7 +452,7 @@ def docval(*validator, **options):
                 return func(self, **parsed['args'])
         else:
             def func_call(*args, **kwargs):
-                parsed = __parse_args(_copy.deepcopy(loc_val),
+                parsed = __parse_args(loc_val,
                                       args,
                                       kwargs,
                                       enforce_type=enforce_type,

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -225,7 +225,7 @@ def __parse_args(validator, args, kwargs, enforce_type=True, enforce_shape=True,
                 ret[argname] = args[argsi]
                 argsi += 1
             else:
-                ret[argname] = _copy.copy(arg['default'])
+                ret[argname] = _copy.deepcopy(arg['default'])
             argval = ret[argname]
             if enforce_type:
                 if not __type_okay(argval, arg['type'], arg['default'] is None):

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -265,17 +265,6 @@ def __parse_args(validator, args, kwargs, enforce_type=True, enforce_shape=True,
     return {'args': ret, 'type_errors': type_errors, 'value_errors': value_errors}
 
 
-def __sort_args(validator):
-    pos = list()
-    kw = list()
-    for arg in validator:
-        if "default" in arg:
-            kw.append(arg)
-        else:
-            pos.append(arg)
-    return list(_itertools.chain(pos, kw))
-
-
 docval_idx_name = '__dv_idx__'
 docval_attr_name = '__docval__'
 __docval_args_loc = 'args'

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -1,5 +1,4 @@
 import copy as _copy
-import itertools as _itertools
 from abc import ABCMeta
 import collections
 import h5py


### PR DESCRIPTION
Fix #237 

This PR improves runtime of hdmf tests by about 20% and runtime of pynwb tests by about 25%. 

The docval list of dictionaries does not need to be deepcopied on every call to a function with docval. The list of dictionaries consists of just strings, types, tuples of strings and types, and critically here, default values. If the default values are not properly copied when used to set the values of missing arguments, missing arguments will all share the same list/dict default value, which is bad.

Rather than deepcopy the whole list of dictionaries, just deepcopy the default value when it is used to set the value of a missing argument. 

This PR also removes a few other unnecessary/redundant calls to `deepcopy` regarding docval. 