### PR TITLE
Do not print out logging.DEBUG statements to stdout for test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -89,9 +89,9 @@ def main():
 
     # set up logger
     root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
+    root.setLevel(logging.INFO)
     ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(logging.INFO)
     formatter = logging.Formatter('======================================================================\n'
                                   '%(asctime)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)


### PR DESCRIPTION
After merging #336, running `python test.py` results in printing a LOT of statements with level DEBUG. This makes running the script print out only statements with level INFO and higher.