### PR TITLE
Allow write of refined ref-spec attribute

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -613,7 +613,15 @@ class ObjectMapper(metaclass=ExtenderMeta):
                             msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
                             raise Exception(msg) from ex
                         builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=dtype)
+
+        # Add attributes from the specification extension to the list of attributes
         all_attrs = self.__spec.attributes + getattr(spec_ext, 'attributes', tuple())
+        # If the spec_ext refines an existing attribute it will now appear twice in the list. The
+        # refinement should only be relevant for validation (not for write). To avoid problems with the
+        # write we here remove duplicates and keep the original spec of the two to make write work.
+        # TODO: We should add validation in the AttributeSpec to make sure refinements are valid
+        # TODO: Check the BuildManager as refinements should probably be resolved rather than be passed in via spec_ext
+        all_attrs = list({a.name: a for a in all_attrs[::-1]}.values())
         self.__add_attributes(builder, all_attrs, container, manager, source)
         return builder
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -297,7 +297,10 @@ class DynamicTable(Container):
                 if col.get('required', False):
                     self.add_column(col['name'], col['description'],
                                     index=col.get('index', False),
-                                    table=col.get('table', False))
+                                    table=col.get('table', False),
+                                    # Pass through extra keyword arguments for add_column that subclasses may have added
+                                    **{k: col[k] for k in col.keys()
+                                       if k not in ['name', 'description', 'index', 'table', 'required']})
 
                 else:  # create column name attributes (set to None) on the object even if column is not required
                     setattr(self, col['name'], None)
@@ -366,7 +369,11 @@ class DynamicTable(Container):
                     if data[col['name']] is not None:
                         self.add_column(col['name'], col['description'],
                                         index=col.get('index', False),
-                                        table=col.get('table', False))
+                                        table=col.get('table', False),
+                                        # Pass through extra keyword arguments for add_column that
+                                        # subclasses may have added
+                                        **{k: col[k] for k in col.keys()
+                                           if k not in ['name', 'description', 'index', 'table', 'required']})
                     extra_columns.remove(col['name'])
 
         if extra_columns or missing_columns:


### PR DESCRIPTION
## Motivation

Fix #300 

This PR implements a fix for writing refined attributes. It works by effectively ignoring the refinement on write as this is mostly a validation issue. However, this points to additional issues that should be addressed down the line:

* We should add validation in the AttributeSpec to make sure refinements are valid
* Check the BuildManager as refinements of attributes should probably be resolved rather than be passed in via ``spec_ext``


## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
