### PR TITLE
Handle missing namespace version

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -967,7 +967,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                               object_id=builder.attributes.get(self.__spec.id_key()))
             obj.__init__(**kwargs)
         except Exception as ex:
-            msg = 'Could not construct %s object due to %s' % (cls.__name__, ex)
+            msg = 'Could not construct %s object due to: %s' % (cls.__name__, ex)
             raise Exception(msg) from ex
         return obj
 

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -51,7 +51,9 @@ class SpecNamespace(dict):
         if version is None:
             # version is required on write -- see YAMLSpecWriter.write_namespace -- but can be None on read in order to
             # be able to read older files with extensions that are missing the version key.
-            version = 'unknown'
+            warn(("Loaded namespace '%s' is missing the required key 'version'. Version will be set to 'unversioned'. "
+                  "Please notify the extension author.") % name)
+            version = 'unversioned'
         self['version'] = version
         if date is not None:
             self['date'] = date
@@ -425,8 +427,6 @@ class NamespaceCatalog:
                 included_types[s['namespace']] = tuple(types)
         # construct namespace
         ns = self.__spec_namespace_cls.build_namespace(catalog=catalog, **namespace)
-        if ns.version is None:
-            warn("Loaded namespace is missing 'version'.")
         self.__namespaces[ns_name] = ns
         return included_types
 

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -46,8 +46,13 @@ class YAMLSpecWriter(SpecWriter):
 
     def write_namespace(self, namespace, path):
         with open(os.path.join(self.__outdir, path), 'w') as stream:
-            ns = namespace
+            # version is required on write as of HDMF 1.5.4. check here instead of SpecNamespace.__init__ to maintain
+            # backwards compatibility with older namespaces that are missing version
+            if namespace['version'] is None:
+                raise TypeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
+                                % namespace['name'])
             # Convert the date to a string if necessary
+            ns = namespace
             if 'date' in namespace and isinstance(namespace['date'], datetime):
                 ns = copy.copy(ns)  # copy the namespace to avoid side-effects
                 ns['date'] = ns['date'].isoformat()

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -117,7 +117,7 @@ class NamespaceBuilder:
         if kwargs['version'] is None:
             # version is required on write as of HDMF 1.5. this check should prevent the writing of namespace files
             # without a verison
-            raise RuntimeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
+            raise ValueError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
                                % kwargs['name'])
         self.__ns_args = copy.deepcopy(kwargs)
         self.__namespaces = OrderedDict()

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -118,7 +118,7 @@ class NamespaceBuilder:
             # version is required on write as of HDMF 1.5. this check should prevent the writing of namespace files
             # without a verison
             raise ValueError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
-                               % kwargs['name'])
+                             % kwargs['name'])
         self.__ns_args = copy.deepcopy(kwargs)
         self.__namespaces = OrderedDict()
         self.__sources = OrderedDict()

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -109,6 +109,11 @@ class NamespaceBuilder:
             {'name': 'namespace_cls', 'type': type, 'doc': 'the SpecNamespace type', 'default': SpecNamespace})
     def __init__(self, **kwargs):
         ns_cls = popargs('namespace_cls', kwargs)
+        if kwargs['version'] is None:
+            # version is required on write as of HDMF 1.5. this check should prevent the writing of namespace files
+            # without a verison
+            raise RuntimeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
+                               % kwargs['name'])
         self.__ns_args = copy.deepcopy(kwargs)
         self.__namespaces = OrderedDict()
         self.__sources = OrderedDict()
@@ -202,11 +207,6 @@ class NamespaceBuilder:
             elif out:
                 writer.write_spec(out, path)
             ns_args['schema'].append(item)
-        if ns_args['version'] is None:
-            # version is required on write as of HDMF 1.5. check before building the namespace so that
-            # SpecNamespace can still be created for older namespaces that are missing version
-            raise RuntimeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
-                               % ns_args['name'])
         namespace = SpecNamespace.build_namespace(**ns_args)
         writer.write_namespace(namespace, ns_path)
 

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -242,9 +242,6 @@ def export_spec(ns_builder, new_data_types, output_dir):
         warnings.warn('No data types specified. Exiting.')
         return
 
