### PR TITLE
WIP: Add export functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HDMF Changelog
 
+## HDMF 2.0.0 (Upcoming)
+
+### Internal improvements
+
+#### Breaking changes
+- `Builder` objects no longer have the `written` field which was used by `HDF5IO` to mark the object as written. This
+  is replaced by `HDF5IO.get_written`. @rly (#381)
+
 ## HDMF 1.6.4 (Upcoming)
 
 ### Bug fixes:

--- a/src/hdmf/backends/__init__.py
+++ b/src/hdmf/backends/__init__.py
@@ -26,7 +26,8 @@ def export_container(**kwargs):
     The `container` can be an unwritten Container or a Container read from a source. Unlike HDMFIO.write,
     export_container allows writing Containers to a new destination, regardless of the source of the Container. It does
     this by creating a clean instance of the HDMFIO class in 'w' mode and a BuildManager flagged for exporting using
-    the given TypeMap.
+    the given TypeMap. Arguments can be passed in for the write_io.write method. By default, all external links will be
+    resolved (i.e., the exported file will have no external links).
 
     The 'manager' key is not allowed in `write_io_args` because a new BuildManager will be used.
 
@@ -60,8 +61,8 @@ def export_container(**kwargs):
     supported_export_write_args = write_io_cls.supported_export_write_args()
     for arg in write_args:
         if arg not in supported_export_write_args or write_args[arg] not in supported_export_write_args[arg]:
-            raise ValueError("The argument '%s=%s' in write_args is not supported during export."
-                             % (arg, repr(write_args[arg])))
+            raise NotImplementedError("The argument '%s=%s' in write_args is not supported during export."
+                                      % (arg, repr(write_args[arg])))
 
     export_manager = BuildManager(type_map, export=True)
     write_io_args['manager'] = export_manager
@@ -94,7 +95,8 @@ def export_io(**kwargs):
 
     Similar to the export_container function, except instead of taking a container as input, this function will read
     the container from a source using the given read_io_cls. Arguments can be passed in for the read_io_cls.read and
-    write_io.write methods.
+    write_io.write methods. By default, all external links will be resolved (i.e., the exported file will have no
+    external links).
 
     The 'manager' key is not allowed in `write_io_args` because a new BuildManager will be used.
 

--- a/src/hdmf/backends/__init__.py
+++ b/src/hdmf/backends/__init__.py
@@ -51,8 +51,8 @@ def export_container(**kwargs):
     write_args, keep_external_links = popargs('write_args', 'keep_external_links', kwargs)
 
     if not issubclass(write_io_cls, HDMFIO):
-        raise ValueError("The 'write_io_cls' argument '%s' is not an instance of HDMFIO."
-                         % write_io_cls.__class__.__name__)
+        raise ValueError("The 'write_io_cls' argument '%s' must be a subclass of HDMFIO."
+                         % write_io_cls.__name__)
 
     if 'manager' in write_io_args:
         raise ValueError("The 'manager' key is not allowed in write_io_args because a new BuildManager will be used.")
@@ -107,14 +107,19 @@ def export_io(**kwargs):
             read_io_cls=HDF5IO,
             write_io_cls=HDF5IO,
             type_map=type_map,
-            read_io_args={'path': 'in.h5'},
+            read_io_args={'path': 'in.h5', 'mode': 'r', 'manager': manager},
             read_args={},
-            write_io_args={'path': 'out.h5'},
+            write_io_args={'path': 'out.h5', 'mode': 'w'},
             write_args={'cache_spec': False},
             keep_external_links=True,
         )
     """
     read_io_cls, read_io_args, read_args = popargs('read_io_cls', 'read_io_args', 'read_args', kwargs)
+
+    if not issubclass(read_io_cls, HDMFIO):
+        raise ValueError("The 'read_io_cls' argument '%s' must be a subclass of HDMFIO."
+                         % read_io_cls.__name__)
+
     with read_io_cls(**read_io_args) as read_io:
         container = read_io.read(**read_args)
         export_container(container=container, **kwargs)

--- a/src/hdmf/backends/__init__.py
+++ b/src/hdmf/backends/__init__.py
@@ -1,1 +1,107 @@
+from ..utils import docval, popargs
+from ..container import Container
+from ..build import BuildManager, TypeMap
+
 from . import hdf5
+
+
+@docval({'name': 'container', 'type': Container, 'doc': 'the Container to export'},
+        {'name': 'write_io_cls', 'type': type, 'doc': 'a subclass of HDMFIO to use for exporting the file'},
+        {'name': 'type_map', 'type': TypeMap, 'doc': 'the TypeMap to use'},
+        {'name': 'write_io_args', 'type': dict,
+         'doc': 'dict of arguments to use when initializing a new instance of class write_io_cls',
+         'default': dict()},
+        {'name': 'write_args', 'type': dict, 'doc': 'dict of arguments to use when calling write_io.write',
+         'default': dict()},
+        {'name': 'keep_external_links', 'type': bool,
+         'doc': ('whether to preserve links to external files. If False (default), all external links will be '
+                 'resolved. This flag depends on support from the write_io_cls class'),
+         'default': False})
+def export_container(**kwargs):
+    """
+    Export the container to a new destination using the given HDF5IO class.
+
+    The `container` can be an unwritten Container or a Container read from a source. Unlike HDMFIO.write,
+    export_container allows writing Containers to a new destination, regardless of the source of the Container. It does
+    this by creating a clean instance of the HDMFIO class in 'w' mode and a BuildManager flagged for exporting using
+    the given TypeMap.
+
+    The 'manager' key is not allowed in `write_io_args` because a new BuildManager will be used.
+
+    Some arguments in `write_args` may not be supported during export.
+
+    Example usage:
+
+        # export container to out.h5 without caching the spec and with keeping external links
+        export_container(
+            container=container,
+            write_io_cls=HDF5IO,
+            type_map=type_map,
+            write_io_args={'path': 'out.h5'},
+            write_args={'cache_spec': False},
+            keep_external_links=True,
+        )
+    """
+    # NOTE: this function is designed to prevent users from accessing the HDMFIO or BuildManager instances created
+    # during export, which could lead to unintended behavior
+    container, type_map = popargs('container', 'type_map', kwargs)
+    write_io_cls, write_io_args = popargs('write_io_cls', 'write_io_args', kwargs)
+    write_args, keep_external_links = popargs('write_args', 'keep_external_links', kwargs)
+
+    if 'manager' in write_io_args:
+        raise ValueError("The 'manager' key is not allowed in write_io_args because a new BuildManager will be used.")
+
+    export_manager = BuildManager(type_map, export=True)
+    write_io_args['manager'] = export_manager
+    with write_io_cls(**write_io_args) as write_io:
+        write_io.write(container=container, **write_args)
+
+
+@docval({'name': 'read_io_cls', 'type': type, 'doc': 'a subclass of HDMFIO to use for opening a source'},
+        {'name': 'write_io_cls', 'type': type, 'doc': 'a subclass of HDMFIO to use for exporting'},
+        {'name': 'type_map', 'type': TypeMap, 'doc': 'the TypeMap to use'},
+        {'name': 'read_io_args', 'type': dict,
+         'doc': 'dict of arguments to use when initializing a new instance of class read_io_cls',
+         'default': dict()},
+        {'name': 'read_args', 'type': dict,
+         'doc': 'dict of arguments to use when calling read_io.read',
+         'default': dict()},
+        {'name': 'write_io_args', 'type': dict,
+         'doc': 'dict of arguments to use when initializing a new instance of class write_io_cls',
+         'default': dict()},
+        {'name': 'write_args', 'type': dict, 'doc': 'dict of arguments to use when calling write_io.write',
+         'default': dict()},
+        {'name': 'keep_external_links', 'type': bool,
+         'doc': ('whether to preserve links to external files. If False (default), all external links will be '
+                 'resolved. This flag depends on support from the write_io_cls class'),
+         'default': False})
+def export_io(**kwargs):
+    """
+    Export from one HDMFIO class to another with the given arguments.
+
+    Similar to the export_container function, except this function will read the contents of a source using the given
+    read_io_cls and export those contents to a new destination. Arguments can be passed in for the read_io_cls.read and
+    write_io.write methods.
+
+    The 'manager' key is not allowed in `write_io_args` because a new BuildManager will be used.
+
+    Some arguments in `write_args` may not be supported during export.
+
+    Example usage:
+
+        # export the contents of in.h5 to out.h5 without caching the spec and with keeping external links
+        export_io(
+            read_io_cls=HDF5IO,
+            write_io_cls=HDF5IO,
+            type_map=type_map,
+            read_io_args={'path': 'in.h5'},
+            read_args={},
+            write_io_args={'path': 'out.h5'},
+            write_args={'cache_spec': False},
+            keep_external_links=True,
+        )
+    """
+    read_io_cls, read_io_args, read_args = popargs('read_io_cls', 'read_io_args', 'read_args', kwargs)
+    read_io = read_io_cls(**read_io_args)
+    container = read_io.read(**read_args)
+    export_container(container=container, **kwargs)

--- a/src/hdmf/backends/__init__.py
+++ b/src/hdmf/backends/__init__.py
@@ -92,8 +92,8 @@ def export_io(**kwargs):
     """
     Export from one HDMFIO class to another with the given arguments.
 
-    Similar to the export_container function, except this function will read the contents of a source using the given
-    read_io_cls and export those contents to a new destination. Arguments can be passed in for the read_io_cls.read and
+    Similar to the export_container function, except instead of taking a container as input, this function will read
+    the container from a source using the given read_io_cls. Arguments can be passed in for the read_io_cls.read and
     write_io.write methods.
 
     The 'manager' key is not allowed in `write_io_args` because a new BuildManager will be used.
@@ -115,6 +115,6 @@ def export_io(**kwargs):
         )
     """
     read_io_cls, read_io_args, read_args = popargs('read_io_cls', 'read_io_args', 'read_args', kwargs)
-    read_io = read_io_cls(**read_io_args)
-    container = read_io.read(**read_args)
-    export_container(container=container, **kwargs)
+    with read_io_cls(**read_io_args) as read_io:
+        container = read_io.read(**read_args)
+        export_container(container=container, **kwargs)

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -67,15 +67,15 @@ class DatasetOfReferences(H5Dataset, ReferenceResolver, metaclass=ABCMeta):
             self.__inverted = cls(**kwargs)
         return self.__inverted
 
-    def __get_ref(self, ref):
+    def _get_ref(self, ref):
         return self.get_object(self.dataset.file[ref])
 
     def __iter__(self):
         for ref in super().__iter__():
-            yield self.__get_ref(ref)
+            yield self._get_ref(ref)
 
     def __next__(self):
-        return self.__get_ref(super().__next__())
+        return self._get_ref(super().__next__())
 
 
 class BuilderResolverMixin(BuilderResolver):
@@ -118,7 +118,7 @@ class AbstractH5TableDataset(DatasetOfReferences):
             if t is RegionReference:
                 self.__refgetters[i] = self.__get_regref
             elif t is Reference:
-                self.__refgetters[i] = self.__get_ref
+                self.__refgetters[i] = self._get_ref
         self.__types = types
         tmp = list()
         for i in range(len(self.dataset.dtype)):
@@ -163,7 +163,7 @@ class AbstractH5TableDataset(DatasetOfReferences):
             row[i] = getref(row[i])
 
     def __get_regref(self, ref):
-        obj = self.__get_ref(ref)
+        obj = self._get_ref(ref)
         return obj[ref]
 
     def resolve(self, manager):
@@ -175,9 +175,9 @@ class AbstractH5ReferenceDataset(DatasetOfReferences):
     def __getitem__(self, arg):
         ref = super().__getitem__(arg)
         if isinstance(ref, np.ndarray):
-            return [self.get_object(self.dataset.file[x]) for x in ref]
+            return [self._get_ref(x) for x in ref]
         else:
-            return self.get_object(self.dataset.file[ref])
+            return self._get_ref(ref)
 
     @property
     def dtype(self):

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -67,6 +67,16 @@ class DatasetOfReferences(H5Dataset, ReferenceResolver, metaclass=ABCMeta):
             self.__inverted = cls(**kwargs)
         return self.__inverted
 
+    def __get_ref(self, ref):
+        return self.get_object(self.dataset.file[ref])
+
+    def __iter__(self):
+        for ref in super().__iter__():
+            yield self.__get_ref(ref)
+
+    def __next__(self):
+        return self.__get_ref(super().__next__())
+
 
 class BuilderResolverMixin(BuilderResolver):
     """
@@ -151,9 +161,6 @@ class AbstractH5TableDataset(DatasetOfReferences):
         for i in self.__refgetters:
             getref = self.__refgetters[i]
             row[i] = getref(row[i])
