### PR TITLE
Improve msg for "can't change contianer_source" error for debugging

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -152,7 +152,9 @@ class BuildManager:
                     source = container.container_source
                 else:
                     if container.container_source != source:
-                        raise ValueError("Can't change container_source once set")
+                        raise ValueError("Cannot change container_source once set: '%s' %s.%s"
+                                         % (container.name, container.__class__.__module__,
+                                            container.__class__.__name__))
             result = self.__type_map.build(container, self, source=source, spec_ext=spec_ext)
             self.prebuilt(container, result)
         elif container.modified or spec_ext is not None:


### PR DESCRIPTION
The previous error message was "Can't change container_source once set" and did not say which container raised the error. The new error message fixes that.