-    if not ns_builder.name:
-        raise RuntimeError('Namespace name is required to export specs')
-
     ns_path = ns_builder.name + '.namespace.yaml'
     ext_path = ns_builder.name + '.extensions.yaml'
 

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -45,6 +45,11 @@ class YAMLSpecWriter(SpecWriter):
             yaml.dump(sorted_data, fd_write, Dumper=yaml.dumper.RoundTripDumper)
 
     def write_namespace(self, namespace, path):
+        """Write the given namespace key-value pairs as YAML to the given path.
+
+        :param namespace: SpecNamespace holding the key-value pairs that define the namespace
+        :param path: File path to write the namespace to as YAML under the key 'namespaces'
+        """
         with open(os.path.join(self.__outdir, path), 'w') as stream:
             # Convert the date to a string if necessary
             ns = namespace
@@ -55,7 +60,7 @@ class YAMLSpecWriter(SpecWriter):
 
     def reorder_yaml(self, path):
         """
-        Open a YAML file, load it as python data, sort the data, and write it back out to the
+        Open a YAML file, load it as python data, sort the data alphabetically, and write it back out to the
         same path.
         """
         with open(path, 'rb') as fd_read:

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -46,11 +46,6 @@ class YAMLSpecWriter(SpecWriter):
 
     def write_namespace(self, namespace, path):
         with open(os.path.join(self.__outdir, path), 'w') as stream:
-            # version is required on write as of HDMF 1.5.4. check here instead of SpecNamespace.__init__ to maintain
-            # backwards compatibility with older namespaces that are missing version
-            if namespace['version'] is None:
-                raise TypeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
-                                % namespace['name'])
             # Convert the date to a string if necessary
             ns = namespace
             if 'date' in namespace and isinstance(namespace['date'], datetime):
@@ -207,6 +202,11 @@ class NamespaceBuilder:
             elif out:
                 writer.write_spec(out, path)
             ns_args['schema'].append(item)
+        if ns_args['version'] is None:
+            # version is required on write as of HDMF 1.5. check before building the namespace so that
+            # SpecNamespace can still be created for older namespaces that are missing version
+            raise RuntimeError("Namespace '%s' missing key 'version'. Please specify a version for the extension."
+                               % ns_args['name'])
         namespace = SpecNamespace.build_namespace(**ns_args)
         writer.write_namespace(namespace, ns_path)
 

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -113,3 +113,66 @@ class TestSpecLoad(TestCase):
         src_dsets = {s.name for s in self.ext_datasets}
         ext_dsets = {s.name for s in es_spec.datasets}
         self.assertSetEqual(src_dsets, ext_dsets)
+
+
+class TestSpecLoadEdgeCase(TestCase):
+
+    def setUp(self):
+        self.specs_path = 'test_load_namespace.specs.yaml'
+        self.namespace_path = 'test_load_namespace.namespace.yaml'
+
+        # write basically empty specs file
+        to_dump = {'groups': []}
+        with open(self.specs_path, 'w') as tmp:
+            yaml.safe_dump(json.loads(json.dumps(to_dump)), tmp, default_flow_style=False)
+
+    def tearDown(self):
+        if os.path.exists(self.namespace_path):
+            os.remove(self.namespace_path)
+        if os.path.exists(self.specs_path):
+            os.remove(self.specs_path)
+
+    def test_build_namespace_missing_version(self):
+        """Test that building/creating a SpecNamespace without a version works but raises a warning."""
+        # create namespace without version key
+        ns_dict = {
+            'doc': 'a test namespace',
+            'name': 'test_ns',
+            'schema': [
+                {'source': self.specs_path}
+            ],
+        }
+        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
+               "'unversioned'. Please notify the extension author.")
+        with self.assertWarnsWith(UserWarning, msg):
+            namespace = SpecNamespace.build_namespace(**ns_dict)
+
+        self.assertEqual(namespace.version, 'unversioned')
+
+    def test_load_namespace_missing_version(self):
+        """Test that reading a namespace file without a version works but raises a warning."""
+        # create namespace with version key (remove it later)
+        ns_dict = {
+            'doc': 'a test namespace',
+            'name': 'test_ns',
+            'schema': [
+                {'source': self.specs_path}
+            ],
+            'version': '0.0.1'
+        }
+        namespace = SpecNamespace.build_namespace(**ns_dict)
+        namespace['version'] = None  # remove version key
+
+        # write the namespace to file without version key
+        to_dump = {'namespaces': [namespace]}
+        with open(self.namespace_path, 'w') as tmp:
+            yaml.safe_dump(json.loads(json.dumps(to_dump)), tmp, default_flow_style=False)
+
+        # load the namespace from file
+        ns_catalog = NamespaceCatalog()
+        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
+               "'unversioned'. Please notify the extension author.")
+        with self.assertWarnsWith(UserWarning, msg):
+            ns_catalog.load_namespaces(self.namespace_path)
+
+        self.assertEqual(ns_catalog.get_namespace('test_ns').version, 'unversioned')

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -140,7 +140,7 @@ class TestNamespaceBuilder(TestSpec):
     def test_missing_version(self):
         """Test that creating a namespace builder without a version raises an error."""
         msg = "Namespace '%s' missing key 'version'. Please specify a version for the extension." % self.ns_name
