### PR TITLE
Register new child types before new parent type for dynamic cls gen

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -549,7 +549,6 @@ class TypeMap:
                 name = spec.data_type_def
                 if name is None:
                     name = 'Unknown'
-                breakpoint()
                 raise ValueError("Cannot dynamically generate class for type '%s'. " % name
                                  + str(e)
                                  + " Please define that type before defining '%s'." % name)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -384,7 +384,8 @@ class TypeMap:
             container_type = val.get(container_name)
             if container_type is not None:
                 return container_type
-        if container_type is None:
+        if container_type is None:  # pragma: no cover
+            # this code should never happen after hdmf#322
             raise TypeDoesNotExistError("Type '%s' does not exist." % container_name)
 
     def __get_type(self, spec):
@@ -545,7 +546,8 @@ class TypeMap:
                     fields[k] = field_spec
             try:
                 d = self.__get_cls_dict(parent_cls, fields, spec.name, spec.default_name)
-            except TypeDoesNotExistError as e:
+            except TypeDoesNotExistError as e:  # pragma: no cover
+                # this error should never happen after hdmf#322
                 name = spec.data_type_def
                 if name is None:
                     name = 'Unknown'
@@ -793,5 +795,5 @@ class TypeMap:
             return obj_mapper.get_builder_name(container)
 
 
-class TypeDoesNotExistError(Exception):
+class TypeDoesNotExistError(Exception):  # pragma: no cover
     pass

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -347,7 +347,7 @@ class TestDynamicContainer(TestCase):
         with self.assertRaises(TypeError):
             Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0, baz2=bar)
 
-    def test_dynamic_container_composition_wrong_order(self):
+    def test_dynamic_container_composition_reverse_order(self):
         baz_spec2 = GroupSpec('A composition inside', data_type_def='Baz2',
                               data_type_inc=self.bar_spec,
                               attributes=[
@@ -360,12 +360,16 @@ class TestDynamicContainer(TestCase):
                               groups=[GroupSpec('A composition inside', data_type_inc='Baz2')])
         self.spec_catalog.register_spec(baz_spec1, 'extension.yaml')
         self.spec_catalog.register_spec(baz_spec2, 'extension.yaml')
+        Baz1 = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz1')
+        Baz2 = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz2')
+        Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0,
+             baz2=Baz2('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0))
 
-        # Setup all the data we need
-        msg = ("Cannot dynamically generate class for type 'Baz1'. Type 'Baz2' does not exist. "
-               "Please define that type before defining 'Baz1'.")
-        with self.assertRaisesWith(ValueError, msg):
-            self.manager.type_map.get_container_cls(CORE_NAMESPACE, 'Baz1')
+        Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
+        bar = Bar('My Bar', [1, 2, 3, 4], 'string attribute', 1000)
+
+        with self.assertRaises(TypeError):
+            Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0, baz2=bar)
 
 
 class ObjectMapperMixin(metaclass=ABCMeta):

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -371,6 +371,17 @@ class TestDynamicContainer(TestCase):
         with self.assertRaises(TypeError):
             Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0, baz2=bar)
 
+    def test_dynamic_container_composition_missing_type(self):
+        baz_spec1 = GroupSpec('A composition test outside', data_type_def='Baz1', data_type_inc=self.bar_spec,
+                              attributes=[AttributeSpec('attr3', 'an example float attribute', 'float'),
+                                          AttributeSpec('attr4', 'another example float attribute', 'float')],
+                              groups=[GroupSpec('A composition inside', data_type_inc='Baz2')])
+        self.spec_catalog.register_spec(baz_spec1, 'extension.yaml')
+
+        msg = "No specification for 'Baz2' in namespace 'test_core'"
+        with self.assertRaisesWith(ValueError, msg):
+            self.manager.type_map.get_container_cls(CORE_NAMESPACE, 'Baz1')
+
 
 class ObjectMapperMixin(metaclass=ABCMeta):
 


### PR DESCRIPTION
Fixes https://github.com/NeurodataWithoutBorders/pynwb/issues/1210 .

Issue:
An extension defines a new data type that includes a child group or dataset that also defines a new data type. There are no custom classes for either data type. When reading a file with these two extension data types, if the parent data type is encountered before the child data type, then dynamic class generation for the parent data type fails because the child data type does not exist.

In this PR, I changed dynamic class generation so that generating a class for a group data type will first generate classes for all children of the group that lack classes.