### PR TITLE
Change dtype conversion warning to include path to type

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -13,7 +13,7 @@ from ..query import ReferenceResolver
 from ..spec.spec import BaseStorageSpec
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, RegionBuilder, BaseBuilder
 from .manager import Proxy, BuildManager
-from .warnings import OrphanContainerWarning, MissingRequiredWarning
+from .warnings import OrphanContainerWarning, MissingRequiredWarning, DtypeConversionWarning
 
 
 _const_arg = '__constructor_arg'
@@ -129,34 +129,34 @@ class ObjectMapper(metaclass=ExtenderMeta):
         g = np.dtype(given)
         s = np.dtype(specified)
         if g is s:
-            return s.type
+            return s.type, None
         if g.itemsize <= s.itemsize:  # given type has precision < precision of specified type
             # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,
             # truncated values, and other unexpected consequences.
-            warnings.warn('Value with data type %s is being converted to data type %s as specified.'
-                          % (g.name, s.name))
-            return s.type
+            warning_msg = ('Value with data type %s is being converted to data type %s as specified.'
+                           % (g.name, s.name))
+            return s.type, warning_msg
         elif g.name[:3] == s.name[:3]:
-            return g.type  # same base type, use higher-precision given type
+            return g.type, None  # same base type, use higher-precision given type
         else:
             if np.issubdtype(s, np.unsignedinteger):
                 # e.g.: given int64 and spec uint32, return uint64. given float32 and spec uint8, return uint32.
                 ret_type = np.dtype('uint' + str(int(g.itemsize*8)))
-                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
-                              % (g.name, ret_type.name, s.name))
-                return ret_type.type
+                warning_msg = ('Value with data type %s is being converted to data type %s (min specification: %s).'
+                               % (g.name, ret_type.name, s.name))
+                return ret_type.type, warning_msg
             if np.issubdtype(s, np.floating):
                 # e.g.: given int64 and spec float32, return float64. given uint64 and spec float32, return float32.
                 ret_type = np.dtype('float' + str(max(int(g.itemsize*8), 32)))
-                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
-                              % (g.name, ret_type.name, s.name))
-                return ret_type.type
+                warning_msg = ('Value with data type %s is being converted to data type %s (min specification: %s).'
+                               % (g.name, ret_type.name, s.name))
+                return ret_type.type, warning_msg
             if np.issubdtype(s, np.integer):
                 # e.g.: given float64 and spec int8, return int64. given uint32 and spec int8, return int32.
                 ret_type = np.dtype('int' + str(int(g.itemsize*8)))
-                warnings.warn('Value with data type %s is being converted to data type %s (min specification: %s).'
-                              % (g.name, ret_type.name, s.name))
-                return ret_type.type
+                warning_msg = ('Value with data type %s is being converted to data type %s (min specification: %s).'
+                               % (g.name, ret_type.name, s.name))
+                return ret_type.type, warning_msg
             if s.type is np.bool_:
                 msg = "expected %s, received %s - must supply %s" % (s.name, g.name, s.name)
                 raise ValueError(msg)
@@ -185,6 +185,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
         if ret is not None or ret_dtype is not None:
             return ret, ret_dtype
         spec_dtype = cls.__dtypes[spec.dtype]
+        warning_msg = None
         if isinstance(value, np.ndarray):
             if spec_dtype is _unicode:
                 ret = value.astype('U')
@@ -193,7 +194,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret = value.astype('S')
                 ret_dtype = "ascii"
             else:
-                dtype_func = cls.__resolve_dtype(value.dtype, spec_dtype)
+                dtype_func, warning_msg = cls.__resolve_dtype(value.dtype, spec_dtype)
                 ret = np.asarray(value).astype(dtype_func)
                 ret_dtype = ret.dtype.type
         elif isinstance(value, (tuple, list)):
@@ -207,7 +208,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             ret_dtype = tmp_dtype
         elif isinstance(value, AbstractDataChunkIterator):
             ret = value
-            ret_dtype = cls.__resolve_dtype(value.dtype, spec_dtype)
+            ret_dtype, warning_msg = cls.__resolve_dtype(value.dtype, spec_dtype)
         else:
             if spec_dtype in (_unicode, _ascii):
                 ret_dtype = 'ascii'
@@ -215,9 +216,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     ret_dtype = 'utf8'
                 ret = spec_dtype(value)
             else:
-                dtype_func = cls.__resolve_dtype(type(value), spec_dtype)
+                dtype_func, warning_msg = cls.__resolve_dtype(type(value), spec_dtype)
                 ret = dtype_func(value)
                 ret_dtype = type(ret)
