### PR TITLE
Refactor add_column to raise error when name is an optional column

### DIFF
--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -510,3 +510,57 @@ class TestElementIdentifiers(TestCase):
             _ = (e == 0.1)
         with self.assertRaises(TypeError):
             _ = (e == 'test')
+
+
+class SubTable(DynamicTable):
+
+    __columns__ = (
+        {'name': 'col1', 'description': 'required column', 'required': True},
+        {'name': 'col2', 'description': 'optional column'},
+        {'name': 'col3', 'description': 'required, indexed column', 'required': True, 'index': True},
+        {'name': 'col4', 'description': 'optional, indexed column', 'index': True}
+    )
+
+
+class TestCustomDynamicTable(TestCase):
+
+    def test_init(self):
+        table = SubTable(name='subtable', description='subtable description')
+        self.assertEqual(table.colnames, ('col1', 'col3'))
+
+    def test_add_column(self):
+        table = SubTable(name='subtable', description='subtable description')
+        table.add_column(name='col5', description='column #5')
+        self.assertEqual(table.colnames, ('col1', 'col3', 'col5'))
+        self.assertTrue(hasattr(table, 'col5'))
+
+    def test_add_existing_column(self):
+        table = SubTable(name='subtable', description='subtable description')
+        msg = "column 'col1' already exists in SubTable 'subtable'"
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='col1', description='column #1')
+
+    def test_add_optional_column(self):
+        table = SubTable(name='subtable', description='subtable description')
+        msg = "column 'col2' already exists in SubTable 'subtable'"
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='col2', description='column #2')
+
+    def test_add_optional_column_after_data(self):
+        table = SubTable(name='subtable', description='subtable description')
+        table.add_row(col1='a', col3='c')
+        msg = "column 'col2' already exists in SubTable 'subtable'"
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='col2', description='column #2', data=('b', ))
+
+    def test_add_row_opt_column(self):
+        table = SubTable(name='subtable', description='subtable description')
+        table.add_row(col1='a', col2='b', col3='c')
+        self.assertEqual(set(table.colnames), {'col1', 'col2', 'col3'})
+        self.assertEqual(table['col2'].description, 'optional column')
+
+    def test_add_row_opt_column_after_data(self):
+        table = SubTable(name='subtable', description='subtable description')
+        table.add_row(col1='a', col3='c')
+        with self.assertRaises(ValueError):
+            table.add_row(col1='a', col2='b', col3='c')


### PR DESCRIPTION
I refactored `DynamicTable.add_column` to raise an error when the name of the new column is the same as the name of an optional column specified in `__column__`.

The refactor is necessary so that on `__init__`and `add_row`, this check is bypassed. Previously, `__init__`, `add_row`, and any public functions would call `add_column`. Now `add_column` checks the column name and then calls the internal `_add_column` which has the code that `add_column` used to have. And `__init__` and `add_row` call `_add_column` directly (bypassing the check). 

This is needed to handle https://github.com/NeurodataWithoutBorders/pynwb/issues/1204