### PR TITLE
Explicitly enable Azure pull request builds for all branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,13 @@
 trigger:
 - dev
 
+# 2020-03-12: Azure Pipelines PR triggers not working without this
+# explicitly enable pull request builds for all branches
+pr:
+  branches:
+    include:
+    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
 jobs:
 
 - job: 'Test'


### PR DESCRIPTION
Azure Pipelines is not triggering for PRs in HDMF for some unknown reason. Overriding the YAML pull request trigger from the web interface fixes it, but reverting to using the YAML default pull request trigger makes Azure not trigger again. It would be better to have all of the Azure Pipelines settings in the YAML file, not on an obscure settings page on Azure.

This PR explicitly enable Azure pull request builds for all branches (the default settings) in the *hope* that this will make Azure will work again.