+        if warning_msg:
+            full_warning_msg = "Spec %s: %s" % (spec.path_str(), warning_msg)
+            warnings.warn(full_warning_msg, DtypeConversionWarning)
         return ret, ret_dtype
 
     @classmethod
@@ -605,7 +609,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         builder = DatasetBuilder(name, bldr_data, parent=parent, source=source,
                                                  dtype='object')
                     else:
-                        # a dataset that has no references, pass the donversion off to
+                        # a dataset that has no references, pass the conversion off to
                         # the convert_dtype method
                         try:
                             bldr_data, dtype = self.convert_dtype(spec, container.data)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -220,7 +220,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret = dtype_func(value)
                 ret_dtype = type(ret)
         if warning_msg:
-            full_warning_msg = "Spec %s: %s" % (spec.path_str(), warning_msg)
+            full_warning_msg = "Spec '%s': %s" % (spec.path_str(), warning_msg)
             warnings.warn(full_warning_msg, DtypeConversionWarning)
         return ret, ret_dtype
 

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -220,7 +220,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret = dtype_func(value)
                 ret_dtype = type(ret)
         if warning_msg:
-            full_warning_msg = "Spec '%s': %s" % (spec.path_str(), warning_msg)
+            full_warning_msg = "Spec '%s': %s" % (spec.path, warning_msg)
             warnings.warn(full_warning_msg, DtypeConversionWarning)
         return ret, ret_dtype
 

