### PR TITLE
Add minimum requirements CI testing for Windows and Mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,14 @@ jobs:
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
+      macOS-py3.5-min-req:
+        imageName: 'macos-10.13'
+        pythonVersion: '3.5'
+        testToxEnv: 'py35-min-req'
+        coverageToxEnv: ''
+        buildToxEnv: 'build-py35-min-req'
+        testWheelInstallEnv: 'wheelinstall-py35-min-req'
+
       Windows-py3.8:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
@@ -71,6 +79,14 @@ jobs:
         coverageToxEnv: ''
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
+
+      Windows-py3.5-min-req:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.5'
+        testToxEnv: 'py35-min-req'
+        coverageToxEnv: ''
+        buildToxEnv: 'build-py35-min-req'
+        testWheelInstallEnv: 'wheelinstall-py35-min-req'
 
   pool:
     vmImage: $(imageName)


### PR DESCRIPTION
Following up on #258 which added minimum requirements CI testing on Linux, this PR tests the same on Windows and Mac. This is important because Windows, at least, sometimes has weird issues with some packages and compiled binaries.