-        with self.assertRaisesWith(RuntimeError, msg):
+        with self.assertRaisesWith(ValueError, msg):
             self.ns_builder = NamespaceBuilder(doc="mydoc",
                                                name=self.ns_name,
                                                full_name="My Laboratory",

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -215,9 +215,3 @@ class TestExportSpec(TestSpec):
         """Test that calling export_spec on a namespace builder without data types raises a warning."""
         with self.assertWarnsWith(UserWarning, 'No data types specified. Exiting.'):
             export_spec(self.ns_builder, [], '.')
-
-    def test_missing_name(self):
-        """Test that calling export_spec on a namespace builder without a name raises an error."""
-        self.ns_builder._NamespaceBuilder__ns_args['name'] = None
-        with self.assertRaisesWith(RuntimeError, 'Namespace name is required to export specs'):
-            export_spec(self.ns_builder, self.data_types, '.')

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -187,6 +187,35 @@ class TestYAMLSpecWrite(TestSpec):
             self.assertEqual(nsstr, match_str)
 
 
+class TestYAMLSpecWriteVersion(TestCase):
+
+    def setUp(self):
+        # create a builder for the namespace
+        self.ns_name = "mylab"
+        self.date = datetime.datetime.now()
+
+        self.ns_builder = NamespaceBuilder(doc="mydoc",
+                                           name=self.ns_name,
+                                           full_name="My Laboratory",
+                                           # version="0.0.1",
+                                           author="foo",
+                                           contact="foo@bar.com",
+                                           namespace_cls=SpecNamespace,
+                                           date=self.date)
+
+        self.namespace_path = 'mylab.namespace.yaml'
+
+    def tearDown(self):
+        if os.path.exists(self.namespace_path):
+            os.remove(self.namespace_path)
+
+    def test_export_missing_version(self):
+        writer = YAMLSpecWriter()
+        msg = "Namespace '%s' missing key 'version'. Please specify a version for the extension." % self.ns_name
+        with self.assertRaisesWith(RuntimeError, msg):
+            self.ns_builder.export(self.namespace_path, writer=writer)
+
+
 class TestExportSpec(TestSpec):
 
     def test_export(self):
@@ -224,4 +253,10 @@ class TestExportSpec(TestSpec):
     def test_missing_name(self):
         self.ns_builder._NamespaceBuilder__ns_args['name'] = None
         with self.assertRaisesWith(RuntimeError, 'Namespace name is required to export specs'):
+            export_spec(self.ns_builder, self.data_types, '.')
+
+    def test_missing_version(self):
+        self.ns_builder._NamespaceBuilder__ns_args['version'] = None
+        msg = "Namespace '%s' missing key 'version'. Please specify a version for the extension." % self.ns_name
+        with self.assertRaisesWith(RuntimeError, msg):
             export_spec(self.ns_builder, self.data_types, '.')


### PR DESCRIPTION
Fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1183

- If a user loads a namespace (or otherwise creates a `SpecNamespace` object) without the version key, a warning is raised and the version is set to "unversioned".

- If a user creates a `NamespaceBuilder` (which is necessary to write a namespace to file) without the version key, an error is raised. Note that making `version` required cannot be done in the docval spec for `NamespaceBuilder` because there is an optional argument earlier in the arg list.

I also took the opportunity to refactor some of the unit tests.