### PR TITLE
Enh/read scalar dset

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -465,10 +465,7 @@ class HDF5IO(HDMFIO):
                 kwargs["data"] = scalar
         elif ndims == 1:
             d = None
-            if h5obj.shape == (1, ):
-                # read scalar (1-element) dataset into memory
-                d = h5obj[0]
-            elif h5obj.dtype.kind == 'O':
+            if h5obj.dtype.kind == 'O':
                 elem1 = h5obj[0]
                 if isinstance(elem1, (str, bytes)):
                     d = h5obj

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -447,11 +447,8 @@ class HDF5IO(HDMFIO):
             name = str(os.path.basename(h5obj.name))
         kwargs['source'] = h5obj.file.filename
         ndims = len(h5obj.shape)
-        if ndims == 0 or h5obj.shape == (1, ):
-            if ndims == 0:  # read scalar dataspace
-                scalar = h5obj[()]
-            else:  # read shape (1, ) dataset as scalar
-                scalar = h5obj[0]
+        if ndims == 0:                                       # read scalar
+            scalar = h5obj[()]
             if isinstance(scalar, bytes):
                 scalar = scalar.decode('UTF-8')
 
@@ -468,7 +465,10 @@ class HDF5IO(HDMFIO):
                 kwargs["data"] = scalar
         elif ndims == 1:
             d = None
-            if h5obj.dtype.kind == 'O':
+            if h5obj.shape == (1, ):
+                # read scalar (1-element) dataset into memory
+                d = h5obj[0]
+            elif h5obj.dtype.kind == 'O':
                 elem1 = h5obj[0]
                 if isinstance(elem1, (str, bytes)):
                     d = h5obj

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -465,7 +465,10 @@ class HDF5IO(HDMFIO):
                 kwargs["data"] = scalar
         elif ndims == 1:
             d = None
-            if h5obj.dtype.kind == 'O':
+            if h5obj.shape == (1, ):
+                # read scalar (1-element) dataset into memory
+                d = h5obj[0]
+            elif h5obj.dtype.kind == 'O':
                 elem1 = h5obj[0]
                 if isinstance(elem1, (str, bytes)):
                     d = h5obj

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -447,8 +447,11 @@ class HDF5IO(HDMFIO):
             name = str(os.path.basename(h5obj.name))
         kwargs['source'] = h5obj.file.filename
         ndims = len(h5obj.shape)
-        if ndims == 0:                                       # read scalar
-            scalar = h5obj[()]
+        if ndims == 0 or h5obj.shape == (1, ):
+            if ndims == 0:  # read scalar dataspace
+                scalar = h5obj[()]
+            else:  # read shape (1, ) dataset as scalar
+                scalar = h5obj[0]
             if isinstance(scalar, bytes):
                 scalar = scalar.decode('UTF-8')
 
@@ -465,10 +468,7 @@ class HDF5IO(HDMFIO):
                 kwargs["data"] = scalar
         elif ndims == 1:
             d = None
-            if h5obj.shape == (1, ):
-                # read scalar (1-element) dataset into memory
-                d = h5obj[0]
-            elif h5obj.dtype.kind == 'O':
+            if h5obj.dtype.kind == 'O':
                 elem1 = h5obj[0]
                 if isinstance(elem1, (str, bytes)):
                     d = h5obj

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -866,6 +866,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
         elif isinstance(spec, DatasetSpec):
             if not isinstance(builder, DatasetBuilder):
                 raise ValueError("__get_subspec_values - must pass DatasetBuilder with DatasetSpec")
+            if spec.shape is None and getattr(builder.data, 'shape', None) == (1, ):
+                # if a scalar dataset is expected and a 1-element dataset is given, then read the dataset
+                builder['data'] = builder.data[0]  # use dictionary reference instead of .data to bypass error
             ret[spec] = self.__check_ref_resolver(builder.data)
         return ret
 


### PR DESCRIPTION
@t-b says that the MIES software cannot write scalar datasets, which are represented by h5py as having shape `()`, so MIES instead writes 1-element datasets, which have shape `(1, )`. HDMF reads datasets as `h5py.Dataset`s, i.e., it does not read the data into memory. Therefore, docval fails where a string/int/float is expected and an `h5py.Dataset` is provided.

This PR makes HDMF read all datasets that have shape `(1, )` into memory as if they were scalars with shape `()`.

See original PR #78. 