### PR TITLE
Add __repr__ function for DynamicTableRegion to ease debugging

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -733,3 +733,12 @@ class DynamicTableRegion(VectorData):
         :return: Shape tuple with two integers indicating the number of rows and number of columns
         """
         return (len(self.data), len(self.table.columns))
+
+    def __repr__(self):
+        cls = self.__class__
+        template = "%s %s.%s at 0x%d\n" % (self.name, cls.__module__, cls.__name__, id(self))
+        template += "    Target table: %s %s.%s at 0x%d\n" % (self.table.name,
+                                                              self.table.__class__.__module__,
+                                                              self.table.__class__.__name__,
+                                                              id(self.table))
+        return template

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -305,6 +305,21 @@ class TestDynamicTable(TestCase):
         self.assertTupleEqual(tuple(res.iloc[0]), (3, 30.0, 'bird'))
         self.assertTupleEqual(tuple(res.iloc[1]), (5, 50.0, 'lizard'))
 
+    def test_repr(self):
+        table = self.with_spec()
+        expected = """with_spec hdmf.common.table.DynamicTable at 0x%d
+Fields:
+  colnames: ['foo' 'bar' 'baz']
+  columns: (
+    foo <class 'hdmf.common.table.VectorData'>,
+    bar <class 'hdmf.common.table.VectorData'>,
+    baz <class 'hdmf.common.table.VectorData'>
+  )
+  description: a test table
+"""
+        expected = expected % id(table)
+        self.assertEqual(str(table), expected)
+
 
 class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 
@@ -439,6 +454,15 @@ class TestDynamicTableRegion(TestCase):
         with self.assertRaises(IndexError):
             dynamic_table_region.table = table
         self.assertIsNone(dynamic_table_region.table)
+
+    def test_repr(self):
+        table = self.with_columns_and_data()
+        dynamic_table_region = DynamicTableRegion('dtr', [1, 2, 2], 'desc', table=table)
+        expected = """dtr hdmf.common.table.DynamicTableRegion at 0x%d
+    Target table: with_columns_and_data hdmf.common.table.DynamicTable at 0x%d
+"""
+        expected = expected % (id(dynamic_table_region), id(table))
+        self.assertEqual(str(dynamic_table_region), expected)
 
 
 class TestElementIdentifiers(TestCase):


### PR DESCRIPTION
## Motivation

Make printing DynamicTableRegion more intuitive. 

This is non-essential, i.e., feel free to reject and close if there are any issues with this. 

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
