### PR TITLE
Refactor missing namespace version

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -281,8 +281,6 @@ class HDF5IO(HDMFIO):
                 ns_builder = self.__convert_namespace(ns_catalog, ns_name)
                 namespace = ns_catalog.get_namespace(ns_name)
                 if namespace.version is None:
-                    group_name = '%s/unversioned' % ns_name
-                else:
                     group_name = '%s/%s' % (ns_name, namespace.version)
                 ns_group = spec_group.require_group(group_name)
                 writer = H5SpecWriter(ns_group)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -280,8 +280,7 @@ class HDF5IO(HDMFIO):
             for ns_name in ns_catalog.namespaces:
                 ns_builder = self.__convert_namespace(ns_catalog, ns_name)
                 namespace = ns_catalog.get_namespace(ns_name)
-                if namespace.version is None:
-                    group_name = '%s/%s' % (ns_name, namespace.version)
+                group_name = '%s/%s' % (ns_name, namespace.version)
                 ns_group = spec_group.require_group(group_name)
                 writer = H5SpecWriter(ns_group)
                 ns_builder.export('namespace', writer=writer)

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -91,7 +91,7 @@ class SpecNamespace(dict):
     @property
     def version(self):
         """
-        String, list, or tuple with the version or SpecNamespace.UNVERSIONED 
+        String, list, or tuple with the version or SpecNamespace.UNVERSIONED
         if the version is missing or empty
         """
         return self.get('version', None) or SpecNamespace.UNVERSIONED

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -36,7 +36,7 @@ class SpecNamespace(dict):
 
     __types_key = 'data_types'
 
-    UNVERSIONED = None  # string representing missing version
+    UNVERSIONED = None  # value representing missing version
 
     @docval(*_namespace_args)
     def __init__(self, **kwargs):
@@ -50,6 +50,10 @@ class SpecNamespace(dict):
         self['name'] = name
         if full_name is not None:
             self['full_name'] = full_name
+        if version == str(SpecNamespace.UNVERSIONED):
+            # the unversioned version may be written to file as a string and read from file as a string
+            warn("Loaded namespace '%s' is unversioned. Please notify the extension author." % name)
+            version = SpecNamespace.UNVERSIONED
         if version is None:
             # version is required on write -- see YAMLSpecWriter.write_namespace -- but can be None on read in order to
             # be able to read older files with extensions that are missing the version key.

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -85,13 +85,16 @@ class SpecNamespace(dict):
 
     @property
     def author(self):
-        """String or list of strings with the authors or  None"""
+        """String or list of strings with the authors or None"""
         return self.get('author', None)
 
     @property
     def version(self):
-        """String, list, or tuple with the version or None """
-        return self.get('version', None)
+        """String, list, or tuple with the version or SpecNamespace.UNVERSIONED """
+        version = self.get('version', None)
+        if version is None:
+            self['version'] = SpecNamespace.UNVERSIONED
+        return self.get('version')
 
     @property
     def date(self):

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -36,6 +36,8 @@ class SpecNamespace(dict):
 
     __types_key = 'data_types'
 
+    UNVERSIONED = 'unversioned'  # string representing missing version
+
     @docval(*_namespace_args)
     def __init__(self, **kwargs):
         doc, full_name, name, version, date, author, contact, schema, catalog = \
@@ -51,9 +53,9 @@ class SpecNamespace(dict):
         if version is None:
             # version is required on write -- see YAMLSpecWriter.write_namespace -- but can be None on read in order to
             # be able to read older files with extensions that are missing the version key.
-            warn(("Loaded namespace '%s' is missing the required key 'version'. Version will be set to 'unversioned'. "
-                  "Please notify the extension author.") % name)
-            version = 'unversioned'
+            warn(("Loaded namespace '%s' is missing the required key 'version'. Version will be set to '%s'. "
+                  "Please notify the extension author.") % (name, SpecNamespace.UNVERSIONED))
+            version = SpecNamespace.UNVERSIONED
         self['version'] = version
         if date is not None:
             self['date'] = date

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -36,7 +36,7 @@ class SpecNamespace(dict):
 
     __types_key = 'data_types'
 
-    UNVERSIONED = 'unversioned'  # string representing missing version
+    UNVERSIONED = None  # string representing missing version
 
     @docval(*_namespace_args)
     def __init__(self, **kwargs):

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -51,9 +51,8 @@ class SpecNamespace(dict):
         if version is None:
             # version is required on write -- see YAMLSpecWriter.write_namespace -- but can be None on read in order to
             # be able to read older files with extensions that are missing the version key.
