### PR TITLE
Allow specfication of custom VectorData types for add_column

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -468,7 +468,8 @@ class DynamicTable(Container):
             {'name': 'table', 'type': (bool, 'DynamicTable'),
              'doc': 'whether or not this is a table region or the table the region applies to', 'default': False},
             {'name': 'index', 'type': (bool, VectorIndex, 'array_data'),
-             'doc': 'whether or not this column should be indexed', 'default': False})
+             'doc': 'whether or not this column should be indexed', 'default': False},
+            {'name': 'colcls', 'type': type, 'doc': 'VectorData class to be used', 'default': None})
     def add_column(self, **kwargs):
         name = getargs('name', kwargs)
         for col in self.__columns__:
@@ -485,7 +486,8 @@ class DynamicTable(Container):
             {'name': 'table', 'type': (bool, 'DynamicTable'),
              'doc': 'whether or not this is a table region or the table the region applies to', 'default': False},
             {'name': 'index', 'type': (bool, VectorIndex, 'array_data'),
-             'doc': 'whether or not this column should be indexed', 'default': False})
+             'doc': 'whether or not this column should be indexed', 'default': False},
+            {'name': 'colcls', 'type': type, 'doc': 'VectorData class to be used', 'default': None})
     def _add_column(self, **kwargs):
         """
         Add a column to this table.
@@ -501,8 +503,9 @@ class DynamicTable(Container):
             msg = "column '%s' already exists in %s '%s'" % (name, self.__class__.__name__, self.name)
             raise ValueError(msg)
 
+        colcls = popargs('colcls', kwargs)
+        cls = VectorData if colcls is None else colcls
         ckwargs = dict(kwargs)
-        cls = VectorData
 
         # Add table if it's been specified
         if table is not False:


### PR DESCRIPTION
## Motivation

Allow users to create derived ``VectorData`` classes and use them with DynamicTable. This came up as a need to implement the column with TimeSeries references as its own type in https://github.com/oruebel/ndx-icephys-meta/issues/60



## Checklist

- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
