### PR TITLE
Allow extending/overwriting attributes on dataset builders

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -156,7 +156,7 @@ class BuildManager:
             result = self.__type_map.build(container, self, source=source, spec_ext=spec_ext)
             self.prebuilt(container, result)
         elif container.modified or spec_ext is not None:
-            if isinstance(result, BaseBuilder) or isinstance(result, DatasetBuilder):
+            if isinstance(result, BaseBuilder):
                 result = self.__type_map.build(container, self, builder=result, source=source, spec_ext=spec_ext)
         return result
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -136,10 +136,10 @@ class BuildManager:
     @docval({"name": "container", "type": AbstractContainer, "doc": "the container to convert to a Builder"},
             {"name": "source", "type": str,
              "doc": "the source of container being built i.e. file path", 'default': None},
-            {"name": "spec_ext", "type": BaseStorageSpec, "doc": "a spec that further refines the base specificatoin",
+            {"name": "spec_ext", "type": BaseStorageSpec, "doc": "a spec that further refines the base specification",
              'default': None})
     def build(self, **kwargs):
-        """ Build the GroupBuilder for the given AbstractContainer"""
+        """ Build the GroupBuilder/DatasetBuilder for the given AbstractContainer"""
         container = getargs('container', kwargs)
         container_id = self.__conthash__(container)
         result = self.__builders.get(container_id)
@@ -155,8 +155,8 @@ class BuildManager:
                         raise ValueError("Can't change container_source once set")
             result = self.__type_map.build(container, self, source=source, spec_ext=spec_ext)
             self.prebuilt(container, result)
-        elif container.modified:
-            if isinstance(result, GroupBuilder):
+        elif container.modified or spec_ext is not None:
+            if isinstance(result, BaseBuilder) or isinstance(result, DatasetBuilder):
                 # TODO: if Datasets attributes are allowed to be modified, we need to
                 # figure out how to handle that starting here.
                 result = self.__type_map.build(container, self, builder=result, source=source, spec_ext=spec_ext)
@@ -727,10 +727,10 @@ class TypeMap:
              "doc": "the BuildManager to use for managing this build", 'default': None},
             {"name": "source", "type": str,
              "doc": "the source of container being built i.e. file path", 'default': None},
-            {"name": "builder", "type": GroupBuilder, "doc": "the Builder to build on", 'default': None},
+            {"name": "builder", "type": BaseBuilder, "doc": "the Builder to build on", 'default': None},
             {"name": "spec_ext", "type": BaseStorageSpec, "doc": "a spec extension", 'default': None})
     def build(self, **kwargs):
-        """ Build the GroupBuilder for the given AbstractContainer"""
+        """Build the GroupBuilder/DatasetBuilder for the given AbstractContainer"""
         container, manager, builder = getargs('container', 'manager', 'builder', kwargs)
         source, spec_ext = getargs('source', 'spec_ext', kwargs)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -157,8 +157,6 @@ class BuildManager:
             self.prebuilt(container, result)
         elif container.modified or spec_ext is not None:
             if isinstance(result, BaseBuilder) or isinstance(result, DatasetBuilder):
-                # TODO: if Datasets attributes are allowed to be modified, we need to
-                # figure out how to handle that starting here.
                 result = self.__type_map.build(container, self, builder=result, source=source, spec_ext=spec_ext)
         return result
 

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -11,7 +11,7 @@ from ..spec import Spec, AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NAME_W
 from ..data_utils import DataIO, AbstractDataChunkIterator
 from ..query import ReferenceResolver
 from ..spec.spec import BaseStorageSpec
-from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, RegionBuilder
+from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, RegionBuilder, BaseBuilder
 from .manager import Proxy, BuildManager
 from .warnings import OrphanContainerWarning, MissingRequiredWarning
 
@@ -520,10 +520,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
 
     @docval({"name": "container", "type": AbstractContainer, "doc": "the container to convert to a Builder"},
             {"name": "manager", "type": BuildManager, "doc": "the BuildManager to use for managing this build"},
-            {"name": "parent", "type": Builder, "doc": "the parent of the resulting Builder", 'default': None},
+            {"name": "parent", "type": GroupBuilder, "doc": "the parent of the resulting Builder", 'default': None},
             {"name": "source", "type": str,
              "doc": "the source of container being built i.e. file path", 'default': None},
-            {"name": "builder", "type": GroupBuilder, "doc": "the Builder to build on", 'default': None},
+            {"name": "builder", "type": BaseBuilder, "doc": "the Builder to build on", 'default': None},
             {"name": "spec_ext", "type": BaseStorageSpec, "doc": "a spec extension", 'default': None},
             returns="the Builder representing the given AbstractContainer", rtype=Builder)
     def build(self, **kwargs):
@@ -539,55 +539,57 @@ class ObjectMapper(metaclass=ExtenderMeta):
             self.__add_groups(builder, self.__spec.groups, container, manager, source)
             self.__add_links(builder, self.__spec.links, container, manager, source)
         else:
-            if not isinstance(container, Data):
-                msg = "'container' must be of type Data with DatasetSpec"
-                raise ValueError(msg)
-            spec_dtype, spec_shape, spec = self.__check_dset_spec(self.spec, spec_ext)
-            if isinstance(spec_dtype, RefSpec):
-                # a dataset of references
-                bldr_data = self.__get_ref_builder(spec_dtype, spec_shape, container, manager, source=source)
-                builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=spec_dtype.reftype)
-            elif isinstance(spec_dtype, list):
-                # a compound dataset
-                #
-                # check for any references in the compound dtype, and
-                # convert them if necessary
-                refs = [(i, subt) for i, subt in enumerate(spec_dtype) if isinstance(subt.dtype, RefSpec)]
-                bldr_data = copy(container.data)
-                bldr_data = list()
-                for i, row in enumerate(container.data):
-                    tmp = list(row)
-                    for j, subt in refs:
-                        tmp[j] = self.__get_ref_builder(subt.dtype, None, row[j], manager, source=source)
-                    bldr_data.append(tuple(tmp))
-                try:
-                    bldr_data, dtype = self.convert_dtype(spec, bldr_data)
-                except Exception as ex:
-                    msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
-                    raise Exception(msg) from ex
-                builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=dtype)
-            else:
-                # a regular dtype
-                if spec_dtype is None and self.__is_reftype(container.data):
-                    # an unspecified dtype and we were given references
+            if builder is None:
+                if not isinstance(container, Data):
+                    msg = "'container' must be of type Data with DatasetSpec"
+                    raise ValueError(msg)
+                spec_dtype, spec_shape, spec = self.__check_dset_spec(self.spec, spec_ext)
+                if isinstance(spec_dtype, RefSpec):
+                    # a dataset of references
+                    bldr_data = self.__get_ref_builder(spec_dtype, spec_shape, container, manager, source=source)
+                    builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=spec_dtype.reftype)
+                elif isinstance(spec_dtype, list):
+                    # a compound dataset
+                    #
+                    # check for any references in the compound dtype, and
+                    # convert them if necessary
+                    refs = [(i, subt) for i, subt in enumerate(spec_dtype) if isinstance(subt.dtype, RefSpec)]
+                    bldr_data = copy(container.data)
                     bldr_data = list()
-                    for d in container.data:
-                        if d is None:
-                            bldr_data.append(None)
-                        else:
-                            bldr_data.append(ReferenceBuilder(manager.build(d, source=source)))
-                    builder = DatasetBuilder(name, bldr_data, parent=parent, source=source,
-                                             dtype='object')
-                else:
-                    # a dataset that has no references, pass the donversion off to
-                    # the convert_dtype method
+                    for i, row in enumerate(container.data):
+                        tmp = list(row)
+                        for j, subt in refs:
+                            tmp[j] = self.__get_ref_builder(subt.dtype, None, row[j], manager, source=source)
+                        bldr_data.append(tuple(tmp))
                     try:
-                        bldr_data, dtype = self.convert_dtype(spec, container.data)
+                        bldr_data, dtype = self.convert_dtype(spec, bldr_data)
                     except Exception as ex:
                         msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
                         raise Exception(msg) from ex
                     builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=dtype)
-        self.__add_attributes(builder, self.__spec.attributes, container, manager, source)
+                else:
+                    # a regular dtype
+                    if spec_dtype is None and self.__is_reftype(container.data):
+                        # an unspecified dtype and we were given references
+                        bldr_data = list()
+                        for d in container.data:
+                            if d is None:
+                                bldr_data.append(None)
+                            else:
+                                bldr_data.append(ReferenceBuilder(manager.build(d, source=source)))
+                        builder = DatasetBuilder(name, bldr_data, parent=parent, source=source,
+                                                 dtype='object')
+                    else:
+                        # a dataset that has no references, pass the donversion off to
+                        # the convert_dtype method
+                        try:
+                            bldr_data, dtype = self.convert_dtype(spec, container.data)
+                        except Exception as ex:
+                            msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
+                            raise Exception(msg) from ex
+                        builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=dtype)
+        all_attrs = self.__spec.attributes + getattr(spec_ext, 'attributes', tuple())
+        self.__add_attributes(builder, all_attrs, container, manager, source)
         return builder
 
     def __check_dset_spec(self, orig, ext):

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -1,7 +1,6 @@
 from ...utils import docval, getargs
 from ...build import ObjectMapper, BuildManager
 from ...spec import Spec
-from ...container import Container
 from ..table import DynamicTable, VectorIndex
 from .. import register_map
 
@@ -23,7 +22,7 @@ class DynamicTableMap(ObjectMapper):
         return container.colnames
 
     @docval({"name": "spec", "type": Spec, "doc": "the spec to get the attribute value for"},
-            {"name": "container", "type": Container, "doc": "the container to get the attribute value from"},
+            {"name": "container", "type": DynamicTable, "doc": "the container to get the attribute value from"},
             {"name": "manager", "type": BuildManager, "doc": "the BuildManager used for managing this build"},
             returns='the value of the attribute')
     def get_attr_value(self, **kwargs):


### PR DESCRIPTION
In order to support attributes on uses or extensions of `VectorData`, the `ObjectMapper` needs to be able to add attributes from an extended spec to a `DatasetBuilder`. This should also work if the `DatasetBuilder` was built by resolving a reference and was memoized by the BuildManager. 

The key lines are new line numbers 542 and 589 of `objectmapper.py` and 158-159 in `manager.py`. 
GitHub's diff function poorly displays the fact that a significant chunk of `ObjectMapper.build` was just indented under the if statement of line 542.