### PR TITLE
Avoid creating modules.rst when running 'make apidoc'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -159,5 +159,5 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 apidoc:
-	$(SPHINXAPIDOC) -f -e -o $(RSTDIR) $(SRCDIR)
+	$(SPHINXAPIDOC) -f -e --no-toc -o $(RSTDIR) $(SRCDIR)
 	@echo "Build rst docs from source code."

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -197,7 +197,7 @@ results in %BUILDDIR%/doctest/output.txt.
 )
 
 if "%1" == "apidoc" (
-	%SPHINXAPIDOC% -f -e -o %RSTDIR% %SRCDIR%
+	%SPHINXAPIDOC% -f -e --no-toc -o %RSTDIR% %SRCDIR%
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build rst docs from source code.


### PR DESCRIPTION
Sphinx creates the file `modules.rst` when running `'make apidoc'`. This file is not used and is ignored. I had already changed `'make html' -> run_apidoc()` to not create `modules.rst`. This PR changes the `'make apidoc'` command to do the same.