-            warn(("Loaded namespace '%s' is missing the required key 'version'. Version will be set to 'unversioned'. "
-                  "Please notify the extension author.") % name)
-            version = 'unversioned'
+            warn("Loaded namespace '%s' is missing the required key 'version'. Please notify the extension author."
+                 % name)
         self['version'] = version
         if date is not None:
             self['date'] = date

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -90,11 +90,11 @@ class SpecNamespace(dict):
 
     @property
     def version(self):
-        """String, list, or tuple with the version or SpecNamespace.UNVERSIONED """
-        version = self.get('version', None)
-        if version is None:
-            self['version'] = SpecNamespace.UNVERSIONED
-        return self.get('version')
+        """
+        String, list, or tuple with the version or SpecNamespace.UNVERSIONED 
+        if the version is missing or empty
+        """
+        return self.get('version', None) or SpecNamespace.UNVERSIONED
 
     @property
     def date(self):

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -51,8 +51,9 @@ class SpecNamespace(dict):
         if version is None:
             # version is required on write -- see YAMLSpecWriter.write_namespace -- but can be None on read in order to
             # be able to read older files with extensions that are missing the version key.
-            warn("Loaded namespace '%s' is missing the required key 'version'. Please notify the extension author."
-                 % name)
+            warn(("Loaded namespace '%s' is missing the required key 'version'. Version will be set to 'unversioned'. "
+                  "Please notify the extension author.") % name)
+            version = 'unversioned'
         self['version'] = version
         if date is not None:
             self['date'] = date

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -179,7 +179,7 @@ class TestSpecLoadEdgeCase(TestCase):
 
     def test_missing_version_string(self):
         """Test that the constant variable representing a missing version has not changed."""
-        self.assertEqual(SpecNamespace.UNVERSIONED, 'unversioned')
+        self.assertIsNone(SpecNamespace.UNVERSIONED)
 
     def test_get_namespace_missing_version(self):
         """Test that SpecNamespace.version returns the constant for a missing version if version gets removed."""

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -181,3 +181,18 @@ class TestSpecLoadEdgeCase(TestCase):
         """Test that the constant variable representing a missing version has not changed."""
         self.assertEqual(SpecNamespace.UNVERSIONED, 'unversioned')
 
+    def test_get_namespace_missing_version(self):
+        """Test that SpecNamespace.version returns the constant for a missing version if version gets removed."""
+        # create namespace with version key (remove it later)
+        ns_dict = {
+            'doc': 'a test namespace',
+            'name': 'test_ns',
+            'schema': [
+                {'source': self.specs_path}
+            ],
+            'version': '0.0.1'
+        }
+        namespace = SpecNamespace.build_namespace(**ns_dict)
+        namespace['version'] = None  # work around lack of setter to remove version key
+
+        self.assertEqual(namespace.version, SpecNamespace.UNVERSIONED)

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -142,12 +142,11 @@ class TestSpecLoadEdgeCase(TestCase):
                 {'source': self.specs_path}
             ],
         }
-        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
-               "'unversioned'. Please notify the extension author.")
+        msg = "Loaded namespace 'test_ns' is missing the required key 'version'. Please notify the extension author."
         with self.assertWarnsWith(UserWarning, msg):
             namespace = SpecNamespace.build_namespace(**ns_dict)
 
-        self.assertEqual(namespace.version, 'unversioned')
+        self.assertIsNone(namespace.version)
 
     def test_load_namespace_missing_version(self):
         """Test that reading a namespace file without a version works but raises a warning."""
@@ -170,9 +169,8 @@ class TestSpecLoadEdgeCase(TestCase):
 
         # load the namespace from file
         ns_catalog = NamespaceCatalog()
-        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
-               "'unversioned'. Please notify the extension author.")
+        msg = "Loaded namespace 'test_ns' is missing the required key 'version'. Please notify the extension author."
         with self.assertWarnsWith(UserWarning, msg):
             ns_catalog.load_namespaces(self.namespace_path)
 
-        self.assertEqual(ns_catalog.get_namespace('test_ns').version, 'unversioned')
+        self.assertIsNone(ns_catalog.get_namespace('test_ns').version)

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -142,11 +142,12 @@ class TestSpecLoadEdgeCase(TestCase):
                 {'source': self.specs_path}
             ],
         }
