### PR TITLE
Fix codecov reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-codecov==2.0.15
-coverage==5.0.2
+codecov==2.1.3
+coverage==5.1
 flake8==3.7.9
 python-dateutil==2.8.1
 tox==3.14.3

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands = {[testenv:build]commands}
 
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
-passenv = CI CIRCLECI CIRCLECI_*
+passenv = CI CIRCLECI CIRCLE_*
 basepython = python3.8
 commands =
     python -m coverage run test.py -u

--- a/tox.ini
+++ b/tox.ini
@@ -66,12 +66,12 @@ commands = {[testenv:build]commands}
 
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
-passenv = CODECOV_TOKEN
+passenv = CI CIRCLECI
 basepython = python3.8
-commands = 
+commands =
     python -m coverage run test.py -u
     coverage report -m
-    codecov -X fix
+    codecov
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ basepython = python3.8
 commands =
     python -m coverage run test.py -u
     coverage report -m
-    codecov
+    bash <(curl -s https://codecov.io/bash)
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]

--- a/tox.ini
+++ b/tox.ini
@@ -66,12 +66,12 @@ commands = {[testenv:build]commands}
 
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
-passenv = CI CIRCLECI
+passenv = CI CIRCLECI CIRCLECI_*
 basepython = python3.8
 commands =
     python -m coverage run test.py -u
     coverage report -m
-    bash <(curl -s https://codecov.io/bash)
+    codecov
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]


### PR DESCRIPTION
codecov.io has been broken for the past 9 days with the error: `400 Client Error: Bad Request for url: https://storage.googleapis.com/codecov/v4/raw/...`

This error could be due to a codecov server issue or a configuration issue. This PR tries to update the tox/codecov configuration to the new preferred method which no longer relies on a private token.