### PR TITLE
Fix sphinx/rst table formatting, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update MacOS in CI. @rly (#310)
 - Raise more informative error when adding column to `DynamicTable` w/ used name. @rly (#307)
 - Refactor `_init_class_columns` for use by DynamicTable subclasses. @rly (#323)
-- Add/fix docstrings for DynamicTable. @oruebel (#304)
+- Add/fix docstrings for DynamicTable. @oruebel, @rly (#304, #353)
 - Make docval-decorated functions more debuggable in pdb. @rly (#308)
 - Change dtype conversion warning to include path to type. @rly (#311)
 - Refactor `DynamicTable.add_column` to raise error when name is an optional column. @rly (#305)
@@ -16,6 +16,7 @@
 - Add allowed value / enum validation in docval. @rly (#335)
 - Add logging of build and hdf5 write process. @rly (#336, #349)
 - Allow loading namespaces from h5py.File object not backed by file. @rly (#348)
+- Add CHANGELOG.md. @rly (#352)
 
 ### Bug fixes:
 - Register new child types before new parent type for dynamic class generation. @rly (#322)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -573,13 +573,15 @@ class DynamicTable(Container):
         Select a subset from the table
 
         :param key: Key defining which elements of the table to select. This may be one of the following:
-                    1) string with the name of the column to select,
-                    2) a tuple consisting of (str, int) where the string defines the column to select
-                       and the int selects the row
-                    3) int, list of ints, or slice selecting a set of full rows in the table
-        :return: 1) If key is a string then return array with the data of the selected column,
-                 2) If key is a tuple of (int, str) then return the scalar value of the selected cell
-                 3) If key is an int, list or slice then return pandas Dataframe consisting of one or more rows
+
+            1) string with the name of the column to select
+            2) a tuple consisting of (str, int) where the string identifies the column to select by name
+               and the int selects the row
+            3) int, list of ints, or slice selecting a set of full rows in the table
+
+        :return: 1) If key is a string, then return array with the data of the selected column
+                 2) If key is a tuple of (int, str), then return the scalar value of the selected cell
+                 3) If key is an int, list or slice, then return pandas.DataFrame consisting of one or more rows
 
         :raises: KeyError
         """


### PR DESCRIPTION
The docstring for `DynamicTable.__getitem__` did not render properly and raised a sphinx warning. This PR fixes that.