-
-    def __get_ref(self, ref):
-        return self.get_object(self.dataset.file[ref])
 
     def __get_regref(self, ref):
         obj = self.__get_ref(ref)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -72,6 +72,7 @@ class HDF5IO(HDMFIO):
         self.__ref_queue = deque()  # a queue of the references that need to be added
         self.__dci_queue = deque()  # a queue of DataChunkIterators that need to be exhausted
         ObjectMapper.no_convert(Dataset)
+        self._written_builders = dict()  # keep track of which builders were written (or read) by this IO object
 
     @property
     def comm(self):
@@ -344,6 +345,21 @@ class HDF5IO(HDMFIO):
             self.__read[self.__file] = f_builder
         return f_builder
 
+    def set_written(self, builder):
+        """Mark this builder as written."""
+        # currently all values in self._written_builders are True, so this could be a set but is a dict for
+        # future flexibility
+        builder_id = self.__bldrhash__(builder)
+        self._written_builders[builder_id] = True
+
+    def get_written(self, builder):
+        """Return True if this builder has been written to (or read from) disk by this IO object."""
+        builder_id = self.__bldrhash__(builder)
+        return self._written_builders.get(builder_id, False)
+
+    def __bldrhash__(self, obj):
+        return id(obj)
+
     def __set_built(self, fpath, id, builder):
         """
         Update self.__built to cache the given builder for the given file and id.
@@ -440,7 +456,7 @@ class HDF5IO(HDMFIO):
                         self.__set_built(sub_h5obj.file.filename,  sub_h5obj.file[target_path].id, builder)
                     builder.location = parent_loc
                     link_builder = LinkBuilder(builder, k, source=h5obj.file.filename)
-                    link_builder.written = True
+                    self.set_written(link_builder)
                     kwargs['links'][builder_name] = link_builder
                 else:
                     builder = self.__get_built(sub_h5obj.file.filename, sub_h5obj.id)
@@ -462,7 +478,7 @@ class HDF5IO(HDMFIO):
                 continue
         kwargs['source'] = h5obj.file.filename
         ret = GroupBuilder(name, **kwargs)
-        ret.written = True
+        self.set_written(ret)
         return ret
 
     def __read_dataset(self, h5obj, name=None):
@@ -515,7 +531,7 @@ class HDF5IO(HDMFIO):
         else:
             kwargs["data"] = h5obj
         ret = DatasetBuilder(name, **kwargs)
-        ret.written = True
+        self.set_written(ret)
         return ret
 
     def __read_attrs(self, h5obj):
@@ -573,6 +589,7 @@ class HDF5IO(HDMFIO):
         self.set_attributes(self.__file, f_builder.attributes)
         self.__add_refs()
         self.__exhaust_dcis()
+        self.set_written(f_builder)
 
     def __add_refs(self):
         '''
@@ -726,8 +743,10 @@ class HDF5IO(HDMFIO):
     def write_group(self, **kwargs):
         parent, builder, exhaust_dci = getargs('parent', 'builder', 'exhaust_dci', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             group = parent[builder.name]
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write group '%s' because it already exists." % self.__get_path(builder))
         else:
             group = parent.create_group(builder.name)
         # write all groups
@@ -748,7 +767,7 @@ class HDF5IO(HDMFIO):
                 self.write_link(group, sub_builder)
         attributes = builder.attributes
         self.set_attributes(group, attributes)
-        builder.written = True
+        self.set_written(builder)
         return group
 
     def __get_path(self, builder):
@@ -767,8 +786,10 @@ class HDF5IO(HDMFIO):
     def write_link(self, **kwargs):
         parent, builder = getargs('parent', 'builder', kwargs)
         self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             return None
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write link '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         target_builder = builder.builder
         path = self.__get_path(target_builder)
@@ -790,7 +811,7 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        builder.written = True
+        self.set_written(builder)
         return link_obj
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
@@ -808,8 +829,10 @@ class HDF5IO(HDMFIO):
         """
         parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
         self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             return None
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write dataset '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         data = builder.data
         options = dict()   # dict with additional
@@ -860,7 +883,7 @@ class HDF5IO(HDMFIO):
                     msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)
                     raise Exception(msg) from exc
                 dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
-                builder.written = True
+                self.set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing references. attributes: %s"
                                   % (name, list(attributes.keys())))
 
@@ -884,10 +907,10 @@ class HDF5IO(HDMFIO):
         # NOTE: we can ignore options['io_settings'] for scalar data
         elif self.__is_ref(options['dtype']):
             _dtype = self.__dtypes.get(options['dtype'])
+            self.set_written(builder)
             # Write a scalar data region reference dataset
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
-                builder.written = True
                 self.logger.debug("Queueing set attribute on dataset '%s' containing a region reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -900,7 +923,6 @@ class HDF5IO(HDMFIO):
             # Write a scalar object reference dataset
             elif isinstance(data, ReferenceBuilder):
                 dset = parent.require_dataset(name, dtype=_dtype, shape=())
-                builder.written = True
                 self.logger.debug("Queueing set attribute on dataset '%s' containing an object reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -915,7 +937,6 @@ class HDF5IO(HDMFIO):
                 # Write a array of region references
                 if options['dtype'] == 'region':
                     dset = parent.require_dataset(name, dtype=_dtype, shape=(len(data),), **options['io_settings'])
-                    builder.written = True
                     self.logger.debug("Queueing set attribute on dataset '%s' containing region references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 
@@ -929,8 +950,7 @@ class HDF5IO(HDMFIO):
                         self.set_attributes(dset, attributes)
                 # Write array of object references
                 else:
-                    dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, ** options['io_settings'])
-                    builder.written = True
+                    dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
                     self.logger.debug("Queueing set attribute on dataset '%s' containing object references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 
@@ -964,10 +984,9 @@ class HDF5IO(HDMFIO):
         # Validate the attributes on the linked dataset
         elif len(attributes) > 0:
             pass
-        builder.written = True
+        self.set_written(builder)
         if exhaust_dci:
             self.__exhaust_dcis()
-        return
 
     @classmethod
     def __scalar_fill__(cls, parent, name, data, options=None):
@@ -1202,3 +1221,7 @@ class HDF5IO(HDMFIO):
         Return the HDF5 file mode. One of ("w", "r", "r+", "a", "w-", "x").
         """
         return self.__mode
+
+
+class WriteError(Exception):
+    pass

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -431,6 +431,13 @@ class HDF5IO(HDMFIO):
     #     cls.export(container=container, type_map=io.type_map, path=path, comm=comm, write_args=write_args)
 
     def read(self, **kwargs):
+        """Short summary.
+
+        :param type **kwargs: Description of parameter `**kwargs`.
+        :return: Description of returned object.
+        :rtype: type
+
+        """
         if self.__mode == 'w' or self.__mode == 'w-' or self.__mode == 'x':
             raise UnsupportedOperation("Cannot read from file %s in mode '%s'. Please use mode 'r', 'r+', or 'a'."
                                        % (self.__path, self.__mode))

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -561,7 +561,7 @@ class HDF5IO(HDMFIO):
         '''
         failed = set()
         print('__ref_queue', len(self.__ref_queue))
-        breakpoint()
+        # breakpoint()
         while len(self.__ref_queue) > 0:
             call = self.__ref_queue.popleft()
             try:
@@ -670,8 +670,8 @@ class HDF5IO(HDMFIO):
                 obj.attrs[key] = value
             elif isinstance(value, (Container, Builder, ReferenceBuilder)):           # a reference
                 print('setting attribute container, builder, referencebuilder', obj.name)
-                if obj.name == '/units/electrodes':
-                    breakpoint()
+                # if obj.name == '/units/electrodes':
+                #     breakpoint()
                 self.__queue_ref(self._make_attr_ref_filler(obj, key, value))
             else:
                 obj.attrs[key] = value                   # a regular scalar
@@ -1110,8 +1110,8 @@ class HDF5IO(HDMFIO):
             builder = self.manager.build(container)
         path = self.__get_path(builder)
         print(path, builder.name)
-        if path == '/electrodes':
-            breakpoint()
+        # if path == '/electrodes':
+        #     breakpoint()
         if isinstance(container, RegionBuilder):
             region = container.region
         if region is not None:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -727,13 +727,13 @@ class HDF5IO(HDMFIO):
                         self.__queue_ref(self._make_attr_ref_filler(obj, key, tmp))
                     else:
                         value = np.array(value)
-                self.logger.debug("Setting attribute on %s '%s' attribute '%s' to %s"
+                self.logger.debug("Setting %s '%s' attribute '%s' to %s"
                                   % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
                 obj.attrs[key] = value
             elif isinstance(value, (Container, Builder, ReferenceBuilder)):           # a reference
                 self.__queue_ref(self._make_attr_ref_filler(obj, key, value))
             else:
-                self.logger.debug("Setting attribute on %s '%s' attribute '%s' to %s"
+                self.logger.debug("Setting %s '%s' attribute '%s' to %s"
                                   % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
                 obj.attrs[key] = value                   # a regular scalar
 
@@ -741,7 +741,7 @@ class HDF5IO(HDMFIO):
         '''
             Make the callable for setting references to attributes
         '''
-        self.logger.debug("Queueing set attribute on %s '%s' attribute '%s' to %s"
+        self.logger.debug("Queueing set %s '%s' attribute '%s' to %s"
                           % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
         if isinstance(value, (tuple, list)):
             def _filler():
@@ -763,7 +763,7 @@ class HDF5IO(HDMFIO):
             returns='the Group that was created', rtype='Group')
     def write_group(self, **kwargs):
         parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
-        self.logger.debug("Writing group builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             group = parent[builder.name]
         else:
@@ -804,7 +804,7 @@ class HDF5IO(HDMFIO):
             returns='the Link that was created', rtype='Link')
     def write_link(self, **kwargs):
         parent, builder = getargs('parent', 'builder', kwargs)
-        self.logger.debug("Writing link builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             return None
         name = builder.name
@@ -824,6 +824,8 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
+        self.logger.debug("    Created %s '%s/%s' to '%s://%s'"
+                          % (link_obj.__class__.__name__, parent.name, name, link_obj.filename, link_obj.path))
         builder.written = True
         return link_obj
 
@@ -841,7 +843,7 @@ class HDF5IO(HDMFIO):
         __scalar_fill__, __list_fill__ and __setup_chunked_dset__ to write the data.
         """
         parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
-        self.logger.debug("Writing dataset builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             return None
         name = builder.name

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -329,7 +329,14 @@ class HDF5IO(HDMFIO):
             {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
              'default': dict()})
     def export(cls, **kwargs):
-        ''' Export the given container using this IO object initialized with the given arguments '''
+        '''
+        Export the given container to a new destination using a clean instance of this HDF5IO class.
+
+        If Container objects were read from file, then HDF5IO.write supports writing changes to the Containers
+        back to the same file, but not to a new file. HDF5IO.export allows writing Containers to a new destination,
+        regardless of the origin of the Container. It does this by creating a clean instance of this HDF5IO class in
+        'w' mode and a clean BuildManager using the same TypeMap.
+        '''
         container, type_map, path, comm, write_args = popargs('container', 'type_map', 'path', 'comm', 'write_args',
                                                               kwargs)
         if 'link_data' in write_args:
@@ -351,7 +358,20 @@ class HDF5IO(HDMFIO):
             {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
              'default': dict()})
     def export_io(cls, **kwargs):
-        ''' Export data from the given IO object using this IO object initialized with the given arguments '''
+        '''
+        Export the container read from the given HDF5IO object to a new destination using a clean instance of this
+        HDF5IO class.
+
+        Similar to the export method, except this method takes care of reading the container from the given HDF5IO
+        object first. Arguments can be passed in for the io.read and write_io.write methods.
+
+        Example usage:
+
+            # create a new HDF5IO object for reading a file and export its contents to a new HDF5 file
+            with HDF5IO('in_file.h5', 'r') as io:
+                HDF5IO.export_io(io=io, path='out_file.h5')
+
+        '''
         io, path, comm, read_args, write_args = popargs('io', 'path', 'comm', 'read_args', 'write_args', kwargs)
         container = io.read(**read_args)
         cls.export(container=container, type_map=io.type_map, path=path, comm=comm, write_args=write_args)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -833,6 +833,8 @@ class HDF5IO(HDMFIO):
         # source will indicate target_builder's location
         if parent.file.filename == target_builder.source:
             link_obj = SoftLink(path)
+            self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
+                              % (parent.name, name, link_obj.path))
         elif target_builder.source is not None:
             target_filename = os.path.abspath(target_builder.source)
             parent_filename = os.path.abspath(parent.file.filename)
@@ -840,12 +842,12 @@ class HDF5IO(HDMFIO):
             if target_builder.location is not None:
                 path = target_builder.location + path
             link_obj = ExternalLink(relative_path, path)
+            self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
+                              % (parent.name, name, link_obj.filename, link_obj.path))
         else:
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        self.logger.debug("    Created %s '%s/%s' to '%s://%s'"
-                          % (link_obj.__class__.__name__, parent.name, name, link_obj.filename, link_obj.path))
         builder.written = True
         return link_obj
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -332,13 +332,14 @@ class HDF5IO(HDMFIO):
         ''' Export the given container using this IO object initialized with the given arguments '''
         container, type_map, path, comm, write_args = popargs('container', 'type_map', 'path', 'comm', 'write_args',
                                                               kwargs)
