### PR TITLE
Ignore hdmf-common-schema git submodule when checking flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ exclude =
   __pycache__,
   build/,
   dist/,
+  src/hdmf/common/hdmf-common-schema,
   docs/source/conf.py
   versioneer.py
 per-file-ignores =


### PR DESCRIPTION
When running flake8 locally it also checks the hdmf-common-schema git submodule. This change ignores the submodule as any flake8 issues there should be fixed on it not in HDMF. 