-        msg = "Loaded namespace 'test_ns' is missing the required key 'version'. Please notify the extension author."
+        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
+               "'unversioned'. Please notify the extension author.")
         with self.assertWarnsWith(UserWarning, msg):
             namespace = SpecNamespace.build_namespace(**ns_dict)
 
-        self.assertIsNone(namespace.version)
+        self.assertEqual(namespace.version, 'unversioned')
 
     def test_load_namespace_missing_version(self):
         """Test that reading a namespace file without a version works but raises a warning."""
@@ -169,8 +170,9 @@ class TestSpecLoadEdgeCase(TestCase):
 
         # load the namespace from file
         ns_catalog = NamespaceCatalog()
-        msg = "Loaded namespace 'test_ns' is missing the required key 'version'. Please notify the extension author."
+        msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
+               "'unversioned'. Please notify the extension author.")
         with self.assertWarnsWith(UserWarning, msg):
             ns_catalog.load_namespaces(self.namespace_path)
 
-        self.assertIsNone(ns_catalog.get_namespace('test_ns').version)
+        self.assertEqual(ns_catalog.get_namespace('test_ns').version, 'unversioned')

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -143,7 +143,7 @@ class TestSpecLoadEdgeCase(TestCase):
             ],
         }
         msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
-               "'unversioned'. Please notify the extension author.")
+               "'%s'. Please notify the extension author." % SpecNamespace.UNVERSIONED)
         with self.assertWarnsWith(UserWarning, msg):
             namespace = SpecNamespace.build_namespace(**ns_dict)
 
@@ -161,7 +161,7 @@ class TestSpecLoadEdgeCase(TestCase):
             'version': '0.0.1'
         }
         namespace = SpecNamespace.build_namespace(**ns_dict)
-        namespace['version'] = None  # remove version key
+        namespace['version'] = None  # work around lack of setter to remove version key
 
         # write the namespace to file without version key
         to_dump = {'namespaces': [namespace]}
@@ -171,8 +171,13 @@ class TestSpecLoadEdgeCase(TestCase):
         # load the namespace from file
         ns_catalog = NamespaceCatalog()
         msg = ("Loaded namespace 'test_ns' is missing the required key 'version'. Version will be set to "
-               "'unversioned'. Please notify the extension author.")
+               "'%s'. Please notify the extension author." % SpecNamespace.UNVERSIONED)
         with self.assertWarnsWith(UserWarning, msg):
             ns_catalog.load_namespaces(self.namespace_path)
 
         self.assertEqual(ns_catalog.get_namespace('test_ns').version, SpecNamespace.UNVERSIONED)
+
+    def test_missing_version_string(self):
+        """Test that the constant variable representing a missing version has not changed."""
+        self.assertEqual(SpecNamespace.UNVERSIONED, 'unversioned')
+

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -147,7 +147,7 @@ class TestSpecLoadEdgeCase(TestCase):
         with self.assertWarnsWith(UserWarning, msg):
             namespace = SpecNamespace.build_namespace(**ns_dict)
 
-        self.assertEqual(namespace.version, 'unversioned')
+        self.assertEqual(namespace.version, SpecNamespace.UNVERSIONED)
 
     def test_load_namespace_missing_version(self):
         """Test that reading a namespace file without a version works but raises a warning."""
@@ -175,4 +175,4 @@ class TestSpecLoadEdgeCase(TestCase):
         with self.assertWarnsWith(UserWarning, msg):
             ns_catalog.load_namespaces(self.namespace_path)
 
-        self.assertEqual(ns_catalog.get_namespace('test_ns').version, 'unversioned')
+        self.assertEqual(ns_catalog.get_namespace('test_ns').version, SpecNamespace.UNVERSIONED)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1356,11 +1356,6 @@ class TestLoadNamespaces(TestCase):
         # make the file have group name "None" instead of "0.1.0" (namespace version is used as group name)
         # and set the version key to "None"
         with h5py.File(self.path, mode='r+') as f:
-            # check that the namespace dataset is what it should be
-            old_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core",'
-                      '"version":"0.1.0"}]}')
-            self.assertEqual(f['/specifications/' + CORE_NAMESPACE + '/0.1.0/namespace'][()], old_ns)
-
             # rename the group
             f.move('/specifications/' + CORE_NAMESPACE + '/0.1.0', '/specifications/' + CORE_NAMESPACE + '/None')
 