-        temp_manager = BuildManager(type_map, export=True)
-        write_io = cls(path=path, mode='w', manager=temp_manager, comm=comm)
         if 'link_data' in write_args:
             link_data = popargs('link_data', write_args)
             if link_data:
                 raise ValueError('Exporting requires link_data to be False')
-        write_io.write(container, link_data=False, **write_args)
+
+        temp_manager = BuildManager(type_map, export=True)
+        with cls(path=path, mode='w', manager=temp_manager, comm=comm) as write_io:
+            write_io.write(container, link_data=False, **write_args)
 
     @classmethod
     @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -302,14 +302,12 @@ class HDF5IO(HDMFIO):
             {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
             {'name': 'comm', 'type': 'Intracomm',
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
-            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
-             'default': dict()},
             {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
              'default': dict()})
     def export(cls, **kwargs):
         ''' Export the given container using this IO object initialized with the given arguments '''
-        container, type_map, path, comm, read_args, write_args = popargs('container', 'type_map', 'path', 'comm',
-                                                                         'read_args', 'write_args', kwargs)
+        container, type_map, path, comm, write_args = popargs('container', 'type_map', 'path', 'comm', 'write_args',
+                                                              kwargs)
         temp_manager = BuildManager(type_map, export=True)
         write_io = cls(path=path, mode='w', manager=temp_manager, comm=comm)
         if 'link_data' in write_args:
@@ -317,6 +315,21 @@ class HDF5IO(HDMFIO):
             if link_data:
                 raise ValueError('Exporting requires link_data to be False')
         write_io.write(container, link_data=False, **write_args)
+
+    @classmethod
+    @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},
+            {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
+            {'name': 'comm', 'type': 'Intracomm',
+             'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
+            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
+             'default': dict()},
+            {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
+             'default': dict()})
+    def export_io(cls, **kwargs):
+        ''' Export data from the given IO object using this IO object initialized with the given arguments '''
+        io, path, comm, read_args, write_args = popargs('io', 'path', 'comm', 'read_args', 'write_args', kwargs)
+        container = io.read(**read_args)
+        cls.export(container=container, type_map=io.type_map, path=path, comm=comm, write_args=write_args)
 
     def read(self, **kwargs):
         if self.__mode == 'w' or self.__mode == 'w-' or self.__mode == 'x':

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1221,7 +1221,3 @@ class HDF5IO(HDMFIO):
         Return the HDF5 file mode. One of ("w", "r", "r+", "a", "w-", "x").
         """
         return self.__mode
-
-
-class WriteError(Exception):
-    pass

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -757,8 +757,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             group = parent[builder.name]
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write group '%s' because it already exists." % self.__get_path(builder))
         else:
             group = parent.create_group(builder.name)
         # write all groups
@@ -800,8 +798,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             return None
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write link '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         target_builder = builder.builder
         path = self.__get_path(target_builder)
@@ -843,8 +839,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             return None
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write dataset '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         data = builder.data
         options = dict()   # dict with additional

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -541,9 +541,9 @@ class HDF5IO(HDMFIO):
     def write_builder(self, **kwargs):
         f_builder, link_data, exhaust_dci = getargs('builder', 'link_data', 'exhaust_dci', kwargs)
         for name, gbldr in f_builder.groups.items():
-            self.write_group(self.__file, gbldr, exhaust_dci=exhaust_dci)
+            self.write_group(self.__file, gbldr, link_data=link_data, exhaust_dci=exhaust_dci)
         for name, dbldr in f_builder.datasets.items():
-            self.write_dataset(self.__file, dbldr, link_data, exhaust_dci=exhaust_dci)
+            self.write_dataset(self.__file, dbldr, link_data=link_data, exhaust_dci=exhaust_dci)
         for name, lbldr in f_builder.links.items():
             self.write_link(self.__file, lbldr)
         self.set_attributes(self.__file, f_builder.attributes)
@@ -686,12 +686,13 @@ class HDF5IO(HDMFIO):
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
             {'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder to write'},
+            {'name': 'link_data', 'type': bool,
+             'doc': 'If not specified otherwise link (True) or copy (False) HDF5 Datasets', 'default': True},
             {'name': 'exhaust_dci', 'type': bool,
              'doc': 'exhaust DataChunkIterators one at a time. If False, exhaust them concurrently', 'default': True},
             returns='the Group that was created', rtype='Group')
     def write_group(self, **kwargs):
-
-        parent, builder, exhaust_dci = getargs('parent', 'builder', 'exhaust_dci', kwargs)
+        parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
         if builder.written:
             group = parent[builder.name]
         else:
@@ -701,12 +702,12 @@ class HDF5IO(HDMFIO):
         if subgroups:
             for subgroup_name, sub_builder in subgroups.items():
                 # do not create an empty group without attributes or links
-                self.write_group(group, sub_builder, exhaust_dci=exhaust_dci)
+                self.write_group(group, sub_builder, link_data=link_data, exhaust_dci=exhaust_dci)
         # write all datasets
         datasets = builder.datasets
         if datasets:
             for dset_name, sub_builder in datasets.items():
-                self.write_dataset(group, sub_builder, exhaust_dci=exhaust_dci)
+                self.write_dataset(group, sub_builder, link_data=link_data, exhaust_dci=exhaust_dci)
         # write all links
         links = builder.links
         if links:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -560,11 +560,14 @@ class HDF5IO(HDMFIO):
         will be references, and then write them after we write everything else.
         '''
         failed = set()
+        print('__ref_queue', len(self.__ref_queue))
+        breakpoint()
         while len(self.__ref_queue) > 0:
             call = self.__ref_queue.popleft()
             try:
                 call()
             except KeyError:
+                print('KeyError')
                 if id(call) in failed:
                     raise RuntimeError('Unable to resolve reference')
                 failed.add(id(call))
@@ -660,11 +663,15 @@ class HDF5IO(HDMFIO):
                     elif isinstance(tmp[0], bytes):
                         value = [np.string_(s) for s in tmp]
                     elif isinstance(tmp[0], Container):  # a list of references
+                        print('adding list of references', obj.name)
                         self.__queue_ref(self._make_attr_ref_filler(obj, key, tmp))
                     else:
                         value = np.array(value)
                 obj.attrs[key] = value
             elif isinstance(value, (Container, Builder, ReferenceBuilder)):           # a reference
+                print('setting attribute container, builder, referencebuilder', obj.name)
+                if obj.name == '/units/electrodes':
+                    breakpoint()
                 self.__queue_ref(self._make_attr_ref_filler(obj, key, value))
             else:
                 obj.attrs[key] = value                   # a regular scalar
@@ -784,6 +791,7 @@ class HDF5IO(HDMFIO):
         options['dtype'] = builder.dtype
         dset = None
         link = None
+        print('    writing hdf5 dataset', builder.name, link_data, type(data))
 
         # The user provided an existing h5py dataset as input and asked to create a link to the dataset
         if isinstance(data, Dataset):
@@ -822,6 +830,7 @@ class HDF5IO(HDMFIO):
                     raise Exception(msg) from exc
                 dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
                 builder.written = True
+                print('writing compound dataset', name)
 
                 @self.__queue_ref
                 def _filler():
@@ -846,6 +855,7 @@ class HDF5IO(HDMFIO):
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
                 builder.written = True
+                print('writing scalar region reference dataset', name)
 
                 @self.__queue_ref
                 def _filler():
@@ -857,6 +867,7 @@ class HDF5IO(HDMFIO):
             elif isinstance(data, ReferenceBuilder):
                 dset = parent.require_dataset(name, dtype=_dtype, shape=())
                 builder.written = True
+                print('writing scalar object reference dataset', name)
 
                 @self.__queue_ref
                 def _filler():
@@ -870,6 +881,7 @@ class HDF5IO(HDMFIO):
                 if options['dtype'] == 'region':
                     dset = parent.require_dataset(name, dtype=_dtype, shape=(len(data),), **options['io_settings'])
                     builder.written = True
+                    print('writing array of region references dataset', name)
 
                     @self.__queue_ref
                     def _filler():
@@ -883,6 +895,7 @@ class HDF5IO(HDMFIO):
                 else:
                     dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, ** options['io_settings'])
                     builder.written = True
+                    print('writing array of object references dataset', name)
 
                     @self.__queue_ref
                     def _filler():
@@ -1096,6 +1109,9 @@ class HDF5IO(HDMFIO):
         else:
             builder = self.manager.build(container)
         path = self.__get_path(builder)
+        print(path, builder.name)
+        if path == '/electrodes':
+            breakpoint()
         if isinstance(container, RegionBuilder):
             region = container.region
         if region is not None:
@@ -1129,6 +1145,7 @@ class HDF5IO(HDMFIO):
         # TODO: come up with more intelligent way of
         # queueing reference resolution, based on reference
         # dependency
+        print('add queue ref', func)
         self.__ref_queue.append(func)
 
     def __rec_get_ref(self, l):

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -345,19 +345,31 @@ class HDF5IO(HDMFIO):
             self.__read[self.__file] = f_builder
         return f_builder
 
-    def set_written(self, builder):
-        """Mark this builder as written."""
+    def __set_written(self, builder):
+        """
+        Mark this builder as written.
+
+        :param builder: Builder object to be marked as written
+        :type builder: Builder
+        """
         # currently all values in self._written_builders are True, so this could be a set but is a dict for
         # future flexibility
         builder_id = self.__bldrhash__(builder)
         self._written_builders[builder_id] = True
 
     def get_written(self, builder):
-        """Return True if this builder has been written to (or read from) disk by this IO object."""
+        """Return True if this builder has been written to (or read from) disk by this IO object, False otherwise.
+
+        :param builder: Builder object to get the written flag for
+        :type builder: Builder
+
+        :return: True if the builder is found in self._written_builders using the builder ID, False otherwise
+        """
         builder_id = self.__bldrhash__(builder)
         return self._written_builders.get(builder_id, False)
 
     def __bldrhash__(self, obj):
+        """Return the ID of a builder for use as a unique hash."""
         return id(obj)
 
     def __set_built(self, fpath, id, builder):
@@ -456,7 +468,7 @@ class HDF5IO(HDMFIO):
                         self.__set_built(sub_h5obj.file.filename,  sub_h5obj.file[target_path].id, builder)
                     builder.location = parent_loc
                     link_builder = LinkBuilder(builder, k, source=h5obj.file.filename)
-                    self.set_written(link_builder)
+                    self.__set_written(link_builder)
                     kwargs['links'][builder_name] = link_builder
                 else:
                     builder = self.__get_built(sub_h5obj.file.filename, sub_h5obj.id)
@@ -478,7 +490,7 @@ class HDF5IO(HDMFIO):
                 continue
         kwargs['source'] = h5obj.file.filename
         ret = GroupBuilder(name, **kwargs)
-        self.set_written(ret)
+        self.__set_written(ret)
         return ret
 
     def __read_dataset(self, h5obj, name=None):
@@ -531,7 +543,7 @@ class HDF5IO(HDMFIO):
         else:
             kwargs["data"] = h5obj
         ret = DatasetBuilder(name, **kwargs)
-        self.set_written(ret)
+        self.__set_written(ret)
         return ret
 
     def __read_attrs(self, h5obj):
@@ -589,7 +601,7 @@ class HDF5IO(HDMFIO):
         self.set_attributes(self.__file, f_builder.attributes)
         self.__add_refs()
         self.__exhaust_dcis()
-        self.set_written(f_builder)
+        self.__set_written(f_builder)
 
     def __add_refs(self):
         '''
@@ -767,7 +779,7 @@ class HDF5IO(HDMFIO):
                 self.write_link(group, sub_builder)
         attributes = builder.attributes
         self.set_attributes(group, attributes)
-        self.set_written(builder)
+        self.__set_written(builder)
         return group
 
     def __get_path(self, builder):
@@ -811,7 +823,7 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        self.set_written(builder)
+        self.__set_written(builder)
         return link_obj
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
@@ -883,7 +895,7 @@ class HDF5IO(HDMFIO):
                     msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)
                     raise Exception(msg) from exc
                 dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
-                self.set_written(builder)
+                self.__set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing references. attributes: %s"
                                   % (name, list(attributes.keys())))
 
@@ -907,7 +919,7 @@ class HDF5IO(HDMFIO):
         # NOTE: we can ignore options['io_settings'] for scalar data
         elif self.__is_ref(options['dtype']):
             _dtype = self.__dtypes.get(options['dtype'])
-            self.set_written(builder)
+            self.__set_written(builder)
             # Write a scalar data region reference dataset
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
@@ -984,7 +996,7 @@ class HDF5IO(HDMFIO):
         # Validate the attributes on the linked dataset
         elif len(attributes) > 0:
             pass
-        self.set_written(builder)
+        self.__set_written(builder)
         if exhaust_dci:
             self.__exhaust_dcis()
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -349,33 +349,86 @@ class HDF5IO(HDMFIO):
         with cls(path=path, mode='w', manager=temp_manager, comm=comm) as write_io:
             write_io.write(container, link_data=False, **write_args)
 
-    @classmethod
-    @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},
-            {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
-            {'name': 'comm', 'type': 'Intracomm',
-             'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
-            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
-             'default': dict()},
-            {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
-             'default': dict()})
-    def export_io(cls, **kwargs):
-        '''
-        Export the container read from the given HDF5IO object to a new destination using a clean instance of this
-        HDF5IO class.
-
-        Similar to the export method, except this method takes care of reading the container from the given HDF5IO
-        object first. Arguments can be passed in for the io.read and write_io.write methods.
-
+    # module level function
+    @docval({'name': 'readio', 'type': type, 'doc': 'x'},
+            {'name': 'writeio', 'type': type, 'doc': 'x'},
+            {'name': 'type_map', 'type': type, 'doc': 'x'},
+            {'name': 'readio_args', 'type': dict, 'doc': 'x', 'default': dict()},
+            {'name': 'writeio_args', 'type': dict, 'doc': 'x', 'default': dict()},
+            {'name': 'read_args', 'type': dict, 'doc': 'x', 'default': dict()},
+            {'name': 'write_args', 'type': dict, 'doc': 'x', 'default': dict()})
+    def export_io(**kwargs):
+        """
         Example usage:
 
