### PR TITLE
Streamline CI and add testing of min requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,8 @@ workflows:
           <<: *no_filters
       - gallery38:
           <<: *no_filters
+      - gallery35-min-req:
+          <<: *no_filters
       - deploy-dev:
           requires:
             - flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ references:
           # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.
           no_output_timeout: 30m
       - run:
-          name: Run coverage and submit to codecov-io
+          name: Run coverage and submit to codecov-io if COVERAGE_TOX_ENV != ""
           command: |
             . ../venv/bin/activate
             if [[ "${COVERAGE_TOX_ENV}" != "" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ references:
           name: Run coverage and submit to codecov-io
           command: |
             . ../venv/bin/activate
-            tox -e $COVERAGE_TOX_ENV
+            if [[ "${COVERAGE_TOX_ENV}" != "" ]]; then
+              tox -e $COVERAGE_TOX_ENV
+            fi
       - run:
           name: Build wheel and source distribution
           command: |
@@ -75,7 +77,7 @@ references:
             conda config --set always_yes yes --set changeps1 no
             conda config --add channels conda-forge
             conda install python=$CONDA_PYTHON_VER
-            conda install virtualenv==16.0.0
+            conda install virtualenv
             conda install tox
       - run:
           name: Run the tests
@@ -95,9 +97,6 @@ references:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - restore_cache:
-          keys:
-            - ophys-data-cache
       - run:
           <<: *initialize-venv
       - run:
@@ -107,9 +106,6 @@ references:
             pip install tox
             tox -e $TEST_TOX_ENV
           no_output_timeout: 30m
-      - save_cache:
-          key: ophys-data-cache
-          paths: ophys_experiment_data
 
   no_filters: &no_filters
     filters:
@@ -135,7 +131,7 @@ jobs:
       - image: circleci/python:3.5.9-stretch
     environment:
      - TEST_TOX_ENV: "py35"
-     - COVERAGE_TOX_ENV: "coverage-py35"
+     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py35"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
     <<: *ci-steps
@@ -145,7 +141,7 @@ jobs:
       - image: circleci/python:3.6.10-stretch
     environment:
      - TEST_TOX_ENV: "py36"
-     - COVERAGE_TOX_ENV: "coverage-py36"
+     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py36"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
     <<: *ci-steps
@@ -155,7 +151,7 @@ jobs:
       - image: circleci/python:3.7.6-stretch
     environment:
      - TEST_TOX_ENV: "py37"
-     - COVERAGE_TOX_ENV: "coverage-py37"
+     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py37"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
     <<: *ci-steps
@@ -164,11 +160,21 @@ jobs:
     docker:
       - image: circleci/python:3.8.1-buster
     environment:
-     - TEST_TOX_ENV: "py37"
-     - COVERAGE_TOX_ENV: "coverage-py37"
-     - BUILD_TOX_ENV: "build-py37"
-     - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
+     - TEST_TOX_ENV: "py38"
+     - COVERAGE_TOX_ENV: "coverage"
+     - BUILD_TOX_ENV: "build-py38"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py38"
      - UPLOAD_WHEELS: "true"
+    <<: *ci-steps
+
+  python35-min-req:
+    docker:
+      - image: circleci/python:3.5.9-stretch
+    environment:
+     - TEST_TOX_ENV: "py35-min-req"
+     - COVERAGE_TOX_ENV: ""
+     - BUILD_TOX_ENV: "build-py35-min-req"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py35-min-req"
     <<: *ci-steps
 
   miniconda35:
@@ -237,6 +243,13 @@ jobs:
       - image: circleci/python:3.8.1-buster
     environment:
      - TEST_TOX_ENV: "gallery-py38"
+    <<: *gallery-steps
+
+  gallery35-min-req:
+    docker:
+      - image: circleci/python:3.5.9-stretch
+    environment:
+     - TEST_TOX_ENV: "gallery-py35-min-req"
     <<: *gallery-steps
 
   deploy-dev:
@@ -334,6 +347,8 @@ workflows:
           <<: *no_filters
       - python38:
           <<: *no_filters
+      - python35-min-req:
+          <<: *no_filters
       - miniconda35:
           <<: *no_filters
       - miniconda36:
@@ -357,6 +372,7 @@ workflows:
             - python36
             - python37
             - python38
+            - python35-min-req
             - miniconda35
             - miniconda36
             - miniconda37
@@ -365,6 +381,7 @@ workflows:
             - gallery36
             - gallery37
             - gallery38
+            - gallery35-min-req
           filters:
             tags:
               ignore:
@@ -380,6 +397,7 @@ workflows:
             - python36
             - python37
             - python38
+            - python35-min-req
             - miniconda35
             - miniconda36
             - miniconda37
@@ -388,6 +406,7 @@ workflows:
             - gallery36
             - gallery37
             - gallery38
+            - gallery35-min-req
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: 'coverage-py37'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall-py37'
 
@@ -28,7 +28,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: 'coverage-py36'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
@@ -36,7 +36,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.5'
         testToxEnv: 'py35'
-        coverageToxEnv: 'coverage-py35'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
@@ -52,7 +52,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: 'coverage-py37'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall-py37'
 
@@ -60,7 +60,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: 'coverage-py36'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
@@ -68,7 +68,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.5'
         testToxEnv: 'py35'
-        coverageToxEnv: 'coverage-py35'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
@@ -96,7 +96,9 @@ jobs:
     displayName: 'Run tox tests'
 
   - bash: |
-      tox -e $(coverageToxEnv)
+      if [[ "$(coverageToxEnv)" != "" ]]; then
+        tox -e $(coverageToxEnv)
+      fi
     displayName: 'Run coverage tests'
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
       if [[ "$(coverageToxEnv)" != "" ]]; then
         tox -e $(coverageToxEnv)
       fi
-    displayName: 'Run coverage tests'
+    displayName: 'Run coverage tests if coverageToxEnv != ""'
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.8'
         testToxEnv: 'py38'
-        coverageToxEnv: 'coverage-py38'
+        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall-py38'
 
@@ -44,7 +44,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
         testToxEnv: 'py38'
-        coverageToxEnv: 'coverage-py38'
+        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall-py38'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ coverage==5.0.2
 flake8==3.7.9
 python-dateutil==2.8.1
 tox==3.14.3
--r requirements.txt

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx_rtd_theme
 sphinx-gallery
--r requirements.txt

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,4 @@
 # these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
-chardet==3.0.2
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,6 +2,6 @@
 chardet==3.0.2
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
-scipy==1.2
-pandas==0.24
+scipy==1.1
+pandas==0.23
 ruamel.yaml==0.15

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,7 @@
+# these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
+chardet==3.0.2
+h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
+numpy==1.16
+scipy==1.2
+pandas==0.24
+ruamel.yaml==0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-chardet==3.0.4
 h5py==2.10.0
 numpy==1.18.1
 scipy==1.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [versioneer]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
-import re
 
 import versioneer
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,13 @@ print('found these packages:', pkgs)
 
 schema_dir = 'common/hdmf-common-schema/common'
 
+with open('requirements-min.txt', 'r') as fp:
+    # replace == with >= and remove trailing comments and spaces
+    reqs = [x.replace('==', '>=').split('#')[0].strip() for x in fp]
+    reqs = [x for x in reqs if x]  # remove empty strings
+
+print(reqs)
+
 setup_args = {
     'name': 'hdmf',
     'version': versioneer.get_version(),
@@ -23,14 +30,7 @@ setup_args = {
     'author_email': 'ajtritt@lbl.gov',
     'url': 'https://github.com/hdmf-dev/hdmf',
     'license': "BSD",
-    'install_requires': [
-        'chardet>=3.0',
-        'h5py>=2.9',
-        'numpy>=1.16',
-        'scipy>=1.2',
-        'pandas>=0.24',
-        'ruamel.yaml>=0.15'
-    ],
+    'install_requires': reqs,
     'packages': pkgs,
     'package_dir': {'': 'src'},
     'package_data': {'hdmf': ["%s/*.yaml" % schema_dir, "%s/*.json" % schema_dir]},

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,6 @@ print('found these packages:', pkgs)
 
 schema_dir = 'common/hdmf-common-schema/common'
 
-reqs_re = re.compile("[<=>]+")
-with open('requirements.txt', 'r') as fp:
-    reqs = [reqs_re.split(x.strip())[0] for x in fp.readlines()]
-
-print(reqs)
-
 setup_args = {
     'name': 'hdmf',
     'version': versioneer.get_version(),
@@ -30,7 +24,14 @@ setup_args = {
     'author_email': 'ajtritt@lbl.gov',
     'url': 'https://github.com/hdmf-dev/hdmf',
     'license': "BSD",
-    'install_requires': reqs,
+    'install_requires': [
+        'chardet>=3.0',
+        'h5py>=2.9',
+        'numpy>=1.16',
+        'scipy>=1.2',
+        'pandas>=0.24',
+        'ruamel.yaml>=0.15'
+    ],
     'packages': pkgs,
     'package_dir': {'': 'src'},
     'package_data': {'hdmf': ["%s/*.yaml" % schema_dir, "%s/*.json" % schema_dir]},

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,14 @@ commands =
     python -m coverage run test.py -u
     coverage html -d tests/coverage/htmlcov
 
+# Test with python 3.5, pinned dev reqs, and minimum run requirements
+[testenv:py35-min-req]
+basepython = python3.5
+deps =
+    -rrequirements-dev.txt
+    -rrequirements-min.txt
+commands = {[testenv]commands}
+
 # Envs that builds wheels and source distribution
 [testenv:build]
 commands =
@@ -49,32 +57,21 @@ commands = {[testenv:build]commands}
 basepython = python3.8
 commands = {[testenv:build]commands}
 
+[testenv:build-py35-min-req]
+basepython = python3.5
+deps =
+    -rrequirements-dev.txt
+    -rrequirements-min.txt
+commands = {[testenv:build]commands}
+
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
-commands =
+passenv = CODECOV_TOKEN
+basepython = python3.8
+commands = 
     python -m coverage run test.py -u
     coverage report -m
     codecov -X fix
-
-[testenv:coverage-py35]
-passenv = CODECOV_TOKEN
-basepython = python3.5
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage-py36]
-passenv = CODECOV_TOKEN
-basepython = python3.6
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage-py37]
-passenv = CODECOV_TOKEN
-basepython = python3.7
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage-py38]
-passenv = CODECOV_TOKEN
-basepython = python3.8
-commands = {[testenv:coverage]commands}
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]
@@ -90,6 +87,10 @@ deps = null
 commands = python -c "import hdmf"
 
 [testenv:wheelinstall-py38]
+deps = null
+commands = python -c "import hdmf"
+
+[testenv:wheelinstall-py35-min-req]
 deps = null
 commands = python -c "import hdmf"
 
@@ -124,4 +125,12 @@ commands = {[testenv:gallery]commands}
 [testenv:gallery-py38]
 basepython = python3.8
 deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+[testenv:gallery-py35-min-req]
+basepython = python3.5
+deps =
+    -rrequirements-dev.txt
+    -rrequirements-min.txt
+    -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}


### PR DESCRIPTION
h5py needs to be at minimum version 2.9. In case there are other dependency versions that are required for HDMF to work, this PR adds minimum versions for all requirements in setup.py. All tests succeed with the minimum requirements.

This PR also:
- adds unit testing and Sphinx gallery testing on Python 3.5 with the minimum requirements
- fixes Python 3.8 testing on CircleCI (was running Python 3.7)
- removes coverage testing for Python 3.5-3.7 on Windows, Mac, and Linux. Coverage testing and submission to codecov remains for Python 3.8. Coverage testing is not necessary for all versions of Python (especially now that Python 2 support is deprecated), and it slows down CI because it involves installing another environment.
- removes legacy CI crud
- removes "-r requirements.txt" from "requirements-dev.txt" and "requirements-doc.txt". Now, in order to install the dev environment, one must use `pip install -r requirements-dev.txt -r requirements.txt`. Both the installation documentation and tox specification already specify this. 