### PR TITLE
hdmf/validate/validator.py: Add forgotten verification of links

### DIFF
--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -6,7 +6,7 @@ from itertools import chain
 
 from ..utils import docval, getargs, call_docval_func, pystr, get_data_shape
 
-from ..spec import Spec, AttributeSpec, GroupSpec, DatasetSpec, RefSpec
+from ..spec import Spec, AttributeSpec, GroupSpec, DatasetSpec, RefSpec, LinkSpec
 from ..spec.spec import BaseStorageSpec, DtypeHelper
 from ..spec import SpecNamespace
 
@@ -406,6 +406,9 @@ class GroupValidator(BaseStorageValidator):
             else:
                 self.__include_dts[spec.data_type_def] = spec
 
+        for spec in self.spec.links:
+            self.__include_dts[spec.data_type_inc] = spec
+
     @docval({"name": "builder", "type": GroupBuilder, "doc": "the builder to validate"},
             returns='a list of Errors', rtype=list)
     def validate(self, **kwargs):  # noqa: C901
@@ -434,11 +437,14 @@ class GroupValidator(BaseStorageValidator):
                     for bldr in dt_builders:
                         tmp = bldr
                         if isinstance(bldr, LinkBuilder):
-                            if inc_spec.linkable:
+                            if isinstance(inc_spec, LinkSpec):
                                 tmp = bldr.builder
                             else:
-                                ret.append(IllegalLinkError(self.get_spec_loc(inc_spec),
-                                                            location=self.get_builder_loc(tmp)))
+                                if inc_spec.linkable:
+                                    tmp = bldr.builder
+                                else:
+                                    ret.append(IllegalLinkError(self.get_spec_loc(inc_spec),
+                                                                location=self.get_builder_loc(tmp)))
                         ret.extend(sub_val.validate(tmp))
                         found = True
             if not found and self.__include_dts[dt].required:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -437,14 +437,11 @@ class GroupValidator(BaseStorageValidator):
                     for bldr in dt_builders:
                         tmp = bldr
                         if isinstance(bldr, LinkBuilder):
-                            if isinstance(inc_spec, LinkSpec):
+                            if isinstance(inc_spec, LinkSpec) or inc_spec.linkable:
                                 tmp = bldr.builder
                             else:
-                                if inc_spec.linkable:
-                                    tmp = bldr.builder
-                                else:
-                                    ret.append(IllegalLinkError(self.get_spec_loc(inc_spec),
-                                                                location=self.get_builder_loc(tmp)))
+                                ret.append(IllegalLinkError(self.get_spec_loc(inc_spec),
+                                                            location=self.get_builder_loc(tmp)))
                         ret.extend(sub_val.validate(tmp))
                         found = True
             if not found and self.__include_dts[dt].required:


### PR DESCRIPTION
The GroupValidator did only check all datasets and groups it holds but
did not verify that the links from spec also exist.

Now we also check that.

Co-authored-by: Andrew Tritt <ajtritt@lbl.gov>