-            # create a new HDF5IO object for reading a file and export its contents to a new HDF5 file
-            with HDF5IO('in_file.h5', 'r') as io:
-                HDF5IO.export_io(io=io, path='out_file.h5')
+            export(readio=HDF5IO,
+                   writeio=HDF5IO,
+                   type_map=type_map,
+                   readio_args={'path': 'in.h5'},
+                   writeio_args={'path': 'out.h5'},
+                   write_args={'cache_spec': False})
 
-        '''
-        io, path, comm, read_args, write_args = popargs('io', 'path', 'comm', 'read_args', 'write_args', kwargs)
-        container = io.read(**read_args)
-        cls.export(container=container, type_map=io.type_map, path=path, comm=comm, write_args=write_args)
+        """
+        # when creating the writeio object, set the build manager
+        pass
+
+    # module level function
+    @docval({'name': 'container', 'type': Container, 'doc': 'x'},
+            {'name': 'writeio', 'type': type, 'doc': 'x'},
+            {'name': 'type_map', 'type': type, 'doc': 'x'},
+            {'name': 'writeio_args', 'type': dict, 'doc': 'x', 'default': dict()},
+            {'name': 'write_args', 'type': dict, 'doc': 'x', 'default': dict()})
+    def export_container(**kwargs):
+        """
+        Example usage:
+
+            export(container=container,
+                   writeio=HDF5IO,
+                   type_map=type_map,
+                   writeio_args={'path': 'out.h5'},
+                   write_args={'cache_spec': False})
+
+        """
+        # when creating the writeio object, set the build manager
+        pass
+
+    #         {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
+    #         {'name': 'comm', 'type': 'Intracomm',
+    #          'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
+    #         {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
+    #          'default': dict()},
+    #         {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
+    #          'default': dict()})
+    #
+    #
+    #
+    # @classmethod
+    # @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},
+    #         {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
+    #         {'name': 'comm', 'type': 'Intracomm',
+    #          'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
+    #         {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
+    #          'default': dict()},
+    #         {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
+    #          'default': dict()})
+    # def export_io(cls, **kwargs):
+    #     '''
+    #     Export the container read from the given HDF5IO object to a new destination using a clean instance of this
+    #     HDF5IO class.
+    #
+    #     Similar to the export method, except this method takes care of reading the container from the given HDF5IO
+    #     object first. Arguments can be passed in for the io.read and write_io.write methods.
+    #
+    #     Example usage:
+    #
+    #         # create a new HDF5IO object for reading a file and export its contents to a new HDF5 file
+    #         with HDF5IO('in_file.h5', 'r') as io:
+    #             HDF5IO.export_io(io=io, path='out_file.h5')
+    #
+    #     '''
+    #     io, path, comm, read_args, write_args = popargs('io', 'path', 'comm', 'read_args', 'write_args', kwargs)
+    #     container = io.read(**read_args)
+    #     cls.export(container=container, type_map=io.type_map, path=path, comm=comm, write_args=write_args)
 
     def read(self, **kwargs):
         if self.__mode == 'w' or self.__mode == 'w-' or self.__mode == 'x':

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -53,28 +53,6 @@ class HDMFIO(metaclass=ABCMeta):
         self.write_builder(f_builder, **kwargs)
 
     @abstractmethod
-    def export(cls, **kwargs):
-        '''
-        Export the given container to a new destination using a clean instance of this HDMFIO class.
-
-        If Container objects were read from file, then HDMFIO.write supports writing changes to the Containers
-        back to the same file, but not to a new file. HDMFIO.export allows writing Containers to a new destination,
-        regardless of the origin of the Container.
-        '''
-        pass
-
-    @abstractmethod
-    def export_io(cls, **kwargs):
-        '''
-        Export the container read from the given HDMFIO object to a new destination using a clean instance of this
-        HDMFIO class.
-
-        Similar to the export method, except this method takes care of reading the container from the given HDMFIO
-        object first.
-        '''
-        pass
-
-    @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')
     def read_builder(self):
         ''' Read data and return the GroupBuilder representing '''

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -52,6 +52,13 @@ class HDMFIO(metaclass=ABCMeta):
         f_builder = self.__manager.build(container, source=self.__source)
         self.write_builder(f_builder, **kwargs)
 
+    @classmethod
+    @docval(returns='a dict of args and their supported values to the write method when exporting', rtype=dict)
+    def supported_export_write_args(cls):
+        """Return the args supported by HDMFIO.write when exporting besides the "container" argument."""
+        args = {'exhaust_dci': (True, False)}
+        return args
+
     @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')
     def read_builder(self):

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -56,8 +56,6 @@ class HDMFIO(metaclass=ABCMeta):
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to export'},
             {'name': 'type_map', 'type': 'TypeMap', 'doc': 'the TypeMap to use to export'},
             {'name': 'source', 'type': str, 'doc': 'the source of container being built i.e. file path'},
-            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
-             'default': dict()},
             {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
              'default': dict()},
             allow_extra=True)
@@ -68,6 +66,20 @@ class HDMFIO(metaclass=ABCMeta):
         temp_manager = BuildManager(type_map, export=True)
         write_io = cls(manager=temp_manager, source=source)
         write_io.write(container, **write_args)
+
+    @classmethod
+    @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},
+            {'name': 'source', 'type': str, 'doc': 'the source of container being built i.e. file path'},
+            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
+             'default': dict()},
+            {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
+             'default': dict()},
+            allow_extra=True)
+    def export_io(cls, **kwargs):
+        ''' Export data from the given IO object using this IO object initialized with the given arguments '''
+        io, source, read_args, write_args = popargs('io', 'source', 'read_args', 'write_args', kwargs)
+        container = io.read(**read_args)
+        cls.export(container=container, type_map=io.type_map, source=source, write_args=write_args)
 
     @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -52,34 +52,27 @@ class HDMFIO(metaclass=ABCMeta):
         f_builder = self.__manager.build(container, source=self.__source)
         self.write_builder(f_builder, **kwargs)
 
-    @classmethod
-    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to export'},
-            {'name': 'type_map', 'type': 'TypeMap', 'doc': 'the TypeMap to use to export'},
-            {'name': 'source', 'type': str, 'doc': 'the source of container being built i.e. file path'},
-            {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
-             'default': dict()},
-            allow_extra=True)
+    @abstractmethod
     def export(cls, **kwargs):
-        ''' Export the given container using this IO object initialized with the given arguments '''
-        container, type_map, source, read_args, write_args = popargs('container', 'type_map', 'source', 'read_args',
-                                                                     'write_args', kwargs)
-        temp_manager = BuildManager(type_map, export=True)
-        write_io = cls(manager=temp_manager, source=source)
-        write_io.write(container, **write_args)
+        '''
+        Export the given container to a new destination using a clean instance of this HDMFIO class.
 
-    @classmethod
-    @docval({'name': 'io', 'type': 'HDMFIO', 'doc': 'the HDMFIO object to read data from'},
-            {'name': 'source', 'type': str, 'doc': 'the source of container being built i.e. file path'},
-            {'name': 'read_args', 'type': dict, 'doc': 'dictionary of arguments to use when reading from read_io',
-             'default': dict()},
-            {'name': 'write_args', 'type': dict, 'doc': 'dictionary of arguments to use when writing to file',
-             'default': dict()},
-            allow_extra=True)
+        If Container objects were read from file, then HDMFIO.write supports writing changes to the Containers
+        back to the same file, but not to a new file. HDMFIO.export allows writing Containers to a new destination,
+        regardless of the origin of the Container.
+        '''
+        pass
+
+    @abstractmethod
     def export_io(cls, **kwargs):
-        ''' Export data from the given IO object using this IO object initialized with the given arguments '''
-        io, source, read_args, write_args = popargs('io', 'source', 'read_args', 'write_args', kwargs)
-        container = io.read(**read_args)
-        cls.export(container=container, type_map=io.type_map, source=source, write_args=write_args)
+        '''
+        Export the container read from the given HDMFIO object to a new destination using a clean instance of this
+        HDMFIO class.
+
+        Similar to the export method, except this method takes care of reading the container from the given HDMFIO
+        object first.
+        '''
+        pass
 
     @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -43,6 +43,17 @@ class HDMFIO(metaclass=ABCMeta):
         f_builder = self.__manager.build(container, source=self.__source)
         self.write_builder(f_builder, **kwargs)
 
+    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
+            {'name': 'exhaust_dci', 'type': bool,
+             'doc': 'exhaust DataChunkIterators one at a time. If False, exhaust them concurrently', 'default': True},
+            allow_extra=True)
+    def export(self, **kwargs):
+        container = popargs('container', kwargs)
+        # pass the same TypeMap to a clean BuildManager for exporting
+        temp_manager = BuildManager(self.__manager.type_map, export=True)
+        f_builder = temp_manager.build(container, source=self.__source)
+        self.write_builder(f_builder, **kwargs)
+
     @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')
     def read_builder(self):

--- a/src/hdmf/build/builders.py
+++ b/src/hdmf/build/builders.py
@@ -28,7 +28,6 @@ class Builder(dict, metaclass=ABCMeta):
             self.__source = parent.source
         else:
             self.__source = None
-        self.__written = False
 
     @property
     def path(self):
@@ -41,17 +40,6 @@ class Builder(dict, metaclass=ABCMeta):
             s.append(c.name)
             c = c.parent
         return "/".join(s[::-1])