@@ -1388,11 +1383,6 @@ class TestLoadNamespaces(TestCase):
         # make the file have group name "unversioned" instead of "0.1.0" (namespace version is used as group name)
         # and remove the version key
         with h5py.File(self.path, mode='r+') as f:
-            # check that the namespace dataset is what it should be
-            old_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core",'
-                      '"version":"0.1.0"}]}')
-            self.assertEqual(f['/specifications/' + CORE_NAMESPACE + '/0.1.0/namespace'][()], old_ns)
-
             # rename the group
             f.move('/specifications/' + CORE_NAMESPACE + '/0.1.0', '/specifications/' + CORE_NAMESPACE + '/unversioned')
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 import warnings
 import numpy as np
+import h5py
 
 from hdmf.utils import docval, getargs
 from hdmf.data_utils import DataChunkIterator, InvalidDataIOError
@@ -1330,3 +1331,78 @@ class TestReadLink(TestCase):
         bldr2 = read_io2.read_builder()
         self.assertEqual(bldr2['link_to_link'].builder.source, self.target_path)
         read_io2.close()
+
+
+class TestLoadNamespaces(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_load_namespaces_none_version(self):
+        """Test that reading a file with a cached namespace and None version works but raises a warning."""
+        # Setup all the data we need
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        # make the file have group name "None" instead of "0.1.0" (namespace version is used as group name)
+        # and set the version key to "None"
+        with h5py.File(self.path, mode='r+') as f:
+            # check that the namespace dataset is what it should be
+            old_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core",'
+                      '"version":"0.1.0"}]}')
+            self.assertEqual(f['/specifications/' + CORE_NAMESPACE + '/0.1.0/namespace'][()], old_ns)
+
+            # rename the group
+            f.move('/specifications/' + CORE_NAMESPACE + '/0.1.0', '/specifications/' + CORE_NAMESPACE + '/None')
+
+            # replace the namespace dataset with a serialized dict without the version key
+            new_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core",'
+                      '"version":"None"}]}')
+            f['/specifications/' + CORE_NAMESPACE + '/None/namespace'][()] = new_ns
+
+        # load the namespace from file
+        ns_catalog = NamespaceCatalog()
+        msg = "Loaded namespace '%s' is unversioned. Please notify the extension author." % CORE_NAMESPACE
+        with self.assertWarnsWith(UserWarning, msg):
+            HDF5IO.load_namespaces(ns_catalog, self.path)
+
+    def test_load_namespaces_unversioned(self):
+        """Test that reading a file with a cached, unversioned version works but raises a warning."""
+        # Setup all the data we need
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        # make the file have group name "unversioned" instead of "0.1.0" (namespace version is used as group name)
+        # and remove the version key
+        with h5py.File(self.path, mode='r+') as f:
+            # check that the namespace dataset is what it should be
+            old_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core",'
+                      '"version":"0.1.0"}]}')
+            self.assertEqual(f['/specifications/' + CORE_NAMESPACE + '/0.1.0/namespace'][()], old_ns)
+
+            # rename the group
+            f.move('/specifications/' + CORE_NAMESPACE + '/0.1.0', '/specifications/' + CORE_NAMESPACE + '/unversioned')
+
+            # replace the namespace dataset with a serialized dict without the version key
+            new_ns = ('{"namespaces":[{"doc":"a test namespace","schema":[{"source":"test"}],"name":"test_core"}]}')
+            f['/specifications/' + CORE_NAMESPACE + '/unversioned/namespace'][()] = new_ns
+
+        # load the namespace from file
+        ns_catalog = NamespaceCatalog()
+        msg = ("Loaded namespace '%s' is missing the required key 'version'. Version will be set to "
+               "'%s'. Please notify the extension author." % (CORE_NAMESPACE, SpecNamespace.UNVERSIONED))
+        with self.assertWarnsWith(UserWarning, msg):
+            HDF5IO.load_namespaces(ns_catalog, self.path)


### PR DESCRIPTION
Based on [commentary](https://github.com/hdmf-dev/hdmf/commit/d432709374c7e8435f3a47fe29f906495d71ae97#r37363245) from @yarikoptic and @ajtritt, refactor, and:
1. expose the magic value that represents a missing version: None
2. write "None" as the version when writing the spec to disk
3. set the `SpecNamespace.version` to None if "None" is read as the version from disk
4. set the `SpecNamespace.version` to None if "unversioned" is read as the version from disk
5. make sure the "unversioned" and "None" version namespaces are not loaded when a versioned namespace is present
6. add a bunch of tests to cover these edge-cases and backward-compatibility support