### PR TITLE
Use the numpy dtype in get_type if the array is empty

### DIFF
--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -105,7 +105,10 @@ def get_type(data):
     elif isinstance(data, ReferenceBuilder):
         return 'object'
     elif isinstance(data, np.ndarray):
-        return get_type(data[0])
+        if len(data) > 0:
+            return get_type(data[0])
+        else:
+            return data.dtype
     if not hasattr(data, '__len__'):
         return type(data).__name__
     else:


### PR DESCRIPTION
## Motivation

Fix issue identified in https://github.com/oruebel/ndx-icephys-meta/issues/57 with validating empty datasets. This is triggered in the icephys extension because it may use an empty DynamicTable (with just and id column) resulting in an empty columns dataset. 

## How to test the behavior?

See https://github.com/oruebel/ndx-icephys-meta/issues/57#issuecomment-601448001

## Checklist

- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