--- a/src/hdmf/build/warnings.py
+++ b/src/hdmf/build/warnings.py
@@ -13,3 +13,10 @@ class MissingRequiredWarning(UserWarning):
     Raised when a required field is missing.
     """
     pass
+
+
+class DtypeConversionWarning(UserWarning):
+    """
+    Raised when a value is converted to a different data type in order to match the specification.
+    """
+    pass

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -145,7 +145,8 @@ class Spec(ConstructableDict):
     def __hash__(self):
         return id(self)
 
-    def path_str(self):
+    @property
+    def path(self):
         stack = list()
         tmp = self
         while tmp is not None:

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -146,15 +146,17 @@ class Spec(ConstructableDict):
         return id(self)
 
     def path_str(self):
-        """
-        Return string showing full path to this spec, with spec names separated by '/', regardless of the spec type.
-        """
-        spec_path = self.name
-        spec = self.parent
-        while spec is not None:
-            spec_path = spec.name + '/' + spec_path
-            spec = spec.parent
-        return '/' + spec_path
+        stack = list()
+        tmp = self
+        while tmp is not None:
+            name = tmp.name
+            if name is None:
+                name = tmp.data_type_def
+                if name is None:
+                    name = tmp.data_type_inc
+            stack.append(name)
+            tmp = tmp.parent
+        return "/".join(reversed(stack))
 
 #    def __eq__(self, other):
 #        return id(self) == id(other)
@@ -372,6 +374,24 @@ class BaseStorageSpec(Spec):
         for attribute in inc_spec.attributes:
             self.__new_attributes.discard(attribute)
             if attribute.name in self.__attributes:
+                # copy over the fields 'shape' and 'dims' of the parent attribute to this spec's attribute
+                # NOTE: because the default value for the 'required' field is True, it is not possible to know whether
+                # the 'required' field was explicitly set. thus, 'required' defaults to True no matter what the parent
+                # specification defines.
+                # NOTE: the value and default value of a parent attribute are also not copied to the child spec
+                my_attribute = self.get_attribute(attribute.name)
+                if attribute.shape is not None:
+                    if my_attribute.shape is None:
+                        my_attribute['shape'] = attribute.shape
+                    else:
+                        # TODO: test whether child shape is compatible with parent shape
+                        pass
+                if attribute.dims is not None:
+                    if my_attribute.dims is None:
+                        my_attribute['dims'] = attribute.dims
+                    else:
+                        # TODO: test whether child dims is compatible with parent dims
+                        pass
                 self.__overridden_attributes.add(attribute.name)
                 continue
             self.set_attribute(attribute)
@@ -691,6 +711,30 @@ class DatasetSpec(BaseStorageSpec):
     @docval({'name': 'inc_spec', 'type': 'DatasetSpec', 'doc': 'the data type this specification represents'})
     def resolve_spec(self, **kwargs):
         inc_spec = getargs('inc_spec', kwargs)
+        # copy over fields of the parent dataset to this spec
+        # NOTE: because the default value for the 'quantity' field is 1, it is not possible to know whether
+        # the 'quantity' field was explicitly set. thus, 'quantity' defaults to 1 no matter what the parent
+        # specification defines.
+        # NOTE: the default value of a parent attribute is also not copied to the child spec
+        if inc_spec.dtype is not None:
+            if self.dtype is None:
+                self['dtype'] = inc_spec.dtype
+            else:
+                # TODO: test whether child dtype is compatible with parent dtype
+                # e.g., if parent dtype is int, child dtype cannot be text
+                pass
+        if inc_spec.shape is not None:
+            if self.shape is None:
+                self['shape'] = inc_spec.shape
+            elif inc_spec.shape is not None:
+                # TODO: test whether child shape is compatible with parent shape
+                pass
+        if inc_spec.dims is not None:
+            if self.dims is None:
+                self['dims'] = inc_spec.dims
+            elif inc_spec.dims is not None:
+                # TODO: test whether child dims is compatible with parent dims
+                pass
         if isinstance(self.dtype, list):
             # merge the new types
             inc_dtype = inc_spec.dtype

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -145,6 +145,17 @@ class Spec(ConstructableDict):
     def __hash__(self):
         return id(self)
 
+    def path_str(self):
+        """
+        Return string showing full path to this spec, with spec names separated by '/', regardless of the spec type.
+        """
+        spec_path = self.name
+        spec = self.parent
+        while spec is not None:
+            spec_path = spec.name + '/' + spec_path
+            spec = spec.parent
+        return '/' + spec_path
+
 #    def __eq__(self, other):
 #        return id(self) == id(other)
 

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -375,24 +375,6 @@ class BaseStorageSpec(Spec):
         for attribute in inc_spec.attributes:
             self.__new_attributes.discard(attribute)
             if attribute.name in self.__attributes:
-                # copy over the fields 'shape' and 'dims' of the parent attribute to this spec's attribute
-                # NOTE: because the default value for the 'required' field is True, it is not possible to know whether
-                # the 'required' field was explicitly set. thus, 'required' defaults to True no matter what the parent
-                # specification defines.
-                # NOTE: the value and default value of a parent attribute are also not copied to the child spec
-                my_attribute = self.get_attribute(attribute.name)
-                if attribute.shape is not None:
-                    if my_attribute.shape is None:
-                        my_attribute['shape'] = attribute.shape
-                    else:
-                        # TODO: test whether child shape is compatible with parent shape
-                        pass
-                if attribute.dims is not None:
-                    if my_attribute.dims is None:
-                        my_attribute['dims'] = attribute.dims
-                    else:
-                        # TODO: test whether child dims is compatible with parent dims
-                        pass
                 self.__overridden_attributes.add(attribute.name)
                 continue
             self.set_attribute(attribute)
@@ -712,30 +694,6 @@ class DatasetSpec(BaseStorageSpec):
     @docval({'name': 'inc_spec', 'type': 'DatasetSpec', 'doc': 'the data type this specification represents'})
     def resolve_spec(self, **kwargs):
         inc_spec = getargs('inc_spec', kwargs)
-        # copy over fields of the parent dataset to this spec
-        # NOTE: because the default value for the 'quantity' field is 1, it is not possible to know whether
-        # the 'quantity' field was explicitly set. thus, 'quantity' defaults to 1 no matter what the parent
-        # specification defines.
-        # NOTE: the default value of a parent attribute is also not copied to the child spec
-        if inc_spec.dtype is not None:
-            if self.dtype is None:
-                self['dtype'] = inc_spec.dtype
-            else:
-                # TODO: test whether child dtype is compatible with parent dtype
-                # e.g., if parent dtype is int, child dtype cannot be text
-                pass
-        if inc_spec.shape is not None:
-            if self.shape is None:
-                self['shape'] = inc_spec.shape
-            elif inc_spec.shape is not None:
-                # TODO: test whether child shape is compatible with parent shape
-                pass
-        if inc_spec.dims is not None:
-            if self.dims is None:
-                self['dims'] = inc_spec.dims
-            elif inc_spec.dims is not None:
-                # TODO: test whether child dims is compatible with parent dims
-                pass
         if isinstance(self.dtype, list):
             # merge the new types
             inc_dtype = inc_spec.dtype

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -261,7 +261,7 @@ class Validator(metaclass=ABCMeta):
 
     @classmethod
     def get_spec_loc(cls, spec):
-        return spec.path_str()
+        return spec.path
 
     @classmethod
     def get_builder_loc(cls, builder):

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -261,17 +261,7 @@ class Validator(metaclass=ABCMeta):
 
     @classmethod
     def get_spec_loc(cls, spec):
-        stack = list()
-        tmp = spec
-        while tmp is not None:
-            name = tmp.name
-            if name is None:
-                name = tmp.data_type_def
-                if name is None:
-                    name = tmp.data_type_inc
-            stack.append(name)
-            tmp = tmp.parent
-        return "/".join(reversed(stack))
+        return spec.path_str()
 
     @classmethod
     def get_builder_loc(cls, builder):

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -763,7 +763,7 @@ class TestConvertDtype(TestCase):
             with self.subTest(dtype=dtype):
                 s = np.dtype(self._get_type(spec_type))
                 g = np.dtype(self._get_type(dtype))
-                msg = ('Spec /data: Value with data type %s is being converted to data type %s as specified.'
+                msg = ("Spec 'data': Value with data type %s is being converted to data type %s as specified."
                        % (g.name, s.name))
                 with self.assertWarnsWith(UserWarning, msg):
                     ret = ObjectMapper.convert_dtype(spec, value)
@@ -791,8 +791,8 @@ class TestConvertDtype(TestCase):
                 s = np.dtype(self._get_type(spec_type))
                 e = np.dtype(self._get_type(exp_type))
                 g = np.dtype(self._get_type(dtype))
-                msg = ('Spec /data: Value with data type %s is being converted to data type %s (min specification: %s).'
-                       % (g.name, e.name, s.name))
+                msg = ("Spec 'data': Value with data type %s is being converted to data type %s "
+                       "(min specification: %s)." % (g.name, e.name, s.name))
                 with self.assertWarnsWith(UserWarning, msg):
                     ret = ObjectMapper.convert_dtype(spec, value)
                 self.assertTupleEqual(ret, match)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -763,7 +763,8 @@ class TestConvertDtype(TestCase):
             with self.subTest(dtype=dtype):
                 s = np.dtype(self._get_type(spec_type))
                 g = np.dtype(self._get_type(dtype))
-                msg = 'Value with data type %s is being converted to data type %s as specified.' % (g.name, s.name)
+                msg = ('Spec /data: Value with data type %s is being converted to data type %s as specified.'
+                       % (g.name, s.name))
                 with self.assertWarnsWith(UserWarning, msg):
                     ret = ObjectMapper.convert_dtype(spec, value)
                 self.assertTupleEqual(ret, match)
@@ -790,7 +791,7 @@ class TestConvertDtype(TestCase):
                 s = np.dtype(self._get_type(spec_type))
                 e = np.dtype(self._get_type(exp_type))
                 g = np.dtype(self._get_type(dtype))
-                msg = ('Value with data type %s is being converted to data type %s (min specification: %s).'
+                msg = ('Spec /data: Value with data type %s is being converted to data type %s (min specification: %s).'
                        % (g.name, e.name, s.name))
                 with self.assertWarnsWith(UserWarning, msg):
                     ret = ObjectMapper.convert_dtype(spec, value)

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -209,3 +209,29 @@ class GroupSpecTests(TestCase):
         res = spec.get_attribute('attribute1')
         self.assertEqual(res.value, 5)
         self.assertEqual(res.dtype, 'int')
+
+    def test_path_str(self):
+        GroupSpec('A test group',
+                  name='root_constructor',
+                  groups=self.subgroups,
+                  datasets=self.datasets,
+                  attributes=self.attributes,
+                  linkable=False)
+        self.assertEqual(self.attributes[0].path_str(), '/root_constructor/attribute1')
+        self.assertEqual(self.datasets[0].path_str(), '/root_constructor/dataset1')
+        self.assertEqual(self.subgroups[0].path_str(), '/root_constructor/subgroup1')
+
+    def test_path_str_complicated(self):
+        attribute = AttributeSpec('attribute1', 'my fifth attribute', 'text')
+        dataset = DatasetSpec('my first dataset',
+                              'int',
+                              name='dataset1',
+                              attributes=[attribute])
+        subgroup = GroupSpec('A subgroup',
+                             name='subgroup1',
+                             datasets=[dataset])
+        GroupSpec('A test group',
+                  name='root',
+                  groups=[subgroup])
+
+        self.assertEqual(attribute.path_str(), '/root/subgroup1/dataset1/attribute1')

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -217,9 +217,9 @@ class GroupSpecTests(TestCase):
                   datasets=self.datasets,
                   attributes=self.attributes,
                   linkable=False)
-        self.assertEqual(self.attributes[0].path_str(), '/root_constructor/attribute1')
-        self.assertEqual(self.datasets[0].path_str(), '/root_constructor/dataset1')
-        self.assertEqual(self.subgroups[0].path_str(), '/root_constructor/subgroup1')
+        self.assertEqual(self.attributes[0].path_str(), 'root_constructor/attribute1')
+        self.assertEqual(self.datasets[0].path_str(), 'root_constructor/dataset1')
+        self.assertEqual(self.subgroups[0].path_str(), 'root_constructor/subgroup1')
 
     def test_path_str_complicated(self):
         attribute = AttributeSpec('attribute1', 'my fifth attribute', 'text')
@@ -230,8 +230,23 @@ class GroupSpecTests(TestCase):
         subgroup = GroupSpec('A subgroup',
                              name='subgroup1',
                              datasets=[dataset])
-        GroupSpec('A test group',
-                  name='root',
-                  groups=[subgroup])
+        _ = GroupSpec('A test group',
+                      name='root',
+                      groups=[subgroup])
 
-        self.assertEqual(attribute.path_str(), '/root/subgroup1/dataset1/attribute1')
+        self.assertEqual(attribute.path_str(), 'root/subgroup1/dataset1/attribute1')
+
+    def test_path_str_no_name(self):
+        attribute = AttributeSpec('attribute1', 'my fifth attribute', 'text')
+        dataset = DatasetSpec('my first dataset',
+                              'int',
+                              data_type_inc='DatasetType',
+                              attributes=[attribute])
+        subgroup = GroupSpec('A subgroup',
+                             data_type_def='GroupType',
+                             datasets=[dataset])
+        _ = GroupSpec('A test group',
+                      name='root',
+                      groups=[subgroup])
+
+        self.assertEqual(attribute.path_str(), 'root/GroupType/DatasetType/attribute1')

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -210,18 +210,18 @@ class GroupSpecTests(TestCase):
         self.assertEqual(res.value, 5)
         self.assertEqual(res.dtype, 'int')
 
-    def test_path_str(self):
+    def test_path(self):
         GroupSpec('A test group',
                   name='root_constructor',
                   groups=self.subgroups,
                   datasets=self.datasets,
                   attributes=self.attributes,
                   linkable=False)
-        self.assertEqual(self.attributes[0].path_str(), 'root_constructor/attribute1')
-        self.assertEqual(self.datasets[0].path_str(), 'root_constructor/dataset1')
-        self.assertEqual(self.subgroups[0].path_str(), 'root_constructor/subgroup1')
+        self.assertEqual(self.attributes[0].path, 'root_constructor/attribute1')
+        self.assertEqual(self.datasets[0].path, 'root_constructor/dataset1')
+        self.assertEqual(self.subgroups[0].path, 'root_constructor/subgroup1')
 
-    def test_path_str_complicated(self):
+    def test_path_complicated(self):
         attribute = AttributeSpec('attribute1', 'my fifth attribute', 'text')
         dataset = DatasetSpec('my first dataset',
                               'int',
@@ -230,13 +230,15 @@ class GroupSpecTests(TestCase):
         subgroup = GroupSpec('A subgroup',
                              name='subgroup1',
                              datasets=[dataset])
+        self.assertEqual(attribute.path, 'subgroup1/dataset1/attribute1')
+
         _ = GroupSpec('A test group',
                       name='root',
                       groups=[subgroup])
 
-        self.assertEqual(attribute.path_str(), 'root/subgroup1/dataset1/attribute1')
+        self.assertEqual(attribute.path, 'root/subgroup1/dataset1/attribute1')
 
-    def test_path_str_no_name(self):
+    def test_path_no_name(self):
         attribute = AttributeSpec('attribute1', 'my fifth attribute', 'text')
         dataset = DatasetSpec('my first dataset',
                               'int',
@@ -249,4 +251,4 @@ class GroupSpecTests(TestCase):
                       name='root',
                       groups=[subgroup])
 
-        self.assertEqual(attribute.path_str(), 'root/GroupType/DatasetType/attribute1')
+        self.assertEqual(attribute.path, 'root/GroupType/DatasetType/attribute1')


### PR DESCRIPTION
Fix #306.

Note that this gives the path to the spec value, NOT the container hierarchy. It might not be as intuitive to users as giving the container hierarchy; however, that would require a large amount of refactoring, given how certain functions are currently encapsulated.