-
-    @property
-    def written(self):
-        ''' The source of this Builder '''
-        return self.__written
-
-    @written.setter
-    def written(self, s):
-        if self.__written and not s:
-            raise ValueError("cannot change written to not written")
-        self.__written = s
 
     @property
     def name(self):

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -84,10 +84,11 @@ class BuildManager:
     A class for managing builds of AbstractContainers
     """
 
-    def __init__(self, type_map):
+    def __init__(self, type_map, export=False):
         self.__builders = dict()
         self.__containers = dict()
         self.__type_map = type_map
+        self.__export = export
 
     @property
     def namespace_catalog(self):
@@ -96,6 +97,10 @@ class BuildManager:
     @property
     def type_map(self):
         return self.__type_map
+
+    @property
+    def export(self):
+        return self.__export
 
     @docval({"name": "object", "type": (BaseBuilder, AbstractContainer),
              "doc": "the container or builder to get a proxy for"},
@@ -145,16 +150,17 @@ class BuildManager:
         result = self.__builders.get(container_id)
         source, spec_ext = getargs('source', 'spec_ext', kwargs)
         if result is None:
-            if container.container_source is None:
-                container.container_source = source
-            else:
-                if source is None:
-                    source = container.container_source
+            if not self.export:
+                if container.container_source is None:
+                    container.container_source = source
                 else:
-                    if container.container_source != source:
-                        raise ValueError("Cannot change container_source once set: '%s' %s.%s"
-                                         % (container.name, container.__class__.__module__,
-                                            container.__class__.__name__))
+                    if source is None:
+                        source = container.container_source
+                    else:
+                        if container.container_source != source:
+                            raise ValueError("Cannot change container_source once set: '%s' %s.%s"
+                                             % (container.name, container.__class__.__module__,
+                                                container.__class__.__name__))
             result = self.__type_map.build(container, self, source=source, spec_ext=spec_ext)
             self.prebuilt(container, result)
         elif container.modified or spec_ext is not None:

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -102,6 +102,13 @@ class BuildManager:
 
     @property
     def export(self):
+        """Return whether this BuildManager is used solely for exporting data read from one backend to another
+        backend. This property is not settable after being initialized in the constructor.
+
+        A BuildManager with export=True will not set the container_source of its containers to the export destination.
+        A BuildManager used for exporting will also have a separate set of builders and containers than the
+        BuildManager used to read the file.
+        """
         return self.__export
 
     @docval({"name": "object", "type": (BaseBuilder, AbstractContainer),

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -159,9 +159,10 @@ class BuildManager:
         result = self.__builders.get(container_id)
         source, spec_ext = getargs('source', 'spec_ext', kwargs)
         if result is None:
+            self.logger.debug("Building new %s '%s' (container_source: %s, source: %s, extended spec: %s)"
+                              % (container.__class__.__name__, container.name, repr(container.container_source),
+                                 repr(source), spec_ext is not None))
             if not self.export:  # manipulate and check container_source/source only if not exporting
-                self.logger.debug("Building %s '%s' with extended spec (%s) new"
-                                  % (container.__class__.__name__, container.name, spec_ext is not None))
                 if container.container_source is None:
                     container.container_source = source
                 else:
@@ -176,14 +177,16 @@ class BuildManager:
             self.prebuilt(container, result)
             self.logger.debug("Done building %s '%s'" % (container.__class__.__name__, container.name))
         elif container.modified or spec_ext is not None:
-            self.logger.debug("Building %s '%s' modified (%s) / has extended spec (%s) "
-                              % (container.__class__.__name__, container.name, container.modified,
-                                 spec_ext is not None))
             if isinstance(result, BaseBuilder):
+                self.logger.debug("Rebuilding modified / extended %s '%s' (modified: %s, source: %s, extended spec: %s)"
+                                  % (container.__class__.__name__, container.name, container.modified,
+                                     source, spec_ext is not None))
                 result = self.__type_map.build(container, self, builder=result, source=source, spec_ext=spec_ext)
-                self.logger.debug("Done building %s '%s'" % (container.__class__.__name__, container.name))
+                self.logger.debug("Done rebuilding %s '%s'" % (container.__class__.__name__, container.name))
         else:
-            self.logger.debug("Using prebuilt builder for %s '%s'" % (container.__class__.__name__, container.name))
+            self.logger.debug("Using prebuilt %s '%s' for %s '%s'"
+                              % (result.__class__.__name__, result.name,
+                                 container.__class__.__name__, container.name))
         return result
 
     @docval({"name": "container", "type": AbstractContainer, "doc": "the AbstractContainer to save as prebuilt"},

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -150,7 +150,7 @@ class BuildManager:
         result = self.__builders.get(container_id)
         source, spec_ext = getargs('source', 'spec_ext', kwargs)
         if result is None:
-            if not self.export:
+            if not self.export:  # manipulate and check container_source/source only if not exporting
                 if container.container_source is None:
                     container.container_source = source
                 else:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -716,7 +716,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         msg = "invalid type for reference '%s' (%s) - "\
                               "must be AbstractContainer" % (spec.name, type(attr_value))
                     raise ValueError(msg)
-                # breakpoint()
                 target_builder = build_manager.build(attr_value, source=source)
                 attr_value = ReferenceBuilder(target_builder)
             else:
@@ -738,7 +737,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
             builder.set_attribute(spec.name, attr_value)
 
     def __add_links(self, builder, links, container, build_manager, source):
-        print('adding links', builder.name, container.name)
         for spec in links:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if not attr_value:
@@ -746,7 +744,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
             self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_datasets(self, builder, datasets, container, build_manager, source):
-        print('adding datasets', builder.name, container.name)
         for spec in datasets:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if attr_value is None:
@@ -772,7 +769,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_groups(self, builder, groups, container, build_manager, source):
-        print('adding group', builder.name, container.name)
         for spec in groups:
             if spec.data_type_def is None and spec.data_type_inc is None:
                 # we don't need to get attr_name since any named
@@ -828,17 +824,14 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 # object this AbstractContainer corresponds to
                 if (isinstance(spec, LinkSpec)
                         or (value.parent is not parent_container and not build_manager.export)):
-                    print('    making link', builder.name, value.name)
                     name = spec.name
                     builder.set_link(LinkBuilder(rendered_obj, name, builder))
                 elif isinstance(spec, DatasetSpec):
-                    print('    setting dataset', builder.name, value.name)
                     if rendered_obj.dtype is None and spec.dtype is not None:
                         val, dtype = self.convert_dtype(spec, rendered_obj.data)
                         rendered_obj.dtype = dtype
                     builder.set_dataset(rendered_obj)
                 else:
-                    print('    setting group', builder.name, value.name)
                     builder.set_group(rendered_obj)
             elif value.container_source:        # make a link to an existing container
                 if (value.container_source != parent_container.container_source

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -716,7 +716,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         msg = "invalid type for reference '%s' (%s) - "\
                               "must be AbstractContainer" % (spec.name, type(attr_value))
                     raise ValueError(msg)
-                breakpoint()
+                # breakpoint()
                 target_builder = build_manager.build(attr_value, source=source)
                 attr_value = ReferenceBuilder(target_builder)
             else:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -844,6 +844,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     sub_builder = GroupBuilder(spec.name, source=source)
                 self.__add_attributes(sub_builder, spec.attributes, container, build_manager, source)
                 self.__add_datasets(sub_builder, spec.datasets, container, build_manager, source)
+                self.__add_links(sub_builder, spec.links, container, build_manager, source)
 
                 # handle subgroups that are not Containers
                 attr_name = self.get_attribute(spec)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -716,6 +716,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         msg = "invalid type for reference '%s' (%s) - "\
                               "must be AbstractContainer" % (spec.name, type(attr_value))
                     raise ValueError(msg)
+                breakpoint()
                 target_builder = build_manager.build(attr_value, source=source)
                 attr_value = ReferenceBuilder(target_builder)
             else:
@@ -737,6 +738,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             builder.set_attribute(spec.name, attr_value)
 
     def __add_links(self, builder, links, container, build_manager, source):
+        print('adding links', builder.name, container.name)
         for spec in links:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if not attr_value:
@@ -744,6 +746,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_datasets(self, builder, datasets, container, build_manager, source):
+        print('adding datasets', builder.name, container.name)
         for spec in datasets:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if attr_value is None:
@@ -769,6 +772,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_groups(self, builder, groups, container, build_manager, source):
+        print('adding group', builder.name, container.name)
         for spec in groups:
             if spec.data_type_def is None and spec.data_type_inc is None:
                 # we don't need to get attr_name since any named
@@ -815,26 +819,30 @@ class ObjectMapper(metaclass=ExtenderMeta):
                               % (value.name, getattr(value, self.spec.type_key()),
                                  builder.name, self.spec.data_type_def)
                 warnings.warn(msg, OrphanContainerWarning)
-            if value.modified:                   # writing a new container
+            if value.modified or build_manager.export:  # writing a new container
                 if isinstance(spec, BaseStorageSpec):
                     rendered_obj = build_manager.build(value, source=source, spec_ext=spec)
                 else:
                     rendered_obj = build_manager.build(value, source=source)
                 # use spec to determine what kind of HDF5
                 # object this AbstractContainer corresponds to
-                if isinstance(spec, LinkSpec) or value.parent is not parent_container:
+                if (isinstance(spec, LinkSpec)
+                        or (value.parent is not parent_container and not build_manager.export)):
+                    print('    making link', builder.name, value.name)
                     name = spec.name
                     builder.set_link(LinkBuilder(rendered_obj, name, builder))
                 elif isinstance(spec, DatasetSpec):
+                    print('    setting dataset', builder.name, value.name)
                     if rendered_obj.dtype is None and spec.dtype is not None:
                         val, dtype = self.convert_dtype(spec, rendered_obj.data)
                         rendered_obj.dtype = dtype
                     builder.set_dataset(rendered_obj)
                 else:
+                    print('    setting group', builder.name, value.name)
                     builder.set_group(rendered_obj)
             elif value.container_source:        # make a link to an existing container
-                if value.container_source != parent_container.container_source or\
-                   value.parent is not parent_container:
+                if (value.container_source != parent_container.container_source
+                        or value.parent is not parent_container):
                     if isinstance(spec, BaseStorageSpec):
                         rendered_obj = build_manager.build(value, source=source, spec_ext=spec)
                     else:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -888,6 +888,17 @@ class ObjectMapper(metaclass=ExtenderMeta):
                               % (value.__class__.__name__, value.name,
                                  parent_container.__class__.__name__, parent_container.name,
                                  builder.__class__.__name__, builder.name))
+
+            if isinstance(spec, LinkSpec):
+                if value.container_source and build_manager.export:
+                    # link target exists in another file. since we are using a clean buildmanager that
+                    # lacks a cached builder with the correct source, re-build the target with its
+                    # original source
+                    # breakpoint()
+                    rendered_obj = build_manager.build(value, source=value.container_source)
+                    builder.set_link(LinkBuilder(rendered_obj, name=spec.name, parent=builder))
+                    return
+
             if value.parent is None:
                 msg = ("'%s' (%s) for '%s' (%s)"
                        % (value.name, getattr(value, self.spec.type_key()), builder.name, self.spec.data_type_def))

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -894,8 +894,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     # link target exists in another file. since we are using a clean buildmanager that
                     # lacks a cached builder with the correct source, re-build the target with its
                     # original source
-                    # breakpoint()
                     rendered_obj = build_manager.build(value, source=value.container_source)
+                    rendered_obj.location = value.source_location
                     builder.set_link(LinkBuilder(rendered_obj, name=spec.name, parent=builder))
                     return
 
@@ -1107,7 +1107,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 continue
             kwargs[argname] = val
         try:
-            obj = cls.__new__(cls, container_source=builder.source, parent=parent,
+            obj = cls.__new__(cls,
+                              container_source=builder.source,
+                              source_location=builder.location,
+                              parent=parent,
                               object_id=builder.attributes.get(self.__spec.id_key()))
             obj.__init__(**kwargs)
         except Exception as ex:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -585,7 +585,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
         builder, spec_ext = getargs('builder', 'spec_ext', kwargs)
         name = manager.get_builder_name(container)
         if isinstance(self.__spec, GroupSpec):
-            self.logger.debug("Building %s '%s' for GroupSpec" % (container.__class__.__name__, container.name))
+            self.logger.debug("Building %s '%s' as a group (source: %s)"
+                              % (container.__class__.__name__, container.name, repr(source)))
             if builder is None:
                 builder = GroupBuilder(name, parent=parent, source=source)
             self.__add_datasets(builder, self.__spec.datasets, container, manager, source)
@@ -598,15 +599,15 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     raise ValueError(msg)
                 spec_dtype, spec_shape, spec = self.__check_dset_spec(self.spec, spec_ext)
                 if isinstance(spec_dtype, RefSpec):
-                    self.logger.debug("Building %s '%s' as a dataset of references"
-                                      % (container.__class__.__name__, container.name))
+                    self.logger.debug("Building %s '%s' as a dataset of references (source: %s)"
+                                      % (container.__class__.__name__, container.name, repr(source)))
                     bldr_data = self.__get_ref_builder(spec_dtype, spec_shape, container, manager, source=source)
                     builder = DatasetBuilder(name, bldr_data, parent=parent, source=source, dtype=spec_dtype.reftype)
                 elif isinstance(spec_dtype, list):
                     # a compound dataset
                     # check for any references in the compound dtype, and convert them if necessary
-                    self.logger.debug("Building %s '%s' as a dataset of compound dtypes"
-                                      % (container.__class__.__name__, container.name))
+                    self.logger.debug("Building %s '%s' as a dataset of compound dtypes (source: %s)"
+                                      % (container.__class__.__name__, container.name, repr(source)))
                     refs = [(i, subt) for i, subt in enumerate(spec_dtype) if isinstance(subt.dtype, RefSpec)]
                     bldr_data = copy(container.data)
                     bldr_data = list()
@@ -626,8 +627,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     # a regular dtype
                     if spec_dtype is None and self.__is_reftype(container.data):
                         # an unspecified dtype and we were given references
-                        self.logger.debug("Building %s '%s' containing references as a dataset of unspecified dtype"
-                                          % (container.__class__.__name__, container.name))
+                        self.logger.debug("Building %s '%s' containing references as a dataset of unspecified dtype "
+                                          "(source: %s)"
+                                          % (container.__class__.__name__, container.name, repr(source)))
                         bldr_data = list()
                         for d in container.data:
                             if d is None:
@@ -638,8 +640,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                                                  dtype='object')
                     else:
                         # a dataset that has no references, pass the conversion off to the convert_dtype method
-                        self.logger.debug("Building %s '%s' as a dataset"
-                                          % (container.__class__.__name__, container.name))
+                        self.logger.debug("Building %s '%s' as a dataset (source: %s)"
+                                          % (container.__class__.__name__, container.name, repr(source)))
                         try:
                             # use spec_dtype from self.spec when spec_ext does not specify dtype
                             bldr_data, dtype = self.convert_dtype(spec, container.data, spec_dtype=spec_dtype)
@@ -728,9 +730,13 @@ class ObjectMapper(metaclass=ExtenderMeta):
         return False
 
     def __add_attributes(self, builder, attributes, container, build_manager, source):
-        self.logger.debug("Adding attributes to %s '%s' for %s '%s'"
-                          % (builder.__class__.__name__, builder.name, container.__class__.__name__, container.name))
+        if attributes:
+            self.logger.debug("Adding attributes from %s '%s' to %s '%s'"
+                              % (container.__class__.__name__, container.name,
+                                 builder.__class__.__name__, builder.name))
         for spec in attributes:
+            self.logger.debug("    Adding attribute for spec name: %s (dtype: %s)"
+                              % (repr(spec.name), spec.dtype.__class__.__name__))
             if spec.value is not None:
                 attr_value = spec.value
             else:
@@ -742,11 +748,11 @@ class ObjectMapper(metaclass=ExtenderMeta):
             if isinstance(spec.dtype, RefSpec):
                 if not self.__is_reftype(attr_value):
                     if attr_value is None:
-                        msg = "object of data_type %s not found on %s '%s'" % \
-                              (spec.dtype.target_type, type(container).__name__, container.name)
+                        msg = ("object of data_type %s not found on %s '%s'" %
+                               (spec.dtype.target_type, type(container).__name__, container.name))
                     else:
-                        msg = "invalid type for reference '%s' (%s) - "\
-                              "must be AbstractContainer" % (spec.name, type(attr_value))
+                        msg = ("invalid type for reference '%s' (%s) - must be AbstractContainer"
+                               % (spec.name, type(attr_value)))
                     raise ValueError(msg)
                 target_builder = build_manager.build(attr_value, source=source)
                 attr_value = ReferenceBuilder(target_builder)
@@ -761,25 +767,30 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # do not write empty or null valued objects
             if attr_value is None:
                 if spec.required:
-                    msg = "attribute '%s' for '%s' (%s)"\
-                                  % (spec.name, builder.name, self.spec.data_type_def)
+                    msg = "attribute '%s' for '%s' (%s)" % (spec.name, builder.name, self.spec.data_type_def)
                     warnings.warn(msg, MissingRequiredWarning)
                 continue
 
             builder.set_attribute(spec.name, attr_value)
 
     def __add_links(self, builder, links, container, build_manager, source):
-        self.logger.debug("Adding links      to %s '%s' for %s '%s'"
-                          % (builder.__class__.__name__, builder.name, container.__class__.__name__, container.name))
+        if links:
+            self.logger.debug("Adding links from %s '%s' to %s '%s'"
+                              % (container.__class__.__name__, container.name,
+                                 builder.__class__.__name__, builder.name))
         for spec in links:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if not attr_value:
                 continue
+            self.logger.debug("    Adding link for spec name: %s, target_type: %s"
+                              % (repr(spec.name), repr(spec.target_type)))
             self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_datasets(self, builder, datasets, container, build_manager, source):
-        self.logger.debug("Adding datasets   to %s '%s' for %s '%s'"
-                          % (builder.__class__.__name__, builder.name, container.__class__.__name__, container.name))
+        if datasets:
+            self.logger.debug("Adding datasets from %s '%s' to %s '%s'"
+                              % (container.__class__.__name__, container.name,
+                                 builder.__class__.__name__, builder.name))
         for spec in datasets:
             attr_value = self.get_attr_value(spec, container, build_manager)
             if attr_value is None:
@@ -788,29 +799,46 @@ class ObjectMapper(metaclass=ExtenderMeta):
             if isinstance(attr_value, DataIO) and attr_value.data is None:
                 continue
             if isinstance(attr_value, Builder):
-                builder.set_builder(attr_value)
-            elif spec.data_type_def is None and spec.data_type_inc is None:
+                self.logger.debug("    Adding %s '%s' for spec name: %s, %s: %s, %s: %s"
+                                  % (attr_value.name, attr_value.__class__.__name__,
+                                     repr(spec.name),
+                                     spec.def_key(), repr(spec.data_type_def),
+                                     spec.inc_key(), repr(spec.data_type_inc)))
+                builder.set_builder(attr_value)  # add the existing builder
+            elif spec.data_type_def is None and spec.data_type_inc is None:  # untyped, named dataset
                 if spec.name in builder.datasets:
                     sub_builder = builder.datasets[spec.name]
+                    self.logger.debug("    Retrieving existing DatasetBuilder '%s' for spec name %s and adding "
+                                      "attributes" % (sub_builder.name, repr(spec.name)))
                 else:
+                    self.logger.debug("    Converting untyped dataset for spec name %s to spec dtype %s"
+                                      % (repr(spec.name), repr(spec.dtype)))
                     try:
                         data, dtype = self.convert_dtype(spec, attr_value)
                     except Exception as ex:
                         msg = 'could not convert \'%s\' for %s \'%s\''
                         msg = msg % (spec.name, type(container).__name__, container.name)
                         raise Exception(msg) from ex
+                    self.logger.debug("    Adding untyped dataset for spec name %s and adding attributes"
+                                      % repr(spec.name))
                     sub_builder = builder.add_dataset(spec.name, data, dtype=dtype)
                 self.__add_attributes(sub_builder, spec.attributes, container, build_manager, source)
             else:
+                self.logger.debug("    Adding typed dataset for spec name: %s, %s: %s, %s: %s"
+                                  % (repr(spec.name),
+                                     spec.def_key(), repr(spec.data_type_def),
+                                     spec.inc_key(), repr(spec.data_type_inc)))
                 self.__add_containers(builder, spec, attr_value, build_manager, source, container)
 
     def __add_groups(self, builder, groups, container, build_manager, source):
-        self.logger.debug("Adding groups     to %s '%s' for %s '%s'"
-                          % (builder.__class__.__name__, builder.name, container.__class__.__name__, container.name))
+        if groups:
+            self.logger.debug("Adding groups from %s '%s' to %s '%s'"
+                              % (container.__class__.__name__, container.name,
+                                 builder.__class__.__name__, builder.name))
         for spec in groups:
             if spec.data_type_def is None and spec.data_type_inc is None:
-                # we don't need to get attr_name since any named
-                # group does not have the concept of value
+                self.logger.debug("    Adding untyped group for spec name: %s" % repr(spec.name))
+                # we don't need to get attr_name since any named group does not have the concept of value
                 sub_builder = builder.groups.get(spec.name)
                 if sub_builder is None:
                     sub_builder = GroupBuilder(spec.name, source=source)
@@ -835,12 +863,20 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         builder.set_group(sub_builder)
             else:
                 if spec.data_type_def is not None:
+                    self.logger.debug("    Adding group for spec name: %s, %s: %s, %s: %s"
+                                      % (repr(spec.name),
+                                         spec.def_key(), repr(spec.data_type_def),
+                                         spec.inc_key(), repr(spec.data_type_inc)))
                     attr_name = self.get_attribute(spec)
                     if attr_name is not None:
                         attr_value = getattr(container, attr_name, None)
                         if attr_value is not None:
                             self.__add_containers(builder, spec, attr_value, build_manager, source, container)
-                else:
+                else:  # data_type_def is None and data_type_inc is not None
+                    self.logger.debug("    Adding group for spec name: %s, %s: %s, %s: %s"
+                                      % (repr(spec.name),
+                                         spec.def_key(), repr(spec.data_type_def),
+                                         spec.inc_key(), repr(spec.data_type_inc)))
                     attr_name = self.get_attribute(spec)
                     attr_value = self.get_attr_value(spec, container, build_manager)
                     if attr_value is not None:
@@ -848,40 +884,58 @@ class ObjectMapper(metaclass=ExtenderMeta):
 
     def __add_containers(self, builder, spec, value, build_manager, source, parent_container):
         if isinstance(value, AbstractContainer):
-            self.logger.debug("Adding containers to %s '%s' for %s '%s' with parent %s '%s'"
-                              % (builder.__class__.__name__, builder.name, value.__class__.__name__, value.name,
-                                 parent_container.__class__.__name__, parent_container.name))
+            self.logger.debug("    Adding container %s '%s' with parent %s '%s' to %s '%s'"
+                              % (value.__class__.__name__, value.name,
+                                 parent_container.__class__.__name__, parent_container.name,
+                                 builder.__class__.__name__, builder.name))
             if value.parent is None:
-                msg = "'%s' (%s) for '%s' (%s)"\
-                              % (value.name, getattr(value, self.spec.type_key()),
-                                 builder.name, self.spec.data_type_def)
+                msg = ("'%s' (%s) for '%s' (%s)"
+                       % (value.name, getattr(value, self.spec.type_key()), builder.name, self.spec.data_type_def))
                 warnings.warn(msg, OrphanContainerWarning)
-            if value.modified or build_manager.export:  # writing a new container
+
+            if value.modified or build_manager.export:
+                # writing a newly instantiated container (modified is False only after read)
+                self.logger.debug("    Building newly instantiated %s '%s'" % (value.__class__.__name__, value.name))
                 if isinstance(spec, BaseStorageSpec):
                     rendered_obj = build_manager.build(value, source=source, spec_ext=spec)
                 else:
                     rendered_obj = build_manager.build(value, source=source)
-                # use spec to determine what kind of HDF5
-                # object this AbstractContainer corresponds to
+                # use spec to determine what kind of HDF5 object this AbstractContainer corresponds to
                 if (isinstance(spec, LinkSpec)
                         or (value.parent is not parent_container and not build_manager.export)):
-                    name = spec.name
-                    builder.set_link(LinkBuilder(rendered_obj, name, builder))
+                    self.logger.debug("    Adding link to %s '%s' in %s '%s'"
+                                      % (rendered_obj.__class__.__name__, rendered_obj.name,
+                                         builder.__class__.__name__, builder.name))
+                    builder.set_link(LinkBuilder(rendered_obj, name=spec.name, parent=builder))
                 elif isinstance(spec, DatasetSpec):
                     if rendered_obj.dtype is None and spec.dtype is not None:
+                        self.logger.debug("    Converting dataset %s '%s' to spec dtype '%s'"
+                                          % (rendered_obj.__class__.__name__, rendered_obj.name, spec.dtype))
                         val, dtype = self.convert_dtype(spec, rendered_obj.data)
                         rendered_obj.dtype = dtype
+                    self.logger.debug("    Adding dataset %s '%s' to %s '%s'"
+                                      % (rendered_obj.__class__.__name__, rendered_obj.name,
+                                         builder.__class__.__name__, builder.name))
                     builder.set_dataset(rendered_obj)
                 else:
+                    self.logger.debug("    Adding subgroup %s '%s' to %s '%s'"
+                                      % (rendered_obj.__class__.__name__, rendered_obj.name,
+                                         builder.__class__.__name__, builder.name))
                     builder.set_group(rendered_obj)
-            elif value.container_source:        # make a link to an existing container
+            elif value.container_source:  # make a link to an existing container
                 if (value.container_source != parent_container.container_source
                         or value.parent is not parent_container):
+                    self.logger.debug("    Building %s '%s' (container source: %s) and adding a link to it"
+                                      % (value.__class__.__name__, value.name, value.container_source))
                     if isinstance(spec, BaseStorageSpec):
                         rendered_obj = build_manager.build(value, source=source, spec_ext=spec)
                     else:
                         rendered_obj = build_manager.build(value, source=source)
                     builder.set_link(LinkBuilder(rendered_obj, name=spec.name, parent=builder))
+                else:
+                    self.logger.debug("    Skipping build for %s '%s' because both it and its parents were read "
+                                      "from the same source."
+                                      % (value.__class__.__name__, value.name))
             else:
                 raise ValueError("Found unmodified AbstractContainer with no source - '%s' with parent '%s'" %
                                  (value.name, parent_container.name))
@@ -891,10 +945,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
             elif isinstance(value, dict):
                 values = value.values()
             else:
-                msg = ("received %s, expected AbstractContainer - 'value' "
-                       "must be an AbstractContainer a list/tuple/dict of "
-                       "AbstractContainers if 'spec' is a GroupSpec")
-                raise ValueError(msg % value.__class__.__name__)
+                msg = ("received %s, expected AbstractContainer - 'value' must be an AbstractContainer or a "
+                       "list/tuple/dict of AbstractContainers if 'spec' is a GroupSpec"
+                       % value.__class__.__name__)
+                raise ValueError(msg)
             for container in values:
                 if container:
                     self.__add_containers(builder, spec, container, build_manager, source, parent_container)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -102,6 +102,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
     def __new__(cls, *args, **kwargs):
         inst = super().__new__(cls)
         inst.__container_source = kwargs.pop('container_source', None)
+        inst.__source_location = kwargs.pop('source_location', None)
         inst.__parent = None
         inst.__children = list()
         inst.__modified = True
@@ -196,6 +197,19 @@ class AbstractContainer(metaclass=ExtenderMeta):
         if self.__container_source is not None:
             raise Exception('cannot reassign container_source')
         self.__container_source = source
+
+    @property
+    def source_location(self):
+        '''
+        The location of this Container within its source
+        '''
+        return self.__source_location
+
+    @source_location.setter
+    def source_location(self, location):
+        if self.__source_location is not None:
+            raise Exception('cannot reassign source_location')
+        self.__source_location = location
 
     @property
     def parent(self):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -246,6 +246,14 @@ class AbstractContainer(metaclass=ExtenderMeta):
                 parent_container.__children.append(self)
                 parent_container.set_modified()
 
+    def _remove_child(self, child):
+        """Remove a child Container. Intended for use in subclasses that allow dynamic addition of child Containers."""
+        if not isinstance(child, AbstractContainer):
+            raise ValueError('Cannot remove non-AbstractContainer object from children')
+        if child not in self.children:
+            raise ValueError("%s '%s' is not a child of %s" % (child.__class__.__name__, child.name, repr(self)))
+        self.__children.remove(child)
+
 
 class Container(AbstractContainer):
 

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -213,7 +213,7 @@ class H5RoundTripMixin(metaclass=ABCMeta):
         """
         container = self.roundtripContainer(cache_spec=cache_spec)
 
