### PR TITLE
Fix readthedocs config to include all submodules

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,3 +21,8 @@ python:
   install:
     - requirements: requirements-doc.txt
     - requirements: requirements.txt
+
+# Optionally include all submodules
+submodules:
+  include: all
+  recursive: true


### PR DESCRIPTION
Although the readthedocs build for HDMF succeeds, there are hidden errors that suggest that the hdmf-common-schema is not loaded. This PR fixes the readthedocs config to include all submodules, as is done in PyNWB in https://github.com/NeurodataWithoutBorders/pynwb/pull/1155. 