### PR TITLE
Raise more informative error when adding column w/ used name

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -368,7 +368,7 @@ class DynamicTable(Container):
 
         # check to see if any of the extra columns just need to be added
         if extra_columns:
-            for col in self.__uninit_cols:
+            for col in self.__columns__:
                 if col['name'] in extra_columns:
                     if data[col['name']] is not None:
                         self.add_column(col['name'], col['description'],

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -271,7 +271,9 @@ class DynamicTable(Container):
         self.__indices = dict()
         for col in self.columns:
             if hasattr(self, col.name):
-                raise ValueError("Column name '%s' is not allowed because it is already an attribute" % col.name)
+                msg = ("Cannot create column with name '%s'. The attribute '%s' already exists on %s '%s'"
+                       % (col.name, col.name, self.__class__.__name__, self.name))
+                raise ValueError(msg)
             setattr(self, col.name, col)
             if isinstance(col, VectorData):
                 existing = col_dict.get(col.name)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -423,6 +423,10 @@ class DynamicTable(Container):
         if name in self.__colids:
             msg = "column '%s' already exists in DynamicTable '%s'" % (name, self.name)
             raise ValueError(msg)
+        if hasattr(self, name):
+            msg = ("Cannot create column with name '%s'. The attribute '%s' already exists on %s '%s'"
+                   % (name, name, self.__class__.__name__, self.name))
+            raise ValueError(msg)
 
         ckwargs = dict(kwargs)
         cls = VectorData

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -246,7 +246,8 @@ class TestDynamicTable(TestCase):
             'description': ['cat', 'dog', 'bird', 'fish', 'lizard']
         }).loc[:, ('foo', 'bar', 'description')]
 
-        msg = "Column name 'description' is not allowed because it is already an attribute"
+        msg = ("Cannot create column with name 'description'. The attribute 'description' already exists on "
+               "DynamicTable 'test'")
         with self.assertRaisesWith(ValueError, msg):
             DynamicTable.from_dataframe(df, 'test')
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -464,6 +464,16 @@ class TestDynamicTableRegion(TestCase):
         expected = expected % (id(dynamic_table_region), id(table))
         self.assertEqual(str(dynamic_table_region), expected)
 
+    def test_add_column_existing_attr(self):
+        table = self.with_columns_and_data()
+        attrs = ['name', 'description', 'parent', 'id', 'fields']  # just a few
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                msg = ("Cannot create column with name '%s'. The attribute '%s' already exists on "
+                       "DynamicTable 'with_columns_and_data'") % (attr, attr)
+                with self.assertRaisesWith(ValueError, msg):
+                    table.add_column(name=attr, description='')
+
 
 class TestElementIdentifiers(TestCase):
 


### PR DESCRIPTION
When trying to add a column named "description", "name", or another string that is already an attribute on the `DynamicTable`, I get the error message: `AttributeError: can't set attribute 'description' -- already set`. This is not very informative. This PR raises a more informative error.