-        HDF5IO.export(
+        HDF5IO.export_container_to_hdf5(
             container=container,
             type_map=self.manager.type_map,
             path=self.export_filename,

--- a/tests/unit/io_tests/test_export.py
+++ b/tests/unit/io_tests/test_export.py
@@ -92,6 +92,18 @@ class TestExportH5ToH5(TestCase):
                 write_io_args={'path': self.path2, 'mode': 'w'},
             )
 
+    def test_export_bad_write_arg(self):
+        foofile = FooFile([])
+        msg = "The argument 'unknown='val'' in write_args is not supported during export."
+        with self.assertRaisesWith(NotImplementedError, msg):
+            export_container(
+                container=foofile,
+                write_io_cls=HDF5IO,
+                type_map=self.manager.type_map,
+                write_io_args={'path': self.path2, 'mode': 'w'},
+                write_args={'unknown': 'val'},
+            )
+
     def test_export_manager_arg(self):
         foofile = FooFile([])
         msg = "The 'manager' key is not allowed in write_io_args because a new BuildManager will be used."

--- a/tests/unit/io_tests/test_export.py
+++ b/tests/unit/io_tests/test_export.py
@@ -1,0 +1,140 @@
+import h5py
+import os
+
+from hdmf.backends import export_container, export_io
+from hdmf.backends.hdf5.h5tools import HDF5IO
+from hdmf.testing import TestCase
+
+from tests.unit.test_io_hdf5_h5tools import _get_manager, FooFile
+from tests.unit.utils import Foo, FooBucket, get_temp_filepath
+
+
+class TestExportH5ToH5(TestCase):
+    """Test exporting from an HDF5 file to an HDF5 file.
+
+    See test_io_hdf5_h5tools.TestExport for more complete test cases since HDF5IO.export_container_to_hdf5 calls
+    export_container.
+    """
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path1 = get_temp_filepath()
+        self.path2 = get_temp_filepath()
+        self.path3 = get_temp_filepath()
+
+    def tearDown(self):
+        if os.path.exists(self.path1):
+            os.remove(self.path1)
+        if os.path.exists(self.path2):
+            os.remove(self.path2)
+        if os.path.exists(self.path3):
+            os.remove(self.path3)
+
+    def test_unwritten(self):
+        """Test that exporting an unwritten container to file works without modifying container source."""
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        foofile = FooFile([foobucket])
+
+        export_container(
+            container=foofile,
+            write_io_cls=HDF5IO,
+            type_map=self.manager.type_map,
+            write_io_args={'path': self.path1, 'mode': 'w'}
+        )
+
+        self.assertTrue(os.path.exists(self.path1))
+        self.assertIsNone(foofile.container_source)
+
+        with HDF5IO(self.path1, manager=self.manager, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(read_foofile.container_source, self.path1)
+
+            # containers should be equal after setting the container source of in-memory foofile
+            foofile.container_source = self.path1
+            self.assertContainerEqual(foofile, read_foofile)
+
+    def test_written(self):
+        """Test that exporting a written container works."""
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path1, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        with HDF5IO(self.path1, manager=self.manager, mode='r') as io:
+            read_foofile = io.read()
+            export_container(
+                container=foofile,
+                write_io_cls=HDF5IO,
+                type_map=self.manager.type_map,
+                write_io_args={'path': self.path2, 'mode': 'w'},
+            )
+
+        self.assertTrue(os.path.exists(self.path2))
+        self.assertEqual(foofile.container_source, self.path1)
+        self.assertEqual(read_foofile.container_source, self.path1)
+
+        with HDF5IO(self.path2, manager=self.manager, mode='r') as io:
+            read_foofile2 = io.read()
+            self.assertEqual(read_foofile2.container_source, self.path2)
+            self.assertContainerEqual(foofile, read_foofile, ignore_hdmf_attrs=True)
+
+    def test_export_bad_write_cls(self):
+        foofile = FooFile([])
+        msg = "The 'write_io_cls' argument 'File' must be a subclass of HDMFIO."
+        with self.assertRaisesWith(ValueError, msg):
+            export_container(
+                container=foofile,
+                write_io_cls=h5py.File,
+                type_map=self.manager.type_map,
+                write_io_args={'path': self.path2, 'mode': 'w'},
+            )
+
+    def test_export_manager_arg(self):
+        foofile = FooFile([])
+        msg = "The 'manager' key is not allowed in write_io_args because a new BuildManager will be used."
+        with self.assertRaisesWith(ValueError, msg):
+            export_container(
+                container=foofile,
+                write_io_cls=HDF5IO,
+                type_map=self.manager.type_map,
+                write_io_args={'path': self.path2, 'mode': 'w', 'manager': self.manager},
+            )
+
+    def test_export_io_written(self):
+        """Test that exporting a written container works."""
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('test_bucket', [foo1])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.path1, manager=self.manager, mode='w') as io:
+            io.write(foofile)
+
+        export_io(
+            read_io_cls=HDF5IO,
+            write_io_cls=HDF5IO,
+            type_map=self.manager.type_map,
+            read_io_args={'path': self.path1, 'mode': 'r', 'manager': self.manager},
+            write_io_args={'path': self.path2, 'mode': 'w'},
+        )
+
+        self.assertTrue(os.path.exists(self.path2))
+        self.assertEqual(foofile.container_source, self.path1)
+
+        with HDF5IO(self.path2, manager=self.manager, mode='r') as io:
+            read_foofile2 = io.read()
+            self.assertEqual(read_foofile2.container_source, self.path2)
+            self.assertContainerEqual(foofile, foofile, ignore_hdmf_attrs=True)
+
+    def test_export_io_bad_read_cls(self):
+        msg = "The 'read_io_cls' argument 'File' must be a subclass of HDMFIO."
+        with self.assertRaisesWith(ValueError, msg):
+            export_io(
+                read_io_cls=h5py.File,
+                write_io_cls=HDF5IO,
+                type_map=self.manager.type_map,
+                read_io_args={'path': self.path1, 'mode': 'r'},
+                write_io_args={'path': self.path2, 'mode': 'w'},
+            )

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -145,7 +145,6 @@ class TestContainer(TestCase):
             Container('obj1')._remove_child(object())
 
 
-
 class TestData(TestCase):
 
     def test_bool_true(self):

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -110,6 +110,14 @@ class TestContainer(TestCase):
         with self.assertRaisesWith(Exception, 'cannot reassign container_source'):
             parent_obj.container_source = 'some other source'
 
+    def test_reassign_source_location(self):
+        """Test that reassign source location throws error
+        """
+        parent_obj = Container('obj1')
+        parent_obj.source_location = 'a location'
+        with self.assertRaisesWith(Exception, 'cannot reassign source_location'):
+            parent_obj.source_location = 'some other location'
+
     def test_repr(self):
         parent_obj = Container('obj1')
         self.assertRegex(str(parent_obj), r"obj1 hdmf.container.Container at 0x\d+")

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -126,6 +126,25 @@ class TestContainer(TestCase):
         self.assertEqual(Container.type_hierarchy(), (Container, AbstractContainer, object))
         self.assertEqual(Subcontainer.type_hierarchy(), (Subcontainer, Container, AbstractContainer, object))
 
+    def test_remove_child(self):
+        """Test that removing a child removes only the child.
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj3 = Container('obj3')
+        child_obj.parent = parent_obj
+        child_obj3.parent = parent_obj
+        parent_obj._remove_child(child_obj)
+        self.assertTupleEqual(parent_obj.children, (child_obj3, ))
+
+    def test_remove_child_noncontainer(self):
+        """Test that removing a non-Container child raises an error.
+        """
+        msg = "Cannot remove non-AbstractContainer object from children"
+        with self.assertRaisesWith(ValueError, msg):
+            Container('obj1')._remove_child(object())
+
+
 
 class TestData(TestCase):
 

--- a/tests/unit/test_io_hdf5.py
+++ b/tests/unit/test_io_hdf5.py
@@ -221,15 +221,6 @@ class TestHDF5Writer(GroupBuilderTestCase):
         self.assertBuilderEqual(builder, self.builder)
         io.close()
 
-    def test_overwrite_written(self):
-        self.maxDiff = None
-        io = HDF5IO(self.path, manager=self.manager, mode='a')
-        io.write_builder(self.builder)
-        builder = io.read_builder()
-        with self.assertRaisesWith(ValueError, "cannot change written to not written"):
-            builder.written = False
-        io.close()
-
     def test_dataset_shape(self):
         self.maxDiff = None
         io = HDF5IO(self.path, manager=self.manager, mode='a')

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -895,17 +895,17 @@ class TestMultiWrite(TestCase):
             os.remove(self.path)
 
     def test_write_write_unwritten(self):
-        """Test writing a container, adding to the in-memory container, then writing it again."""
+        """Test writing a container, adding to the in-memory container, then overwriting the same file."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
-        # append new container
+        # append new container to in-memory container
         foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
         new_bucket1 = FooBucket('new_bucket1', [foo3])
         self.foofile.buckets.append(new_bucket1)
         new_bucket1.parent = self.foofile
 
-        # write to same file with same manager
+        # write to same file with same manager, overwriting existing file
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -52,6 +52,10 @@ class FooFile(Container):
     def buckets(self):
         return self.__buckets
 
+    def remove_bucket(self, bucket):
+        self.__buckets.remove(bucket)
+        self._remove_child(bucket)
+
     @property
     def foo_link(self):
         return self.__foo_link
@@ -1719,8 +1723,7 @@ class TestExport(TestCase):
 
         with HDF5IO(self.path1, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
-            read_foofile.buckets.clear()  # remove child FooBucket
-            read_foofile.children.clear()  # remove child FooBucket
+            read_foofile.remove_bucket(read_foofile.buckets[0])  # remove child FooBucket
 
             HDF5IO.export(
                 container=read_foofile,

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import tempfile
 import warnings
 import numpy as np
 import h5py
@@ -22,7 +21,7 @@ from hdmf.testing import TestCase
 from h5py import SoftLink, HardLink, ExternalLink, File
 from h5py import filters as h5py_filters
 
-from tests.unit.utils import Foo, FooBucket, CORE_NAMESPACE
+from tests.unit.utils import Foo, FooBucket, CORE_NAMESPACE, get_temp_filepath
 
 
 class FooFile(Container):
@@ -70,14 +69,6 @@ class FooFile(Container):
     @property
     def foofile_data(self):
         return self.__foofile_data
-
-
-def get_temp_filepath():
-    # On Windows, h5py cannot truncate an open file in write mode.
-    # The temp file will be closed before h5py truncates it and will be removed during the tearDown step.
-    temp_file = tempfile.NamedTemporaryFile()
-    temp_file.close()
-    return temp_file.name
 
 
 class H5IOTest(TestCase):
@@ -1538,6 +1529,7 @@ class TestLoadNamespaces(TestCase):
 
 
 class TestExport(TestCase):
+    """Test exporting HDF5 to HDF5 using HDF5IO.export_container_to_hdf5."""
 
     def setUp(self):
         self.manager = _get_manager()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1575,7 +1575,7 @@ class TestExport(TestCase):
         foofile = FooFile([foobucket])
 
         msg = "The argument 'link_data=True' in write_args is not supported during export."
-        with self.assertRaisesWith(ValueError, msg):
+        with self.assertRaisesWith(NotImplementedError, msg):
             HDF5IO.export_container_to_hdf5(
                 container=foofile,
                 type_map=self.manager.type_map,

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1720,6 +1720,7 @@ class TestExport(TestCase):
         with HDF5IO(self.path1, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
             read_foofile.buckets.clear()  # remove child FooBucket
+            read_foofile.buckets.children.clear()  # remove child FooBucket
 
             HDF5IO.export(
                 container=read_foofile,

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1669,15 +1669,12 @@ class TestExport(TestCase):
 
         with HDF5IO(self.path2, manager=self.manager, mode='r') as io:
             read_foofile2 = io.read()
-            print('read')
 
             HDF5IO.export(
                 container=read_foofile2,
                 type_map=self.manager.type_map,  # TODO pass the current manager since it contains the loaded object
                 path=self.path3,
             )
-
-        print('moo')
 
         with HDF5IO(self.path3, manager=self.manager, mode='r') as io:
             read_foofile2 = io.read()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -847,19 +847,6 @@ class TestCacheSpec(TestCase):
             read_types = self.__get_types(ns_catalog)
             self.assertSetEqual(source_types, read_types)
 
-    def test_double_cache_spec(self):
-        # Setup all the data we need
-        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
-        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
-        foobucket = FooBucket('test_bucket', [foo1, foo2])
-        foofile = FooFile([foobucket])
-
-        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile)
-
-        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
-            io.write(foofile)
-
     def __get_types(self, catalog):
         types = set()
         for ns_name in catalog.namespaces:
@@ -891,6 +878,98 @@ class TestNoCacheSpec(TestCase):
 
         with File(self.path, 'r') as f:
             self.assertNotIn('specifications', f)
+
+
+class TestMultiWrite(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_write_append_same_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        # NOTE: self.manager has a build builders cache
+        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_bucket(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 2)
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+    def test_append_double_write(self):
+        """Test using the same IO object to append to a file twice."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+        foo4 = Foo('foo4', [10, 20], "I am foo4", 2, 0.1)
+        new_bucket2 = FooBucket('new_bucket2', [foo4])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+            read_foofile.buckets.append(new_bucket2)
+            new_bucket2.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 3)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket2':
+                    break
+            self.assertContainerEqual(bucket, new_bucket2)
 
 
 class HDF5IOMultiFileTest(TestCase):
@@ -1167,7 +1246,7 @@ class HDF5IOWriteFileExists(TestCase):
     def test_write_a(self):
         with HDF5IO(self.path, manager=_get_manager(), mode='a') as io:
             # even though foofile1 and foofile2 have different names, writing a
-            # root object into a file that already has a root object, in r+ mode
+            # root object into a file that already has a root object, in a mode
             # should throw an error
             with self.assertRaisesWith(ValueError, "Unable to create group (name already exists)"):
                 io.write(self.foofile2)
@@ -1188,6 +1267,41 @@ class HDF5IOWriteFileExists(TestCase):
                                        ("Cannot write to file %s in mode 'r'. "
                                         "Please use mode 'r+', 'w', 'w-', 'x', or 'a'") % self.path):
                 io.write(self.foofile2)
+
+
+class TestWritten(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_set_written_on_write(self):
+        """Test that write_builder changes the written flag of the builder and its children from False to True."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            builder = self.manager.build(container=self.foofile, source=self.path)
+            self.assertFalse(io.get_written(builder))
+            self._check_written_children(io, builder, False)
+            io.write_builder(builder)
+            self.assertTrue(io.get_written(builder))
+            self._check_written_children(io, builder, True)
+
+    def _check_written_children(self, io, builder, val):
+        """Test whether the io object has the written flag of the child builders set to val."""
+        for group_bldr in builder.groups.values():
+            self.assertEqual(io.get_written(group_bldr), val)
+            self._check_written_children(io, group_bldr, val)
+        for dset_bldr in builder.datasets.values():
+            self.assertEqual(io.get_written(dset_bldr), val)
+        for link_bldr in builder.links.values():
+            self.assertEqual(io.get_written(link_bldr), val)
 
 
 class H5DataIOValid(TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1559,11 +1559,16 @@ class TestExport(TestCase):
         foobucket = FooBucket('test_bucket', [foo1])
         foofile = FooFile([foobucket])
 
-        HDF5IO.export(
-            container=foofile,
-            type_map=self.manager.type_map,
-            path=self.path1,
-        )
+        manager = BuildManager(self.manager.type_map, export=True)
+        write_io = HDF5IO(path=self.path1, manager=manager)
+        write_io.export(container=foofile)
+        # ^ this will check that buildmanager.export = True and has an empty prebuilt cache
+
+        # HDF5IO.export(
+        #     container=foofile,
+        #     type_map=self.manager.type_map,
+        #     path=self.path1,
+        # )
 
         self.assertTrue(os.path.exists(self.path1))
         self.assertIsNone(foofile.container_source)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -886,19 +886,6 @@ class TestCacheSpec(TestCase):
             read_types = self.__get_types(ns_catalog)
             self.assertSetEqual(source_types, read_types)
 
-    def test_double_cache_spec(self):
-        # Setup all the data we need
-        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
-        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
-        foobucket = FooBucket('test_bucket', [foo1, foo2])
-        foofile = FooFile([foobucket])
-
-        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile)
-
-        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
-            io.write(foofile)
-
     def __get_types(self, catalog):
         types = set()
         for ns_name in catalog.namespaces:
@@ -930,6 +917,98 @@ class TestNoCacheSpec(TestCase):
 
         with File(self.path, 'r') as f:
             self.assertNotIn('specifications', f)
+
+
+class TestMultiWrite(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_write_append_same_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        # NOTE: self.manager has a build builders cache
+        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_bucket(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 2)
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+    def test_append_double_write(self):
+        """Test using the same IO object to append to a file twice."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+        foo4 = Foo('foo4', [10, 20], "I am foo4", 2, 0.1)
+        new_bucket2 = FooBucket('new_bucket2', [foo4])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+            read_foofile.buckets.append(new_bucket2)
+            new_bucket2.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 3)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket2':
+                    break
+            self.assertContainerEqual(bucket, new_bucket2)
 
 
 class HDF5IOMultiFileTest(TestCase):
@@ -1206,7 +1285,7 @@ class HDF5IOWriteFileExists(TestCase):
     def test_write_a(self):
         with HDF5IO(self.path, manager=_get_manager(), mode='a') as io:
             # even though foofile1 and foofile2 have different names, writing a
-            # root object into a file that already has a root object, in r+ mode
+            # root object into a file that already has a root object, in a mode
             # should throw an error
             with self.assertRaisesWith(ValueError, "Unable to create group (name already exists)"):
                 io.write(self.foofile2)
@@ -1227,6 +1306,41 @@ class HDF5IOWriteFileExists(TestCase):
                                        ("Cannot write to file %s in mode 'r'. "
                                         "Please use mode 'r+', 'w', 'w-', 'x', or 'a'") % self.path):
                 io.write(self.foofile2)
+
+
+class TestWritten(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_set_written_on_write(self):
+        """Test that write_builder changes the written flag of the builder and its children from False to True."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            builder = self.manager.build(container=self.foofile, source=self.path)
+            self.assertFalse(io.get_written(builder))
+            self._check_written_children(io, builder, False)
+            io.write_builder(builder)
+            self.assertTrue(io.get_written(builder))
+            self._check_written_children(io, builder, True)
+
+    def _check_written_children(self, io, builder, val):
+        """Test whether the io object has the written flag of the child builders set to val."""
+        for group_bldr in builder.groups.values():
+            self.assertEqual(io.get_written(group_bldr), val)
+            self._check_written_children(io, group_bldr, val)
+        for dset_bldr in builder.datasets.values():
+            self.assertEqual(io.get_written(dset_bldr), val)
+        for link_bldr in builder.links.values():
+            self.assertEqual(io.get_written(link_bldr), val)
 
 
 class H5DataIOValid(TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1770,4 +1770,7 @@ class TestExport(TestCase):
             read_foofile2 = io.read()
 
             self.assertContainerEqual(read_foofile2, read_foofile, ignore_hdmf_attrs=True)
-            self.assertIs(read_foofile2.foo_link, read_foofile2.buckets[1].foos[0])
+
+            # python 3.5 dicts are unordered so builders can return lists in different order
+            # so this check will not work until we drop python 3.5 support
+            # self.assertIs(read_foofile2.foo_link, read_foofile2.buckets[1].foos[0])

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -894,25 +894,33 @@ class TestMultiWrite(TestCase):
         if os.path.exists(self.path):
             os.remove(self.path)
 
-    def test_write_append_same_manager(self):
+    def test_write_write_unwritten(self):
+        """Test writing a container, adding to the in-memory container, then writing it again."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
-        # NOTE: self.manager has a build builders cache
-        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
-            read_foofile = io.read()
-            io.write(read_foofile)  # no changes
+        # append new container
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+        self.foofile.buckets.append(new_bucket1)
+        new_bucket1.parent = self.foofile
 
-    def test_write_append_new_manager(self):
+        # write to same file with same manager
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
+        # check that new bucket was written
         new_manager = BuildManager(self.manager.type_map)
-        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+        with HDF5IO(self.path, manager=new_manager, mode='r') as io:
             read_foofile = io.read()
-            io.write(read_foofile)  # no changes
+            self.assertEqual(len(read_foofile.buckets), 2)
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
 
-    def test_write_append_new_bucket(self):
+    def test_append_bucket(self):
+        """Test appending a container to a file."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
@@ -922,10 +930,12 @@ class TestMultiWrite(TestCase):
         new_manager = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager, mode='a') as io:
             read_foofile = io.read()
+            # append to read container and call write
             read_foofile.buckets.append(new_bucket1)
             new_bucket1.parent = read_foofile
             io.write(read_foofile)
 
+        # check that new bucket was written
         new_manager2 = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
             read_foofile = io.read()
@@ -935,8 +945,8 @@ class TestMultiWrite(TestCase):
                     break
             self.assertContainerEqual(bucket, new_bucket1)
 
-    def test_append_double_write(self):
-        """Test using the same IO object to append to a file twice."""
+    def test_append_bucket_double_write(self):
+        """Test using the same IO object to append a container to a file twice."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
@@ -948,14 +958,17 @@ class TestMultiWrite(TestCase):
         new_manager = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager, mode='a') as io:
             read_foofile = io.read()
+            # append to read container and call write
             read_foofile.buckets.append(new_bucket1)
             new_bucket1.parent = read_foofile
             io.write(read_foofile)
 
+            # append to read container again and call write again
             read_foofile.buckets.append(new_bucket2)
             new_bucket2.parent = read_foofile
             io.write(read_foofile)
 
+        # check that both new buckets were written
         new_manager2 = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
             read_foofile = io.read()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1738,7 +1738,7 @@ class TestExport(TestCase):
             self.assertListEqual(read_foofile2.buckets, [])
 
             # check that file size of file 2 is smaller
-            self.assertTrue(os.stat(self.path1) > os.stat(self.path2))
+            self.assertTrue(os.path.getsize(self.path1) > os.path.getsize(self.path2))
 
     def test_export_append_data(self):
         """Test that exporting a written container after adding to it in-memory works."""

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1720,7 +1720,7 @@ class TestExport(TestCase):
         with HDF5IO(self.path1, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
             read_foofile.buckets.clear()  # remove child FooBucket
-            read_foofile.buckets.children.clear()  # remove child FooBucket
+            read_foofile.children.clear()  # remove child FooBucket
 
             HDF5IO.export(
                 container=read_foofile,

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from hdmf.utils import docval, getargs
 from hdmf.container import Container
 
@@ -69,3 +71,11 @@ class FooBucket(Container):
     @property
     def foos(self):
         return self.__foos
+
+
+def get_temp_filepath():
+    # On Windows, h5py cannot truncate an open file in write mode.
+    # The temp file will be closed before h5py truncates it and will be removed during the tearDown step.
+    temp_file = tempfile.NamedTemporaryFile()
+    temp_file.close()
+    return temp_file.name


### PR DESCRIPTION
Fix #315 and https://github.com/NeurodataWithoutBorders/pynwb/issues/668

This is a work in progress.

This also addresses two other potential issues discovered during debugging:
1) iterating over a `DatasetOfReferences` returned the reference, not the referenced object, so I added `__iter__` and `__next__` to `DatasetofReferences`
2) the `link_data` keyword argument for `HDF5IO.write` was not being used when writing datasets within groups.

TODO:
- [ ] Test edge case where after read of an existing file, a new link is made to an existing container but not using LinkSpec (see objectmapper.py 947:951). It doesn't seem to work.
- [ ] Note that if a container A is removed from container B that contains it, the children list of container B needs to be updated. This can be hard to track.
- [ ] add test roundtrip with export to hdmf and pynwb testing modules and test suites
- [ ] handle external lninks

I haven't fully tested these potential issues and solutions yet, so they remain part of this WIP. The commits can be cherry-picked into their own issues/PRs if appropriate.