### PR TITLE
Add support for float/uint -> int and uint/int -> float conversions

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -128,7 +128,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         g = np.dtype(given)
         s = np.dtype(specified)
-        if g.itemsize <= s.itemsize:  # given type has precision <= precision of specified type
+        if g is s:
+            return s.type
+        if g.itemsize <= s.itemsize:  # given type has precision < precision of specified type
             # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,
             # truncated values, and other unexpected consequences.
             warnings.warn('Value with data type %s is being converted to data type %s as specified.'

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -122,30 +122,43 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         Determine the dtype to use from the dtype of the given value and the specified dtype.
         This amounts to determining the greater precision of the two arguments, but also
-        checks to make sure the same base dtype is being used.
+        checks to make sure the same base dtype is being used. A warning is raised if the
+        base type of the specified dtype differs from the base type of the given dtype and
+        a conversion will result (e.g., float32 -> uint32).
         """
         g = np.dtype(given)
         s = np.dtype(specified)
-        if g.itemsize <= s.itemsize:
-            if g.name[:3] != s.name[:3]:  # different types
+        if g.itemsize <= s.itemsize:  # given type has precision <= precision of specified type
+            if g.name[:3] != s.name[:3]:  # warn if different base types
+                # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,
+                # truncated values, and other unexpected consequences.
                 warnings.warn('Value with data type %s is being converted to data type %s as specified.'
                               % (g.name, s.name))
             return s.type
         else:
-            if s.name.startswith('uint') and (g.name.startswith('int') or g.name.startswith('float')):
-                # e.g., given int64 and spec uint32, return uint64. given float32 and spec uint8, return uint32.
-                warnings.warn('Value with data type %s is being converted to data type %s as specified.'
-                              % (g.name, s.name))
-                return np.dtype('uint' + str(int(g.itemsize*8))).type
-            if g.name[:3] != s.name[:3]:  # different types
-                # if specified int and given uint/float or if specified float and given int/uint
-                if s.itemsize < 8:
-                    msg = "expected %s, received %s - must supply %s or higher precision" % (s.name, g.name, s.name)
-                else:
-                    msg = "expected %s, received %s - must supply %s" % (s.name, g.name, s.name)
+            if np.issubdtype(s, np.unsignedinteger):
+                # e.g.: given int64 and spec uint32, return uint64. given float32 and spec uint8, return uint32.
+                ret_type = np.dtype('uint' + str(int(g.itemsize*8)))
+                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
+                              % (g.name, ret_type.name, s.name))
+                return ret_type.type
+            if np.issubdtype(s, np.floating):
+                # e.g.: given int64 and spec float32, return float64. given uint64 and spec float32, return float32.
+                ret_type = np.dtype('float' + str(max(int(g.itemsize*8), 32)))
+                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
+                              % (g.name, ret_type.name, s.name))
+                return ret_type.type
+            if np.issubdtype(s, np.integer):
+                # e.g.: given float64 and spec int8, return int64. given uint32 and spec int8, return int32.
+                ret_type = np.dtype('int' + str(int(g.itemsize*8)))
+                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
+                              % (g.name, ret_type.name, s.name))
+                return ret_type.type
+            if s.type is np.bool_:
+                msg = "expected %s, received %s - must supply %s" % (s.name, g.name, s.name)
                 raise ValueError(msg)
-            else:
-                return g.type
+            # all numeric types in __dtypes should be caught by the above
+            raise ValueError('Unsupported conversion to specification data type: %s' % s.name)
 
     @classmethod
     def no_convert(cls, obj_type):

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -129,11 +129,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
         g = np.dtype(given)
         s = np.dtype(specified)
         if g.itemsize <= s.itemsize:  # given type has precision <= precision of specified type
-            if g.name[:3] != s.name[:3]:  # warn if different base types
-                # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,
-                # truncated values, and other unexpected consequences.
-                warnings.warn('Value with data type %s is being converted to data type %s as specified.'
-                              % (g.name, s.name))
+            # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,
+            # truncated values, and other unexpected consequences.
+            warnings.warn('Value with data type %s is being converted to data type %s as specified.'
+                          % (g.name, s.name))
             return s.type
         elif g.name[:3] == s.name[:3]:
             return g.type  # same base type, use higher-precision given type

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -135,6 +135,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 warnings.warn('Value with data type %s is being converted to data type %s as specified.'
                               % (g.name, s.name))
             return s.type
+        elif g.name[:3] == s.name[:3]:
+            return g.type  # same base type, use higher-precision given type
         else:
             if np.issubdtype(s, np.unsignedinteger):
                 # e.g.: given int64 and spec uint32, return uint64. given float32 and spec uint8, return uint32.

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -579,14 +579,15 @@ class TestConvertDtype(TestCase):
     def test_convert_to_64bit_spec(self):
         """
         Test that if given any value for a spec with a 64-bit dtype, convert_dtype will convert to the spec type.
-        Also test that if the given base type differs from the spec base type, a warning is raised.
+        Also test that if the given base type differs from the spec base type, convert_dtype raises a warning.
         """
         spec_type = 'float64'
         value_types = ['double', 'float64', 'float', 'float32']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
         spec_type = 'float64'
-        value_types = ['long', 'int64', 'int', 'int32', 'int16', 'int8', 'uint64', 'uint', 'uint32', 'uint16', 'uint8']
+        value_types = ['long', 'int64', 'int', 'int32', 'int16', 'int8', 'uint64', 'uint', 'uint32', 'uint16', 'uint8',
+                       'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
         spec_type = 'int64'
@@ -594,7 +595,7 @@ class TestConvertDtype(TestCase):
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
         spec_type = 'int64'
-        value_types = ['double', 'float64', 'float', 'float32', 'uint64', 'uint', 'uint32', 'uint16', 'uint8']
+        value_types = ['double', 'float64', 'float', 'float32', 'uint64', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
         spec_type = 'uint64'
@@ -602,13 +603,14 @@ class TestConvertDtype(TestCase):
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
         spec_type = 'uint64'
-        value_types = ['double', 'float64', 'float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'int8']
+        value_types = ['double', 'float64', 'float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'int8',
+                       'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_float32_spec(self):
         """Test conversion of various types to float32.
         If given a value with precision > float32 and float base type, convert_dtype will keep the higher precision.
-        If given a value with precision > float32 and different base type, convert_dtype will raise a ValueError.
+        If given a value with 64-bit precision and different base type, convert_dtype will convert to float64.
         If given a value with precision <= float32 and float base type, convert_dtype will convert to float32.
         If given a value with precision <= float32 and different base type, convert_dtype will convert to float32 and
         raise a warning.
@@ -618,18 +620,19 @@ class TestConvertDtype(TestCase):
         self._test_keep_higher_precision_helper(spec_type, value_types)
 
         value_types = ['long', 'int64', 'uint64']
-        self._test_convert_mismatch_helper(spec_type, value_types)
+        expected_type = 'float64'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['float', 'float32']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['int', 'int32', 'int16', 'int8', 'uint', 'uint32', 'uint16', 'uint8']
+        value_types = ['int', 'int32', 'int16', 'int8', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_int32_spec(self):
         """Test conversion of various types to int32.
         If given a value with precision > int32 and int base type, convert_dtype will keep the higher precision.
-        If given a value with precision > int32 and different base type, convert_dtype will raise a ValueError.
+        If given a value with 64-bit precision and different base type, convert_dtype will convert to int64.
         If given a value with precision <= int32 and int base type, convert_dtype will convert to int32.
         If given a value with precision <= int32 and different base type, convert_dtype will convert to int32 and
         raise a warning.
@@ -639,19 +642,19 @@ class TestConvertDtype(TestCase):
         self._test_keep_higher_precision_helper(spec_type, value_types)
 
         value_types = ['double', 'float64', 'uint64']
-        self._test_convert_mismatch_helper(spec_type, value_types)
+        expected_type = 'int64'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['int', 'int32', 'int16', 'int8', ]
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['float', 'float32', 'uint', 'uint32', 'uint16', 'uint8']
+        value_types = ['float', 'float32', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_uint32_spec(self):
         """Test conversion of various types to uint32.
         If given a value with precision > uint32 and uint base type, convert_dtype will keep the higher precision.
-        If given a value with precision > uint32 and different base type, convert_dtype will convert to uint with the
-        original precision.
+        If given a value with 64-bit precision and different base type, convert_dtype will convert to uint64.
         If given a value with precision <= uint32 and uint base type, convert_dtype will convert to uint32.
         If given a value with precision <= uint32 and different base type, convert_dtype will convert to uint32 and
         raise a warning.
@@ -661,19 +664,20 @@ class TestConvertDtype(TestCase):
         self._test_keep_higher_precision_helper(spec_type, value_types)
 
         value_types = ['double', 'float64', 'long', 'int64']
-        expected_types = ['uint64', 'uint64', 'uint64', 'uint64']
-        self._test_convert_uint_helper(spec_type, value_types, expected_types)
+        expected_type = 'uint64'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['uint', 'uint32', 'uint16', 'uint8']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['float', 'float32', 'int', 'int32', 'int16', 'int8']
+        value_types = ['float', 'float32', 'int', 'int32', 'int16', 'int8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_int16_spec(self):
         """Test conversion of various types to int16.
         If given a value with precision > int16 and int base type, convert_dtype will keep the higher precision.
-        If given a value with precision > int16 and different base type, convert_dtype will raise a ValueError.
+        If given a value with 64-bit precision and different base type, convert_dtype will convert to int64.
+        If given a value with 32-bit precision and different base type, convert_dtype will convert to int32.
         If given a value with precision <= int16 and int base type, convert_dtype will convert to int16.
         If given a value with precision <= int16 and different base type, convert_dtype will convert to int16 and
         raise a warning.
@@ -682,20 +686,25 @@ class TestConvertDtype(TestCase):
         value_types = ['long', 'int64', 'int', 'int32']
         self._test_keep_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['double', 'float64', 'float', 'float32', 'uint64', 'uint', 'uint32']
-        self._test_convert_mismatch_helper(spec_type, value_types)
+        value_types = ['double', 'float64', 'uint64']
+        expected_type = 'int64'
+        self._test_convert_helper(spec_type, value_types, expected_type)
+
+        value_types = ['float', 'float32', 'uint', 'uint32']
+        expected_type = 'int32'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['int16', 'int8']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['uint16', 'uint8']
+        value_types = ['uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_uint16_spec(self):
         """Test conversion of various types to uint16.
         If given a value with precision > uint16 and uint base type, convert_dtype will keep the higher precision.
-        If given a value with precision > uint16 and different base type, convert_dtype will convert to uint with the
-        original precision.
+        If given a value with 64-bit precision and different base type, convert_dtype will convert to uint64.
+        If given a value with 32-bit precision and different base type, convert_dtype will convert to uint32.
         If given a value with precision <= uint16 and uint base type, convert_dtype will convert to uint16.
         If given a value with precision <= uint16 and different base type, convert_dtype will convert to uint16 and
         raise a warning.
@@ -705,24 +714,41 @@ class TestConvertDtype(TestCase):
         self._test_keep_higher_precision_helper(spec_type, value_types)
 
         value_types = ['double', 'float64', 'long', 'int64']
-        expected_types = ['uint64', 'uint64', 'uint64', 'uint64']
-        self._test_convert_uint_helper(spec_type, value_types, expected_types)
+        expected_type = 'uint64'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['float', 'float32', 'int', 'int32']
-        expected_types = ['uint32', 'uint32', 'uint32', 'uint32']
-        self._test_convert_uint_helper(spec_type, value_types, expected_types)
+        expected_type = 'uint32'
+        self._test_convert_helper(spec_type, value_types, expected_type)
 
         value_types = ['uint16', 'uint8']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
-        value_types = ['int16', 'int8']
+        value_types = ['int16', 'int8', 'bool']
         self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+
+    def test_convert_to_bool_spec(self):
+        """Test conversion of various types to bool.
+        If given a value with type bool, convert_dtype will convert to bool.
+        If given a value with type int8/uint8, convert_dtype will convert to bool and raise a warning.
+        Otherwise, convert_dtype will raise an error.
+        """
+        spec_type = 'bool'
+        value_types = ['bool']
+        self._test_keep_higher_precision_helper(spec_type, value_types)
+
+        value_types = ['uint8', 'int8']
+        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+
+        value_types = ['double', 'float64', 'float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'uint64',
+                       'uint', 'uint32', 'uint16']
+        self._test_convert_mismatch_helper(spec_type, value_types)
 
     def _get_type(self, type_str):
         return ObjectMapper._ObjectMapper__dtypes[type_str]  # apply ObjectMapper mapping string to dtype
 
     def _test_convert_higher_precision_helper(self, spec_type, value_types):
-        data = 2
+        data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         match = (self._get_type(spec_type)(data), self._get_type(spec_type))
         for dtype in value_types:
@@ -733,7 +759,7 @@ class TestConvertDtype(TestCase):
                 self.assertIs(ret[0].dtype.type, match[1])
 
     def _test_convert_higher_precision_helper_warn(self, spec_type, value_types):
-        data = 2
+        data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         match = (self._get_type(spec_type)(data), self._get_type(spec_type))
         for dtype in value_types:
@@ -747,20 +773,8 @@ class TestConvertDtype(TestCase):
                 self.assertTupleEqual(ret, match)
                 self.assertIs(ret[0].dtype.type, match[1])
 
-    def _test_convert_mismatch_helper(self, spec_type, value_types):
-        data = 2
-        spec = DatasetSpec('an example dataset', spec_type, name='data')
-        for dtype in value_types:
-            value = self._get_type(dtype)(data)  # convert data to given dtype
-            with self.subTest(dtype=dtype):
-                s = np.dtype(self._get_type(spec_type))
-                g = np.dtype(self._get_type(dtype))
-                msg = r"expected %s, received %s - must supply %s.*" % (s.name, g.name, s.name)
-                with self.assertRaisesRegex(ValueError, msg):
-                    ObjectMapper.convert_dtype(spec, value)
-
     def _test_keep_higher_precision_helper(self, spec_type, value_types):
-        data = 2
+        data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         for dtype in value_types:
             value = self._get_type(dtype)(data)
@@ -770,20 +784,34 @@ class TestConvertDtype(TestCase):
                 self.assertTupleEqual(ret, match)
                 self.assertIs(ret[0].dtype.type, match[1])
 
-    def _test_convert_uint_helper(self, spec_type, value_types, expected_types):
-        data = 2
+    def _test_convert_helper(self, spec_type, value_types, exp_type):
+        data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
-        for dtype, exp_type in zip(value_types, expected_types):
+        match = (self._get_type(exp_type)(data), self._get_type(exp_type))
+        for dtype in value_types:
             value = self._get_type(dtype)(data)  # convert data to given dtype
-            match = (self._get_type(exp_type)(data), self._get_type(exp_type))
             with self.subTest(dtype=dtype):
                 s = np.dtype(self._get_type(spec_type))
+                e = np.dtype(self._get_type(exp_type))
                 g = np.dtype(self._get_type(dtype))
-                msg = 'Value with data type %s is being converted to data type %s as specified.' % (g.name, s.name)
+                msg = ('Value with data type %s is being converted to data type %s (min specification: %s).'
+                       % (g.name, e.name, s.name))
                 with self.assertWarnsWith(UserWarning, msg):
                     ret = ObjectMapper.convert_dtype(spec, value)
                 self.assertTupleEqual(ret, match)
                 self.assertIs(ret[0].dtype.type, match[1])
+
+    def _test_convert_mismatch_helper(self, spec_type, value_types):
+        data = 1
+        spec = DatasetSpec('an example dataset', spec_type, name='data')
+        for dtype in value_types:
+            value = self._get_type(dtype)(data)  # convert data to given dtype
+            with self.subTest(dtype=dtype):
+                s = np.dtype(self._get_type(spec_type))
+                g = np.dtype(self._get_type(dtype))
+                msg = "expected %s, received %s - must supply %s" % (s.name, g.name, s.name)
+                with self.assertRaisesWith(ValueError, msg):
+                    ObjectMapper.convert_dtype(spec, value)
 
     def test_no_spec(self):
         spec_type = None

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -579,7 +579,7 @@ class TestConvertDtype(TestCase):
     def test_convert_to_64bit_spec(self):
         """
         Test that if given any value for a spec with a 64-bit dtype, convert_dtype will convert to the spec type.
-        Also test that if the given base type differs from the spec base type, convert_dtype raises a warning.
+        Also test that if the given value is not the same as the spec, convert_dtype raises a warning.
         """
         spec_type = 'float64'
         value_types = ['double', 'float64']
@@ -612,9 +612,8 @@ class TestConvertDtype(TestCase):
         """Test conversion of various types to float32.
         If given a value with precision > float32 and float base type, convert_dtype will keep the higher precision.
         If given a value with 64-bit precision and different base type, convert_dtype will convert to float64.
-        If given a value with precision <= float32 and float base type, convert_dtype will convert to float32.
-        If given a value with precision <= float32 and different base type, convert_dtype will convert to float32 and
-        raise a warning.
+        If given a value that is float32, convert_dtype will convert to float32.
+        If given a value with precision <= float32, convert_dtype will convert to float32 and raise a warning.
         """
         spec_type = 'float32'
         value_types = ['double', 'float64']
@@ -634,9 +633,8 @@ class TestConvertDtype(TestCase):
         """Test conversion of various types to int32.
         If given a value with precision > int32 and int base type, convert_dtype will keep the higher precision.
         If given a value with 64-bit precision and different base type, convert_dtype will convert to int64.
-        If given a value with precision <= int32 and int base type, convert_dtype will convert to int32.
-        If given a value with precision <= int32 and different base type, convert_dtype will convert to int32 and
-        raise a warning.
+        If given a value that is int32, convert_dtype will convert to int32.
+        If given a value with precision <= int32, convert_dtype will convert to int32 and raise a warning.
         """
         spec_type = 'int32'
         value_types = ['int64', 'long']
@@ -656,9 +654,8 @@ class TestConvertDtype(TestCase):
         """Test conversion of various types to uint32.
         If given a value with precision > uint32 and uint base type, convert_dtype will keep the higher precision.
         If given a value with 64-bit precision and different base type, convert_dtype will convert to uint64.
-        If given a value with precision <= uint32 and uint base type, convert_dtype will convert to uint32.
-        If given a value with precision <= uint32 and different base type, convert_dtype will convert to uint32 and
-        raise a warning.
+        If given a value that is uint32, convert_dtype will convert to uint32.
+        If given a value with precision <= uint32, convert_dtype will convert to uint32 and raise a warning.
         """
         spec_type = 'uint32'
         value_types = ['uint64']
@@ -679,9 +676,8 @@ class TestConvertDtype(TestCase):
         If given a value with precision > int16 and int base type, convert_dtype will keep the higher precision.
         If given a value with 64-bit precision and different base type, convert_dtype will convert to int64.
         If given a value with 32-bit precision and different base type, convert_dtype will convert to int32.
-        If given a value with precision <= int16 and int base type, convert_dtype will convert to int16.
-        If given a value with precision <= int16 and different base type, convert_dtype will convert to int16 and
-        raise a warning.
+        If given a value that is int16, convert_dtype will convert to int16.
+        If given a value with precision <= int16, convert_dtype will convert to int16 and raise a warning.
         """
         spec_type = 'int16'
         value_types = ['long', 'int64', 'int', 'int32']
@@ -706,9 +702,8 @@ class TestConvertDtype(TestCase):
         If given a value with precision > uint16 and uint base type, convert_dtype will keep the higher precision.
         If given a value with 64-bit precision and different base type, convert_dtype will convert to uint64.
         If given a value with 32-bit precision and different base type, convert_dtype will convert to uint32.
-        If given a value with precision <= uint16 and uint base type, convert_dtype will convert to uint16.
-        If given a value with precision <= uint16 and different base type, convert_dtype will convert to uint16 and
-        raise a warning.
+        If given a value that is uint16, convert_dtype will convert to uint16.
+        If given a value with precision <= uint16, convert_dtype will convert to uint16 and raise a warning.
         """
         spec_type = 'uint16'
         value_types = ['uint64', 'uint', 'uint32']

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -582,30 +582,31 @@ class TestConvertDtype(TestCase):
         Also test that if the given base type differs from the spec base type, convert_dtype raises a warning.
         """
         spec_type = 'float64'
-        value_types = ['double', 'float64', 'float', 'float32']
-        self._test_convert_higher_precision_helper(spec_type, value_types)
+        value_types = ['double', 'float64']
+        self._test_convert_alias(spec_type, value_types)
 
         spec_type = 'float64'
-        value_types = ['long', 'int64', 'int', 'int32', 'int16', 'int8', 'uint64', 'uint', 'uint32', 'uint16', 'uint8',
-                       'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
-
-        spec_type = 'int64'
-        value_types = ['long', 'int64', 'int', 'int32', 'int16', 'int8']
+        value_types = ['float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'int8', 'uint64', 'uint',
+                       'uint32', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper(spec_type, value_types)
 
         spec_type = 'int64'
-        value_types = ['double', 'float64', 'float', 'float32', 'uint64', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+        value_types = ['long', 'int64']
+        self._test_convert_alias(spec_type, value_types)
+
+        spec_type = 'int64'
+        value_types = ['double', 'float64', 'float', 'float32', 'int', 'int32', 'int16', 'int8', 'uint64', 'uint',
+                       'uint32', 'uint16', 'uint8', 'bool']
+        self._test_convert_higher_precision_helper(spec_type, value_types)
 
         spec_type = 'uint64'
-        value_types = ['uint64', 'uint', 'uint32', 'uint16', 'uint8']
-        self._test_convert_higher_precision_helper(spec_type, value_types)
+        value_types = ['uint64']
+        self._test_convert_alias(spec_type, value_types)
 
         spec_type = 'uint64'
         value_types = ['double', 'float64', 'float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'int8',
-                       'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+                       'uint', 'uint32', 'uint16', 'uint8', 'bool']
+        self._test_convert_higher_precision_helper(spec_type, value_types)
 
     def test_convert_to_float32_spec(self):
         """Test conversion of various types to float32.
@@ -621,13 +622,13 @@ class TestConvertDtype(TestCase):
 
         value_types = ['long', 'int64', 'uint64']
         expected_type = 'float64'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
         value_types = ['float', 'float32']
-        self._test_convert_higher_precision_helper(spec_type, value_types)
+        self._test_convert_alias(spec_type, value_types)
 
         value_types = ['int', 'int32', 'int16', 'int8', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+        self._test_convert_higher_precision_helper(spec_type, value_types)
 
     def test_convert_to_int32_spec(self):
         """Test conversion of various types to int32.
@@ -643,13 +644,13 @@ class TestConvertDtype(TestCase):
 
         value_types = ['double', 'float64', 'uint64']
         expected_type = 'int64'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
-        value_types = ['int', 'int32', 'int16', 'int8', ]
+        value_types = ['int', 'int32']
+        self._test_convert_alias(spec_type, value_types)
+
+        value_types = ['float', 'float32', 'int16', 'int8', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper(spec_type, value_types)
-
-        value_types = ['float', 'float32', 'uint', 'uint32', 'uint16', 'uint8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_uint32_spec(self):
         """Test conversion of various types to uint32.
@@ -665,13 +666,13 @@ class TestConvertDtype(TestCase):
 
         value_types = ['double', 'float64', 'long', 'int64']
         expected_type = 'uint64'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
-        value_types = ['uint', 'uint32', 'uint16', 'uint8']
+        value_types = ['uint', 'uint32']
+        self._test_convert_alias(spec_type, value_types)
+
+        value_types = ['float', 'float32', 'int', 'int32', 'int16', 'int8', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper(spec_type, value_types)
-
-        value_types = ['float', 'float32', 'int', 'int32', 'int16', 'int8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_int16_spec(self):
         """Test conversion of various types to int16.
@@ -688,17 +689,17 @@ class TestConvertDtype(TestCase):
 
         value_types = ['double', 'float64', 'uint64']
         expected_type = 'int64'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
         value_types = ['float', 'float32', 'uint', 'uint32']
         expected_type = 'int32'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
-        value_types = ['int16', 'int8']
+        value_types = ['int16']
+        self._test_convert_alias(spec_type, value_types)
+
+        value_types = ['int8', 'uint16', 'uint8', 'bool']
         self._test_convert_higher_precision_helper(spec_type, value_types)
-
-        value_types = ['uint16', 'uint8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_uint16_spec(self):
         """Test conversion of various types to uint16.
@@ -715,17 +716,17 @@ class TestConvertDtype(TestCase):
 
         value_types = ['double', 'float64', 'long', 'int64']
         expected_type = 'uint64'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
         value_types = ['float', 'float32', 'int', 'int32']
         expected_type = 'uint32'
-        self._test_convert_helper(spec_type, value_types, expected_type)
+        self._test_change_basetype_helper(spec_type, value_types, expected_type)
 
-        value_types = ['uint16', 'uint8']
+        value_types = ['uint16']
+        self._test_convert_alias(spec_type, value_types)
+
+        value_types = ['int16', 'int8', 'uint8', 'bool']
         self._test_convert_higher_precision_helper(spec_type, value_types)
-
-        value_types = ['int16', 'int8', 'bool']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
 
     def test_convert_to_bool_spec(self):
         """Test conversion of various types to bool.
@@ -735,10 +736,10 @@ class TestConvertDtype(TestCase):
         """
         spec_type = 'bool'
         value_types = ['bool']
-        self._test_keep_higher_precision_helper(spec_type, value_types)
+        self._test_convert_alias(spec_type, value_types)
 
         value_types = ['uint8', 'int8']
-        self._test_convert_higher_precision_helper_warn(spec_type, value_types)
+        self._test_convert_higher_precision_helper(spec_type, value_types)
 
         value_types = ['double', 'float64', 'float', 'float32', 'long', 'int64', 'int', 'int32', 'int16', 'uint64',
                        'uint', 'uint32', 'uint16']
@@ -747,7 +748,7 @@ class TestConvertDtype(TestCase):
     def _get_type(self, type_str):
         return ObjectMapper._ObjectMapper__dtypes[type_str]  # apply ObjectMapper mapping string to dtype
 
-    def _test_convert_higher_precision_helper(self, spec_type, value_types):
+    def _test_convert_alias(self, spec_type, value_types):
         data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         match = (self._get_type(spec_type)(data), self._get_type(spec_type))
@@ -758,7 +759,7 @@ class TestConvertDtype(TestCase):
                 self.assertTupleEqual(ret, match)
                 self.assertIs(ret[0].dtype.type, match[1])
 
-    def _test_convert_higher_precision_helper_warn(self, spec_type, value_types):
+    def _test_convert_higher_precision_helper(self, spec_type, value_types):
         data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         match = (self._get_type(spec_type)(data), self._get_type(spec_type))
@@ -784,7 +785,7 @@ class TestConvertDtype(TestCase):
                 self.assertTupleEqual(ret, match)
                 self.assertIs(ret[0].dtype.type, match[1])
 
-    def _test_convert_helper(self, spec_type, value_types, exp_type):
+    def _test_change_basetype_helper(self, spec_type, value_types, exp_type):
         data = 1
         spec = DatasetSpec('an example dataset', spec_type, name='data')
         match = (self._get_type(exp_type)(data), self._get_type(exp_type))


### PR DESCRIPTION
Supplement to #298 and fix for part 2 of #294. 

Currently, if the spec specifies a float32, then an int/uint/float of lower or equal precision will be converted to float32. However, if the spec specifies a float32 and an int64/uint64, then an error is raised. This is inconsistent.

#298 converted an int/float of higher precision to a uint with the higher precision with a warning.

This PR covers all the other cases (the first is useful to supporting NWB schema 2.2 in PyNWB)
1) converts an int/uint of higher precision to a float with the higher precision with a warning
2) converts a uint/float of higher precision to an int with the higher precision with a warning
3) adds handling of bool values: If the spec specifies a bool, then an int8/uint8 will be converted to bool, but anything else will raise an error.