### PR TITLE
Fix and clean up documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,13 +10,10 @@
 # Auto-generated apidocs RST files
 /docs/source/modules.rst
 /docs/source/gen_modules/
-/docs/source/modules/generated
 
 # Auto-generated files after running tutorials
-*_example.nwb
 mylab.*.yaml
 *.npy
-*.nwb
 manifest.json
 
 # Auto-generated tutorials

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 ### HDMF ###
 
 # Auto-generated apidocs RST files
-/docs/source/modules.rst
 /docs/source/gen_modules/
 
 # Auto-generated files after running tutorials

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "  apidoc     to build RST from source code"
 
 clean:
-	-rm -rf $(BUILDDIR)/* $(RSTDIR)/$(PKGNAME)*.rst $(RSTDIR)/modules.rst
+	-rm -rf $(BUILDDIR)/* $(RSTDIR)/$(PKGNAME)*.rst
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ PKGNAME        = hdmf
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(RSTDIR)
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
@@ -41,7 +41,8 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-	@echo "  apidoc     to to build RST from source code"
+	@echo "  clean      to clean all documents built by Sphinx in _build"
+	@echo "  apidoc     to build RST from source code"
 
 clean:
 	-rm -rf $(BUILDDIR)/* $(RSTDIR)/$(PKGNAME)*.rst $(RSTDIR)/modules.rst
@@ -158,6 +159,5 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 apidoc:
-	$(SPHINXAPIDOC) -f -e -o $(RSTDIR)  $(SRCDIR)
+	$(SPHINXAPIDOC) -f -e -o $(RSTDIR) $(SRCDIR)
 	@echo "Build rst docs from source code."
-

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -50,7 +50,6 @@ if "%1" == "clean" (
 	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
 	del /q /s %BUILDDIR%\*
 	del /q %RSTDIR%\%PKGNAME%*.rst
-	del /q %RSTDIR%\modules.rst
 	goto end
 )
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,8 +5,14 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
+if "%SPHINXAPIDOC%" == "" (
+	set SPHINXAPIDOC=sphinx-apidoc
+)
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set RSTDIR=source
+set SRCDIR=../src
+set PKGNAME=hdmf
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% %RSTDIR%
 set I18NSPHINXOPTS=%SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
@@ -35,12 +41,16 @@ if "%1" == "help" (
 	echo.  changes    to make an overview over all changed/added/deprecated items
 	echo.  linkcheck  to check all external links for integrity
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
+	echo.  clean      to clean all documents built by Sphinx in _build
+	echo.  apidoc     to build RST from source code"
 	goto end
 )
 
 if "%1" == "clean" (
 	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
 	del /q /s %BUILDDIR%\*
+	del /q %RSTDIR%\%PKGNAME%*.rst
+	del /q %RSTDIR%\modules.rst
 	goto end
 )
 
@@ -184,6 +194,14 @@ if "%1" == "doctest" (
 	echo.
 	echo.Testing of doctests in the sources finished, look at the ^
 results in %BUILDDIR%/doctest/output.txt.
+	goto end
+)
+
+if "%1" == "apidoc" (
+	%SPHINXAPIDOC% -f -e -o %RSTDIR% %SRCDIR%
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build rst docs from source code.
 	goto end
 )
 

--- a/docs/source/api_docs.rst
+++ b/docs/source/api_docs.rst
@@ -8,12 +8,15 @@ API Documentation
    :maxdepth: 2
    :caption: HDMF Modules
 
+   Common data types <hdmf.common>
+   Base container classes <hdmf.container>
    Build layer <hdmf.build>
    Specification layer <hdmf.spec>
    I/O layer <hdmf.backends>
    Data I/O utilities <hdmf.data_utils>
    Development utilities <hdmf.utils>
-
+   Validation utilities <hdmf.validate>
+   Testing utilities <hdmf.testing>
 
 
 :ref:`modindex`

--- a/docs/source/api_docs.rst
+++ b/docs/source/api_docs.rst
@@ -17,6 +17,7 @@ API Documentation
    Development utilities <hdmf.utils>
    Validation utilities <hdmf.validate>
    Testing utilities <hdmf.testing>
+   Full list of HDMF package contents <hdmf>
 
 
 :ref:`modindex`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 import sys
 import os
 import sphinx_rtd_theme
-from sphinx.domains.python import PythonDomain
 
 
 # -- Support building doc without install --------------------------------------
@@ -70,7 +69,7 @@ sphinx_gallery_conf = {
 }
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3.8', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('http://matplotlib.org', None),
@@ -304,22 +303,13 @@ latex_logo = 'hdmf_logo.pdf'
 #
 
 def run_apidoc(_):
-    from sphinx.apidoc import main
+    from sphinx.ext.apidoc import main as apidoc_main
     import os
     import sys
     out_dir = os.path.dirname(__file__)
     src_dir = os.path.join(out_dir, '../../src')
     sys.path.append(src_dir)
-    main(['-f', '-e', '-o', out_dir, src_dir])
-
-
-# https://github.com/sphinx-doc/sphinx/issues/3866
-class PatchedPythonDomain(PythonDomain):
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
-        if 'refspecific' in node:
-            del node['refspecific']
-        return super(PatchedPythonDomain, self).resolve_xref(
-            env, fromdocname, builder, typ, target, node, contnode)
+    apidoc_main(['-f', '-e', '-o', out_dir, src_dir])
 
 
 from abc import abstractmethod, abstractproperty
@@ -335,5 +325,4 @@ def skip(app, what, name, obj, skip, options):
 def setup(app):
     app.connect('builder-inited', run_apidoc)
     app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
-    app.override_domain(PatchedPythonDomain)
     app.connect("autodoc-skip-member", skip)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,7 +174,7 @@ html_favicon = 'hdmf_logo-180x180.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -309,7 +309,7 @@ def run_apidoc(_):
     out_dir = os.path.dirname(__file__)
     src_dir = os.path.join(out_dir, '../../src')
     sys.path.append(src_dir)
-    apidoc_main(['-f', '-e', '-o', out_dir, src_dir])
+    apidoc_main(['-f', '-e', '--no-toc', '-o', out_dir, src_dir])
 
 
 from abc import abstractmethod, abstractproperty

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -5,11 +5,6 @@ Extending standards
 
 The following page will discuss how to extend a standard using HDMF.
 
-.. note::
-
-    A simple example demonstrating the creation and use of a custom extension is available as part of the
-    tutorial :ref:`tutorial-extending-standard`.
-
 .. _creating-extensions:
 
 Creating new Extensions

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Dependencies
 
 HDMF has the following minimum requirements, which must be installed before you can get started using HDMF.
 
-#. Python 3.5, 3.6, or 3.7
+#. Python 3.5, 3.6, 3.7, or 3.8
 #. pip
 
 ------------

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -483,6 +483,7 @@ class H5DataIO(DataIO):
     def filter_available(filter, allow_plugin_filters):
         """
         Check if a given I/O filter is available
+
         :param filter: String with the name of the filter, e.g., gzip, szip etc.
                        int with the registered filter ID, e.g. 307
         :type filter: String, int

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -37,6 +37,7 @@ class AbstractDataChunkIterator(metaclass=ABCMeta):
     @abstractmethod
     def recommended_chunk_shape(self):
         """
+        Recommend the chunk shape for the data array.
 
         :return: NumPy-style shape tuple describing the recommended shape for the chunks of the target
                  array or None. This may or may not be the same as the shape of the chunks returned in the
@@ -342,10 +343,7 @@ class DataChunkIterator(AbstractDataChunkIterator):
 
 class DataChunk:
     """
-    Class used to describe a data chunk. Used in DataChunkIterator to describe
-
-    :ivar data: Numpy ndarray with the data value(s) of the chunk
-    :ivar selection: Numpy index tuple describing the location of the chunk
+    Class used to describe a data chunk. Used in DataChunkIterator.
     """
     @docval({'name': 'data', 'type': np.ndarray,
              'doc': 'Numpy array with the data value(s) of the chunk', 'default': None},

--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -169,16 +169,14 @@ class SpecCatalog:
         """
         For a given data type recursively find all the subtypes that inherit from it.
 
-        E.g., assume we have the following inheritance hierarchy:
+        E.g., assume we have the following inheritance hierarchy::
 
-        -BaseContainer--+-->AContainer--->ADContainer
-                        |
-                        +-->BContainer
+            -BaseContainer--+-->AContainer--->ADContainer
+                            |
+                            +-->BContainer
 
-
-        In this case the the subtypes of BaseContainer would be (AContainer, ADContainer, BContainer),
-        for AContainer the subtypes would be (ADContainer) and for BContainer the list of subtypes
-        would be empty ().
+        In this case, the subtypes of BaseContainer would be (AContainer, ADContainer, BContainer),
+        the subtypes of AContainer would be (ADContainer), and the subtypes of BContainer would be empty ().
         """
         data_type, recursive = getargs('data_type', 'recursive', kwargs)
         curr_spec = self.get_spec(data_type)

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -121,10 +121,11 @@ class TestH5RoundTripMixin(metaclass=ABCMeta):
 
     The abstract method setUpContainer needs to be implemented by classes that include this mixin.
 
-    Example:
-    class TestMyContainerRoundTrip(TestH5RoundTripMixin, TestCase):
-        def setUpContainer(self):
-            # return the Container to read/write
+    Example::
+
+        class TestMyContainerRoundTrip(TestH5RoundTripMixin, TestCase):
+            def setUpContainer(self):
+                # return the Container to read/write
 
     NOTE: This class is a mix-in and not a subclass of TestCase so that unittest does not discover it, try to run it,
     and skip it.

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -284,7 +284,7 @@ __docval_args_loc = 'args'
 
 def get_docval(func, *args):
     '''Get a copy of docval arguments for a function.
-    If args are supplied, return only docval arguments with value for 'name' key equal to *args
+    If args are supplied, return only docval arguments with value for 'name' key equal to the args
     '''
     func_docval = getattr(func, docval_attr_name, None)
     if func_docval:


### PR DESCRIPTION
This PR:
- fixes docs makefile for Windows
- updates conf.fy to remove deprecated code
- makes the docs refer to Python 3.8 instead of 3.5
- adds missing packages to the api_docs page
- fixes all Sphinx warnings

The sphinx docs should now build and validate successfully, without warnings.