### PR TITLE
Use dtype from dataset data_type definition when extended spec lacks dtype

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -119,7 +119,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
     __no_convert = set()
 
     @classmethod
-    def __resolve_dtype(cls, given, specified):
+    def __resolve_numeric_dtype(cls, given, specified):
         """
         Determine the dtype to use from the dtype of the given value and the specified dtype.
         This amounts to determining the greater precision of the two arguments, but also
@@ -172,52 +172,60 @@ class ObjectMapper(metaclass=ExtenderMeta):
         cls.__no_convert.add(obj_type)
 
     @classmethod
-    def convert_dtype(cls, spec, value):
+    def convert_dtype(cls, spec, value, spec_dtype=None):
         """
         Convert values to the specified dtype. For example, if a literal int
         is passed in to a field that is specified as a unsigned integer, this function
         will convert the Python int to a numpy unsigned int.
 
+        :param spec: The DatasetSpec or AttributeSpec to which this value is being applied
+        :param value: The value being converted to the spec dtype
+        :param spec_dtype: Optional override of the dtype in spec.dtype. Used to specify the parent dtype when the given
+                           extended spec lacks a dtype.
+
         :return: The function returns a tuple consisting of 1) the value, and 2) the data type.
                  The value is returned as the function may convert the input value to comply
                  with the dtype specified in the schema.
         """
-        ret, ret_dtype = cls.__check_edgecases(spec, value)
+        if spec_dtype is None:
+            spec_dtype = spec.dtype
+        ret, ret_dtype = cls.__check_edgecases(spec, value, spec_dtype)
         if ret is not None or ret_dtype is not None:
             return ret, ret_dtype
-        spec_dtype = cls.__dtypes[spec.dtype]
+        # spec_dtype is a string, spec_dtype_type is a type or the conversion helper functions _unicode or _ascii
+        spec_dtype_type = cls.__dtypes[spec_dtype]
         warning_msg = None
         if isinstance(value, np.ndarray):
-            if spec_dtype is _unicode:
+            if spec_dtype_type is _unicode:
                 ret = value.astype('U')
                 ret_dtype = "utf8"
-            elif spec_dtype is _ascii:
+            elif spec_dtype_type is _ascii:
                 ret = value.astype('S')
                 ret_dtype = "ascii"
             else:
-                dtype_func, warning_msg = cls.__resolve_dtype(value.dtype, spec_dtype)
+                dtype_func, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
                 ret = np.asarray(value).astype(dtype_func)
                 ret_dtype = ret.dtype.type
         elif isinstance(value, (tuple, list)):
             if len(value) == 0:
-                return value, spec_dtype
+                return value, spec_dtype_type
             ret = list()
             for elem in value:
-                tmp, tmp_dtype = cls.convert_dtype(spec, elem)
+                tmp, tmp_dtype = cls.convert_dtype(spec, elem, spec_dtype)
                 ret.append(tmp)
             ret = type(value)(ret)
             ret_dtype = tmp_dtype
         elif isinstance(value, AbstractDataChunkIterator):
             ret = value
-            ret_dtype, warning_msg = cls.__resolve_dtype(value.dtype, spec_dtype)
+            ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
         else:
-            if spec_dtype in (_unicode, _ascii):
+            if spec_dtype_type in (_unicode, _ascii):
                 ret_dtype = 'ascii'
-                if spec_dtype == _unicode:
+                if spec_dtype_type == _unicode:
                     ret_dtype = 'utf8'
-                ret = spec_dtype(value)
+                ret = spec_dtype_type(value)
             else:
-                dtype_func, warning_msg = cls.__resolve_dtype(type(value), spec_dtype)
+                dtype_func, warning_msg = cls.__resolve_numeric_dtype(type(value), spec_dtype_type)
                 ret = dtype_func(value)
                 ret_dtype = type(ret)
         if warning_msg:
@@ -226,22 +234,22 @@ class ObjectMapper(metaclass=ExtenderMeta):
         return ret, ret_dtype
 
     @classmethod
-    def __check_edgecases(cls, spec, value):
+    def __check_edgecases(cls, spec, value, spec_dtype):
         """
         Check edge cases in converting data to a dtype
         """
         if value is None:
-            dt = spec.dtype
+            dt = spec_dtype
             if isinstance(dt, RefSpec):
                 dt = dt.reftype
             return None, dt
-        if isinstance(spec.dtype, list):
+        if isinstance(spec_dtype, list):
             # compound dtype - Since the I/O layer needs to determine how to handle these,
             # return the list of DtypeSpecs
-            return value, spec.dtype
+            return value, spec_dtype
         if isinstance(value, DataIO):
-            return value, cls.convert_dtype(spec, value.data)[1]
-        if spec.dtype is None or spec.dtype == 'numeric' or type(value) in cls.__no_convert:
+            return value, cls.convert_dtype(spec, value.data, spec_dtype)[1]
+        if spec_dtype is None or spec_dtype == 'numeric' or type(value) in cls.__no_convert:
             # infer type from value
             if hasattr(value, 'dtype'):  # covers numpy types, AbstractDataChunkIterator
                 return value, value.dtype.type
@@ -249,20 +257,20 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 if len(value) == 0:
                     msg = "cannot infer dtype of empty list or tuple. Please use numpy array with specified dtype."
                     raise ValueError(msg)
-                return value, cls.__check_edgecases(spec, value[0])[1]  # infer dtype from first element
+                return value, cls.__check_edgecases(spec, value[0], spec_dtype)[1]  # infer dtype from first element
             ret_dtype = type(value)
             if ret_dtype is str:
                 ret_dtype = 'utf8'
             elif ret_dtype is bytes:
                 ret_dtype = 'ascii'
             return value, ret_dtype
-        if isinstance(spec.dtype, RefSpec):
+        if isinstance(spec_dtype, RefSpec):
             if not isinstance(value, ReferenceBuilder):
                 msg = "got RefSpec for value of type %s" % type(value)
                 raise ValueError(msg)
-            return value, spec.dtype
-        if spec.dtype is not None and spec.dtype not in cls.__dtypes:
-            msg = "unrecognized dtype: %s -- cannot convert value" % spec.dtype
+            return value, spec_dtype
+        if spec_dtype is not None and spec_dtype not in cls.__dtypes:
+            msg = "unrecognized dtype: %s -- cannot convert value" % spec_dtype
             raise ValueError(msg)
         return None, None
 
@@ -594,7 +602,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                             tmp[j] = self.__get_ref_builder(subt.dtype, None, row[j], manager, source=source)
                         bldr_data.append(tuple(tmp))
                     try:
-                        bldr_data, dtype = self.convert_dtype(spec, bldr_data)
+                        # use spec_dtype from self.spec when spec_ext does not specify dtype
+                        bldr_data, dtype = self.convert_dtype(spec, bldr_data, spec_dtype=spec_dtype)
                     except Exception as ex:
                         msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
                         raise Exception(msg) from ex
@@ -618,7 +627,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         self.logger.debug("Building %s '%s' as a dataset"
                                           % (container.__class__.__name__, container.name))
                         try:
-                            bldr_data, dtype = self.convert_dtype(spec, container.data)
+                            # use spec_dtype from self.spec when spec_ext does not specify dtype
+                            bldr_data, dtype = self.convert_dtype(spec, container.data, spec_dtype=spec_dtype)
                         except Exception as ex:
                             msg = 'could not resolve dtype for %s \'%s\'' % (type(container).__name__, container.name)
                             raise Exception(msg) from ex

--- a/tests/unit/build_tests/mapper_tests/test_build.py
+++ b/tests/unit/build_tests/mapper_tests/test_build.py
@@ -1,22 +1,25 @@
 from abc import ABCMeta, abstractmethod
 import numpy as np
 
-from hdmf import Container
+from hdmf import Container, Data
 from hdmf.build import ObjectMapper, BuildManager, TypeMap, GroupBuilder, DatasetBuilder
-from hdmf.utils import docval, getargs, get_docval
+from hdmf.build.warnings import DtypeConversionWarning
+from hdmf.utils import docval, getargs
 from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, Spec
 from hdmf.testing import TestCase
 
 from tests.unit.utils import CORE_NAMESPACE
 
 
-# TODO: test build of extended group with attr that modifies dtype (commented out below), shape, value, etc.
+# TODO: test build of extended group/dataset that modifies an attribute dtype (commented out below), shape, value, etc.
+# by restriction. also check that attributes cannot be deleted or scope expanded.
+# TODO: test build of extended dataset that modifies shape by restriction.
 
 class Bar(Container):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
             {'name': 'attr1', 'type': str, 'doc': 'a string attribute'},
-            {'name': 'attr2', 'type': ('int', 'float', 'uint'), 'doc': 'a numeric attribute', 'default': None},
+            {'name': 'attr2', 'type': 'int', 'doc': 'an int attribute', 'default': None},
             {'name': 'ext_attr', 'type': bool, 'doc': 'a boolean attribute', 'default': True})
     def __init__(self, **kwargs):
         name, attr1, attr2, ext_attr = getargs('name', 'attr1', 'attr2', 'ext_attr', kwargs)
@@ -44,7 +47,7 @@ class Bar(Container):
 
 class BarHolder(Container):
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this BarHolder'},
             {'name': 'bars', 'type': ('data', 'array_data'), 'doc': 'bars', 'default': list()})
     def __init__(self, **kwargs):
         name, bars = getargs('name', 'bars', kwargs)
@@ -79,7 +82,7 @@ class ExtBarMapper(ObjectMapper):
         return super().get_attr_value(**kwargs)
 
 
-class BuildExtAttrsMixin(TestCase, metaclass=ABCMeta):
+class BuildGroupExtAttrsMixin(TestCase, metaclass=ABCMeta):
 
     def setUp(self):
         self.setUpBarSpec()
@@ -111,8 +114,8 @@ class BuildExtAttrsMixin(TestCase, metaclass=ABCMeta):
         )
         attr2_attr = AttributeSpec(
             name='attr2',
-            dtype='numeric',
-            doc='an example numeric attribute',
+            dtype='int',
+            doc='an example int attribute',
         )
         self.bar_spec = GroupSpec(
             doc='A test group specification with a data type',
@@ -125,11 +128,11 @@ class BuildExtAttrsMixin(TestCase, metaclass=ABCMeta):
         pass
 
 
-class TestBuildNewExtAttrs(BuildExtAttrsMixin, TestCase):
+class TestBuildGroupAddedAttr(BuildGroupExtAttrsMixin, TestCase):
     """
-    If the spec defines data_type A (Bar) using 'data_type_def' and defines another data_type B (BarHolder) that
-    includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'.
-    The spec of A' can change or add attributes to the spec of A. This test ensures that *new attributes* in A' are
+    If the spec defines a group data_type A (Bar) using 'data_type_def' and defines another data_type B (BarHolder)
+    that includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'.
+    The spec of A' can refine or add attributes to the spec of A. This test ensures that *added attributes* in A' are
     handled properly.
     """
 
@@ -151,7 +154,7 @@ class TestBuildNewExtAttrs(BuildExtAttrsMixin, TestCase):
             groups=[bar_ext_no_name_spec],
         )
 
-    def test_build_new_attr(self):
+    def test_build_added_attr(self):
         """
         Test build of BarHolder which can contain multiple extended Bar objects, which have a new attribute.
         """
@@ -192,19 +195,19 @@ class TestBuildNewExtAttrs(BuildExtAttrsMixin, TestCase):
         self.assertDictEqual(builder, expected)
 
 
-class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
+class TestBuildGroupRefinedAttr(BuildGroupExtAttrsMixin, TestCase):
     """
-    If the spec defines data_type A (Bar) using 'data_type_def' and defines another data_type B (BarHolder) that
-    includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'.
-    The spec of A' can change or add attributes to the spec of A. This test ensures that *modified attributes* in A' are
+    If the spec defines a group data_type A (Bar) using 'data_type_def' and defines another data_type B (BarHolder)
+    that includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'.
+    The spec of A' can refine or add attributes to the spec of A. This test ensures that *refine attributes* in A' are
     handled properly.
     """
 
     def setUpBarHolderSpec(self):
         int_attr2 = AttributeSpec(
             name='attr2',
-            dtype='int',
-            doc='Refine Bar spec from numeric to int',
+            dtype='int64',
+            doc='Refine Bar spec from int to int64',
         )
         bar_ext_no_name_spec = GroupSpec(
             doc='A Bar extended with modified attribute attr2',
@@ -218,14 +221,14 @@ class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
             groups=[bar_ext_no_name_spec],
         )
 
-    def test_build_mod_attr(self):
+    def test_build_refined_attr(self):
         """
         Test build of BarHolder which can contain multiple extended Bar objects, which have a modified attr2.
         """
         ext_bar_inst = Bar(
             name='my_bar',
             attr1='a string',
-            attr2=10,
+            attr2=np.int64(10),
         )
         bar_holder_inst = BarHolder(
             name='my_bar_holder',
@@ -236,7 +239,7 @@ class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
             name='my_bar',
             attributes={
                 'attr1': 'a string',
-                'attr2': 10,
+                'attr2': np.int64(10),
                 'data_type': 'Bar',
                 'namespace': CORE_NAMESPACE,
                 'object_id': ext_bar_inst.object_id,
@@ -256,14 +259,14 @@ class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
         builder = self.manager.build(bar_holder_inst, source='test.h5')
         self.assertDictEqual(builder, expected)
 
-    # def test_build_mod_attr_wrong_type(self):
+    # def test_build_refined_attr_wrong_type(self):
     #     """
     #     Test build of BarHolder which contains a Bar that has the wrong dtype for an attr.
     #     """
     #     ext_bar_inst = Bar(
     #         name='my_bar',
     #         attr1='a string',
-    #         attr2=10.1,  # spec specifies attr2 should be an int for Bars within BarHolder
+    #         attr2=10,  # spec specifies attr2 should be an int64 for Bars within BarHolder
     #     )
     #     bar_holder_inst = BarHolder(
     #         name='my_bar_holder',
@@ -274,7 +277,7 @@ class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
     #         name='my_bar',
     #         attributes={
     #             'attr1': 'a string',
-    #             'attr2': 10,
+    #             'attr2': np.int64(10),
     #             'data_type': 'Bar',
     #             'namespace': CORE_NAMESPACE,
     #             'object_id': ext_bar_inst.object_id,
@@ -292,6 +295,334 @@ class TestBuildModExtAttrs(BuildExtAttrsMixin, TestCase):
     #
     #     # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
     #
-    #     # TODO build should raise a conversion warning for converting 10.1 (float64) to np.int64
+    #     # TODO build should raise a conversion warning for converting 10 (int32) to np.int64
     #     builder = self.manager.build(bar_holder_inst, source='test.h5')
     #     self.assertDictEqual(builder, expected)
+
+
+class BarData(Data):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this BarData'},
+            {'name': 'data', 'type': ('data', 'array_data'), 'doc': 'the data'},
+            {'name': 'attr1', 'type': str, 'doc': 'a string attribute'},
+            {'name': 'attr2', 'type': 'int', 'doc': 'an int attribute', 'default': None},
+            {'name': 'ext_attr', 'type': bool, 'doc': 'a boolean attribute', 'default': True})
+    def __init__(self, **kwargs):
+        name, data, attr1, attr2, ext_attr = getargs('name', 'data', 'attr1', 'attr2', 'ext_attr', kwargs)
+        super().__init__(name=name, data=data)
+        self.__attr1 = attr1
+        self.__attr2 = attr2
+        self.__ext_attr = kwargs['ext_attr']
+
+    @property
+    def data_type(self):
+        return 'BarData'
+
+    @property
+    def attr1(self):
+        return self.__attr1
+
+    @property
+    def attr2(self):
+        return self.__attr2
+
+    @property
+    def ext_attr(self):
+        return self.__ext_attr
+
+
+class BarDataHolder(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this BarDataHolder'},
+            {'name': 'bar_datas', 'type': ('data', 'array_data'), 'doc': 'bar_datas', 'default': list()})
+    def __init__(self, **kwargs):
+        name, bar_datas = getargs('name', 'bar_datas', kwargs)
+        super().__init__(name=name)
+        self.__bar_datas = bar_datas
+        for b in bar_datas:
+            if b is not None and b.parent is None:
+                b.parent = self
+
+    @property
+    def data_type(self):
+        return 'BarDataHolder'
+
+    @property
+    def bar_datas(self):
+        return self.__bar_datas
+
+
+class ExtBarDataMapper(ObjectMapper):
+
+    @docval({"name": "spec", "type": Spec, "doc": "the spec to get the attribute value for"},
+            {"name": "container", "type": BarData, "doc": "the container to get the attribute value from"},
+            {"name": "manager", "type": BuildManager, "doc": "the BuildManager used for managing this build"},
+            returns='the value of the attribute')
+    def get_attr_value(self, **kwargs):
+        ''' Get the value of the attribute corresponding to this spec from the given container '''
+        spec, container, manager = getargs('spec', 'container', 'manager', kwargs)
+        # handle custom mapping of field 'ext_attr' within container
+        # BardataHolder/BarData -> spec BarDataHolder/BarData.ext_attr
+        if isinstance(container.parent, BarDataHolder):
+            if spec.name == 'ext_attr':
+                return container.ext_attr
+        return super().get_attr_value(**kwargs)
+
+
+class BuildDatasetExtAttrsMixin(TestCase, metaclass=ABCMeta):
+
+    def setUp(self):
+        self.set_up_specs()
+        spec_catalog = SpecCatalog()
+        spec_catalog.register_spec(self.bar_data_spec, 'test.yaml')
+        spec_catalog.register_spec(self.bar_data_holder_spec, 'test.yaml')
+        namespace = SpecNamespace(
+            doc='a test namespace',
+            name=CORE_NAMESPACE,
+            schema=[{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=spec_catalog
+        )
+        namespace_catalog = NamespaceCatalog()
+        namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
+        type_map = TypeMap(namespace_catalog)
+        type_map.register_container_type(CORE_NAMESPACE, 'BarData', BarData)
+        type_map.register_container_type(CORE_NAMESPACE, 'BarDataHolder', BarDataHolder)
+        type_map.register_map(BarData, ExtBarDataMapper)
+        type_map.register_map(BarDataHolder, ObjectMapper)
+        self.manager = BuildManager(type_map)
+
+    def set_up_specs(self):
+        attr1_attr = AttributeSpec(
+            name='attr1',
+            dtype='text',
+            doc='an example string attribute',
+        )
+        attr2_attr = AttributeSpec(
+            name='attr2',
+            dtype='int',
+            doc='an example int attribute',
+        )
+        self.bar_data_spec = DatasetSpec(
+            doc='A test dataset specification with a data type',
+            data_type_def='BarData',
+            dtype='int',
+            shape=[[None], [None, None]],
+            attributes=[attr1_attr, attr2_attr],
+        )
+        self.bar_data_holder_spec = GroupSpec(
+            doc='A container of multiple extended BarData objects',
+            data_type_def='BarDataHolder',
+            datasets=[self.get_refined_bar_data_spec()],
+        )
+
+    @abstractmethod
+    def get_refined_bar_data_spec(self):
+        pass
+
+
+class TestBuildDatasetAddedAttrs(BuildDatasetExtAttrsMixin, TestCase):
+    """
+    If the spec defines a dataset data_type A (BarData) using 'data_type_def' and defines another data_type B
+    (BarHolder) that includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A -
+    call it A'. The spec of A' can refine or add attributes, refine the dtype, refine the shape, or set a fixed value
+    to the spec of A. This test ensures that *added attributes* in A' are handled properly. This is similar to how the
+    spec for a subtype of DynamicTable can contain a VectorData that has a new attribute.
+    """
+
+    def get_refined_bar_data_spec(self):
+        ext_attr = AttributeSpec(
+            name='ext_attr',
+            dtype='bool',
+            doc='A boolean attribute',
+        )
+        refined_spec = DatasetSpec(
+            doc='A BarData extended with attribute ext_attr',
+            data_type_inc='BarData',
+            quantity='*',
+            attributes=[ext_attr],
+        )
+        return refined_spec
+
+    def test_build_added_attr(self):
+        """
+        Test build of BarHolder which can contain multiple extended BarData objects, which have a new attribute.
+        """
+        ext_bar_data_inst = BarData(
+            name='my_bar',
+            data=list(range(10)),
+            attr1='a string',
+            attr2=10,
+            ext_attr=False,
+        )
+        bar_data_holder_inst = BarDataHolder(
+            name='my_bar_holder',
+            bar_datas=[ext_bar_data_inst],
+        )
+
+        expected_inner = DatasetBuilder(
+            name='my_bar',
+            data=list(range(10)),
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10,
+                'data_type': 'BarData',
+                'ext_attr': False,
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_data_inst.object_id,
+            },
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            datasets={'my_bar': expected_inner},
+            attributes={
+                'data_type': 'BarDataHolder',
+                'namespace': CORE_NAMESPACE,
+                'object_id': bar_data_holder_inst.object_id,
+            },
+        )
+
+        # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
+        builder = self.manager.build(bar_data_holder_inst, source='test.h5')
+        self.assertDictEqual(builder, expected)
+
+
+class TestBuildDatasetRefinedDtype(BuildDatasetExtAttrsMixin, TestCase):
+    """
+    If the spec defines a dataset data_type A (BarData) using 'data_type_def' and defines another data_type B
+    (BarHolder) that includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A -
+    call it A'. The spec of A' can refine or add attributes, refine the dtype, refine the shape, or set a fixed value
+    to the spec of A. This test ensures that if A' refines the dtype of A, the build process uses the correct dtype for
+    conversion.
+    """
+
+    def get_refined_bar_data_spec(self):
+        refined_spec = DatasetSpec(
+            doc='A BarData with refined int64 dtype',
+            data_type_inc='BarData',
+            dtype='int64',
+            quantity='*',
+        )
+        return refined_spec
+
+    def test_build_refined_dtype_convert(self):
+        """
+        Test build of BarDataHolder which contains a BarData with data that needs to be converted to the refined dtype.
+        """
+        ext_bar_data_inst = BarData(
+            name='my_bar',
+            data=np.array([1, 2], dtype=np.int32),  # the refined spec says data should be int64s
+            attr1='a string',
+            attr2=10,
+        )
+        bar_data_holder_inst = BarDataHolder(
+            name='my_bar_holder',
+            bar_datas=[ext_bar_data_inst],
+        )
+
+        expected_inner = DatasetBuilder(
+            name='my_bar',
+            data=np.array([1, 2], dtype=np.int64),  # the objectmapper should convert the given data to int64s
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10,
+                'data_type': 'BarData',
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_data_inst.object_id,
+            },
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            datasets={'my_bar': expected_inner},
+            attributes={
+                'data_type': 'BarDataHolder',
+                'namespace': CORE_NAMESPACE,
+                'object_id': bar_data_holder_inst.object_id,
+            },
+        )
+
+        # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
+        msg = ("Spec 'BarDataHolder/BarData': Value with data type int32 is being converted to data type int64 "
+               "as specified.")
+        with self.assertWarnsWith(DtypeConversionWarning, msg):
+            builder = self.manager.build(bar_data_holder_inst, source='test.h5')
+        np.testing.assert_array_equal(builder.datasets['my_bar'].data, expected.datasets['my_bar'].data)
+        self.assertEqual(builder.datasets['my_bar'].data.dtype, np.int64)
+
+
+class TestBuildDatasetNotRefinedDtype(BuildDatasetExtAttrsMixin, TestCase):
+    """
+    If the spec defines a dataset data_type A (BarData) using 'data_type_def' and defines another data_type B
+    (BarHolder) that includes A using 'data_type_inc', then the included A spec is an extended (or refined) spec of A -
+    call it A'. The spec of A' can refine or add attributes, refine the dtype, refine the shape, or set a fixed value
+    to the spec of A. This test ensures that if A' does not refine the dtype of A, the build process uses the correct
+    dtype for conversion.
+    """
+
+    def get_refined_bar_data_spec(self):
+        refined_spec = DatasetSpec(
+            doc='A BarData',
+            data_type_inc='BarData',
+            quantity='*',
+        )
+        return refined_spec
+
+    def test_build_correct_dtype(self):
+        """
+        Test build of BarDataHolder which contains a BarData.
+        """
+        ext_bar_data_inst = BarData(
+            name='my_bar',
+            data=[1, 2],
+            attr1='a string',
+            attr2=10,
+        )
+        bar_data_holder_inst = BarDataHolder(
+            name='my_bar_holder',
+            bar_datas=[ext_bar_data_inst],
+        )
+
+        expected_inner = DatasetBuilder(
+            name='my_bar',
+            data=[1, 2],
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10,
+                'data_type': 'BarData',
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_data_inst.object_id,
+            },
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            datasets={'my_bar': expected_inner},
+            attributes={
+                'data_type': 'BarDataHolder',
+                'namespace': CORE_NAMESPACE,
+                'object_id': bar_data_holder_inst.object_id,
+            },
+        )
+
+        # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
+        builder = self.manager.build(bar_data_holder_inst, source='test.h5')
+        self.assertDictEqual(builder, expected)
+
+    def test_build_incorrect_dtype(self):
+        """
+        Test build of BarDataHolder which contains a BarData
+        """
+        ext_bar_data_inst = BarData(
+            name='my_bar',
+            data=['a', 'b'],
+            attr1='a string',
+            attr2=10,
+        )
+        bar_data_holder_inst = BarDataHolder(
+            name='my_bar_holder',
+            bar_datas=[ext_bar_data_inst],
+        )
+
+        # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
+        msg = "could not resolve dtype for BarData 'my_bar'"
+        with self.assertRaisesWith(Exception, msg):
+            self.manager.build(bar_data_holder_inst, source='test.h5')

--- a/tests/unit/build_tests/mapper_tests/test_build.py
+++ b/tests/unit/build_tests/mapper_tests/test_build.py
@@ -1,0 +1,300 @@
+from abc import ABCMeta, abstractmethod
+import numpy as np
+
+from hdmf import Container
+from hdmf.build import ObjectMapper, BuildManager, TypeMap, GroupBuilder, DatasetBuilder
+from hdmf.utils import docval, getargs, get_docval
+from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, Spec
+from hdmf.testing import TestCase
+
+from tests.unit.utils import CORE_NAMESPACE
+
+
+class Bar(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
+            {'name': 'attr1', 'type': str, 'doc': 'a string attribute'},
+            {'name': 'attr2', 'type': ('int', 'float'), 'doc': 'a numeric attribute', 'default': None},
+            {'name': 'ext_attr', 'type': bool, 'doc': 'a boolean attribute', 'default': True})
+    def __init__(self, **kwargs):
+        name, attr1, attr2, ext_attr = getargs('name', 'attr1', 'attr2', 'ext_attr', kwargs)
+        super().__init__(name=name)
+        self.__attr1 = attr1
+        self.__attr2 = attr2
+        self.__ext_attr = kwargs['ext_attr']
+
+    @property
+    def data_type(self):
+        return 'Bar'
+
+    @property
+    def attr1(self):
+        return self.__attr1
+
+    @property
+    def attr2(self):
+        return self.__attr2
+
+    @property
+    def ext_attr(self):
+        return self.__ext_attr
+
+
+class BarHolder(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
+            {'name': 'bars', 'type': ('data', 'array_data'), 'doc': 'bars', 'default': list()})
+    def __init__(self, **kwargs):
+        name, bar_ext, bars = getargs('name', 'bar_ext', 'bars', kwargs)
+        super().__init__(name=name)
+        self.__bars = bars
+        for b in bars:
+            if b is not None and b.parent is None:
+                b.parent = self
+
+    @property
+    def data_type(self):
+        return 'BarHolder'
+
+    @property
+    def bars(self):
+        return self.__bars
+
+
+class ExtBarMapper(ObjectMapper):
+
+    @docval({"name": "spec", "type": Spec, "doc": "the spec to get the attribute value for"},
+            {"name": "container", "type": Bar, "doc": "the container to get the attribute value from"},
+            {"name": "manager", "type": BuildManager, "doc": "the BuildManager used for managing this build"},
+            returns='the value of the attribute')
+    def get_attr_value(self, **kwargs):
+        ''' Get the value of the attribute corresponding to this spec from the given container '''
+        spec, container, manager = getargs('spec', 'container', 'manager', kwargs)
+        # handle custom mapping of field 'ext_attr' within container BarHolder/Bar -> spec BarHolder/Bar.ext_attr
+        if isinstance(container.parent, BarHolder):
+            if spec.name == 'ext_attr':
+                return container.ext_attr
+        return super().get_attr_value(**kwargs)
+
+
+class ObjectMapperExtAttrsMixin(TestCase, metaclass=ABCMeta):
+
+    def setUp(self):
+        self.setUpBarSpec()
+        self.setUpBarHolderSpec()
+        spec_catalog = SpecCatalog()
+        spec_catalog.register_spec(self.bar_spec, 'test.yaml')
+        spec_catalog.register_spec(self.bar_holder_spec, 'test.yaml')
+        namespace = SpecNamespace(
+            doc='a test namespace',
+            name=CORE_NAMESPACE,
+            schema=[{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=spec_catalog
+        )
+        namespace_catalog = NamespaceCatalog()
+        namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
+        type_map = TypeMap(namespace_catalog)
+        type_map.register_container_type(CORE_NAMESPACE, 'Bar', Bar)
+        type_map.register_container_type(CORE_NAMESPACE, 'BarHolder', BarHolder)
+        type_map.register_map(Bar, ExtBarMapper)
+        type_map.register_map(BarHolder, ObjectMapper)
+        self.manager = BuildManager(type_map)
+
+    def setUpBarSpec(self):
+        attr1_attr = AttributeSpec(
+            name='attr1',
+            dtype='text',
+            doc='an example string attribute',
+        )
+        attr2_attr = AttributeSpec(
+            name='attr2',
+            dtype='numeric',
+            doc='an example numeric attribute',
+        )
+        self.bar_spec = GroupSpec(
+            doc='A test group specification with a data type',
+            data_type_def='Bar',
+            attributes=[attr1_attr, attr2_attr],
+        )
+
+    @abstractmethod
+    def setUpBarHolderSpec(self):
+        pass
+
+
+class TestObjectMapperNewExtAttrs(ObjectMapperExtAttrsMixin, TestCase):
+    """
+    If the spec defines data_type A using 'data_type_def' and defines another data_type B that includes A using
+    'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'. The spec of A' can
+    change or add attributes to the spec of A. This test ensures that new attributes in A' are handled properly.
+
+    The Bar type and class is the type A, and the BarHolder type and class is the type B which can contain multiple
+    A' objects.
+    """
+
+    def setUpBarHolderSpec(self):
+        ext_attr = AttributeSpec(
+            name='ext_attr',
+            dtype='bool',
+            doc='A boolean attribute',
+        )
+        bar_ext_no_name_spec = GroupSpec(
+            doc='A Bar extended with attribute ext_attr',
+            data_type_inc='Bar',
+            quantity='*',
+            attributes=[ext_attr],
+        )
+        self.bar_holder_spec = GroupSpec(
+            doc='A container of multiple extended Bar objects',
+            data_type_def='BarHolder',
+            groups=[bar_ext_no_name_spec],
+        )
+
+    def test_build_new_attr(self):
+        """
+        Test build of BarHolder which can contain multiple extended Bar objects, each of which has a new attribute.
+        """
+        ext_bar_inst = Bar(
+            name='my_bar',
+            attr1='a string',
+            attr2=10,
+            ext_attr=False,
+        )
+        bar_holder_inst = BarHolder(
+            name='my_bar_holder',
+            bars=[ext_bar_inst],
+        )
+
+        expected_inner = GroupBuilder(
+            name='my_bar',
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10,
+                'data_type': 'Bar',
+                'ext_attr': False,
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_inst.object_id,
+            },
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            groups={'my_bar': expected_inner},
+            attributes={
+                'data_type': 'BarHolder',
+                'namespace': CORE_NAMESPACE,
+                'object_id': bar_holder_inst.object_id,
+            },
+        )
+
+        # use this object mapper to build the BarHolder
+        # bar_holder_mapper = ObjectMapper(self.bar_holder_spec)
+        # bar_group_spec = bar_holder_mapper.spec.get_data_type('Bar')
+        # bar_holder_mapper.map_spec('bars', bar_group_spec)  # map BarHolder.bars to the included extended bar types
+        builder = self.manager.build(bar_holder_inst, source='test.h5')
+        self.assertDictEqual(builder, expected)
+
+
+class TestObjectMapperModExtAttrs(ObjectMapperExtAttrsMixin, TestCase):
+    """
+    If the spec defines data_type A using 'data_type_def' and defines another data_type B that includes A using
+    'data_type_inc', then the included A spec is an extended (or refined) spec of A - call it A'. The spec of A' can
+    change or add attributes to the spec of A. This test ensures that modified attributes in A' are handled properly.
+
+    The Bar type and class is the type A, and the BarHolder type and class is the type B which can contain multiple
+    A' objects.
+    """
+
+    def setUpBarHolderSpec(self):
+        int_attr2 = AttributeSpec(
+            name='attr2',
+            dtype='int',
+            doc='Refine Bar spec from numeric to int',
+        )
+        bar_ext_no_name_spec = GroupSpec(
+            doc='A Bar extended with modified attribute attr2',
+            data_type_inc='Bar',
+            quantity='*',
+            attributes=[int_attr2],
+        )
+        self.bar_holder_spec = GroupSpec(
+            doc='A container of multiple extended Bar objects',
+            data_type_def='BarHolder',
+            groups=[bar_ext_no_name_spec],
+        )
+
+    def test_build_mod_attr(self):
+        """
+        Test build of BarHolder which can contain multiple extended Bar objects, each of which has a modified attr2.
+        """
+        ext_bar_inst = Bar(
+            name='my_bar',
+            attr1='a string',
+            attr2=10,
+        )
+        bar_holder_inst = BarHolder(
+            name='my_bar_holder',
+            bars=[ext_bar_inst],
+        )
+
+        expected_inner = GroupBuilder(
+            name='my_bar',
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10,
+                'data_type': 'Bar',
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_inst.object_id,
+            }
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            groups={'my_bar': expected_inner},
+            attributes={
+                'data_type': 'BarHolder',
+                'namespace': CORE_NAMESPACE,
+                'object_id': bar_holder_inst.object_id,
+            }
+        )
+
+        # the object mapper automatically maps the spec of extended Bars to the 'BarMapper.bars' field
+        builder = self.manager.build(bar_holder_inst, source='test.h5')
+        self.assertDictEqual(builder, expected)
+
+    def test_build_mod_attr_mismatch(self):
+        """
+        Test build of BarHolder which can contain multiple extended Bar objects, each of which has a modified attr2.
+        """
+        ext_bar_inst = Bar(
+            name='my_bar',
+            attr1='a string',
+            attr2=10.1,  # pass float instead of int
+        )
+        bar_holder_inst = BarHolder(
+            name='my_bar_holder',
+            bars=[ext_bar_inst],
+        )
+
+        expected_inner = GroupBuilder(
+            name='my_bar',
+            attributes={
+                'attr1': 'a string',
+                'attr2': 10.1,  # <-- this should be an int
+                'data_type': 'Bar',
+                'namespace': CORE_NAMESPACE,
+                'object_id': ext_bar_inst.object_id,
+            }
+        )
+        expected = GroupBuilder(
+            name='my_bar_holder',
+            groups={'my_bar': expected_inner},
+        )
+
+        # use this object mapper to build the BarHolder
+        bar_holder_mapper = ObjectMapper(self.bar_holder_spec)
+        bar_group_spec = bar_holder_mapper.spec.get_data_type('Bar')
+        bar_holder_mapper.map_spec('bars', bar_group_spec)  # map BarHolder.bars to the included extended bar types
+        builder = self.manager.build(bar_holder_inst, )
+        self.assertDictEqual(builder, expected)
+        breakpoint()
+        print('hi')

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -949,12 +949,12 @@ class TestConvertDtype(TestCase):
 
     def test_override_type_numeric_to_uint(self):
         spec = DatasetSpec('an example dataset', 'numeric', name='data')
-        res = ObjectMapper.convert_dtype(spec, 1, 'uint8')
+        res = ObjectMapper.convert_dtype(spec, np.uint32(1), 'uint8')
         self.assertTupleEqual(res, (np.uint32(1), np.uint32))
 
     def test_override_type_numeric_to_uint_list(self):
         spec = DatasetSpec('an example dataset', 'numeric', name='data')
-        res = ObjectMapper.convert_dtype(spec, (1, 2, 3), 'uint8')
+        res = ObjectMapper.convert_dtype(spec, np.uint32((1, 2, 3)), 'uint8')
         np.testing.assert_array_equal(res[0], np.uint32((1, 2, 3)))
         self.assertEqual(res[1], np.uint32)
 

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -916,6 +916,16 @@ class TestConvertDtype(TestCase):
         self.assertTupleEqual(ret, match)
         self.assertIs(ret[0].dtype.type, match[1])
 
+        value = ['a', 'b']
+        msg = "Cannot convert from <class 'str'> to 'numeric' specification dtype."
+        with self.assertRaisesWith(ValueError, msg):
+            ObjectMapper.convert_dtype(spec, value)
+
+        value = np.array(['a', 'b'])
+        msg = "Cannot convert from <class 'numpy.str_'> to 'numeric' specification dtype."
+        with self.assertRaisesWith(ValueError, ''):
+            ObjectMapper.convert_dtype(spec, value)
+
     def test_bool_spec(self):
         spec_type = 'bool'
         spec = DatasetSpec('an example dataset', spec_type, name='data')

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -19,18 +19,18 @@ class Bar(Container):
             {'name': 'attr1', 'type': str, 'doc': 'an attribute'},
             {'name': 'attr2', 'type': int, 'doc': 'another attribute'},
             {'name': 'attr3', 'type': float, 'doc': 'a third attribute', 'default': 3.14},
-            {'name': 'attr4', 'type': bool, 'doc': 'a fourth attribute', 'default': True},
+            {'name': 'attr5', 'type': bool, 'doc': 'a fourth attribute', 'default': True},
             {'name': 'foo', 'type': 'Foo', 'doc': 'a group', 'default': None},
             {'name': 'bars', 'type': ('data', 'array_data'), 'doc': 'a group', 'default': list()})
     def __init__(self, **kwargs):
-        name, data, attr1, attr2, attr3, attr4, foo, bars = getargs('name', 'data', 'attr1', 'attr2', 'attr3',
+        name, data, attr1, attr2, attr3, attr5, foo, bars = getargs('name', 'data', 'attr1', 'attr2', 'attr3',
                                                                     'attr4', 'foo', 'bars', kwargs)
         super().__init__(name=name)
         self.__data = data
         self.__attr1 = attr1
         self.__attr2 = attr2
         self.__attr3 = attr3
-        self.__attr4 = attr4
+        self.__attr5 = attr5
         self.__foo = foo
         if self.__foo is not None and self.__foo.parent is None:
             self.__foo.parent = self
@@ -40,11 +40,11 @@ class Bar(Container):
                 b.parent = self
 
     def __eq__(self, other):
-        attrs = ('name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'foo', 'bars')
+        attrs = ('name', 'data', 'attr1', 'attr2', 'attr3', 'attr5', 'foo', 'bars')
         return all(getattr(self, a) == getattr(other, a) for a in attrs)
 
     def __str__(self):
-        attrs = ('name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'foo', 'bars')
+        attrs = ('name', 'data', 'attr1', 'attr2', 'attr3', 'attr5', 'foo', 'bars')
         return ','.join('%s=%s' % (a, getattr(self, a)) for a in attrs)
 
     @property
@@ -68,8 +68,8 @@ class Bar(Container):
         return self.__attr3
 
     @property
-    def attr4(self):
-        return self.__attr4
+    def attr5(self):
+        return self.__attr5
 
     @property
     def foo(self):
@@ -259,7 +259,7 @@ class TestDynamicContainer(TestCase):
         expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4'}
         received_args = set()
         for x in get_docval(cls.__init__):
-            if x['name'] != 'foo':
+            if x['name'] != 'foo' and x['name'] != 'attr5' and x['name'] != 'bars':
                 received_args.add(x['name'])
                 with self.subTest(name=x['name']):
                     self.assertNotIn('default', x)
@@ -281,7 +281,7 @@ class TestDynamicContainer(TestCase):
                                          AttributeSpec('attr4', 'another example float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
         cls = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz')
-        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'foo'}
+        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'attr5', 'foo', 'bars'}
         received_args = set(map(lambda x: x['name'], get_docval(cls.__init__)))
         self.assertSetEqual(expected_args, received_args)
         self.assertEqual(cls.__name__, 'Baz')
@@ -609,7 +609,7 @@ class TestObjectMapperExtAttrs(ObjectMapperMixin, TestCase):
             doc='A test group specification with a data type',
             data_type_inc='Bar',
             quantity='*',
-            attributes=[AttributeSpec('attr4', 'an example boolean attribute', 'bool')]
+            attributes=[AttributeSpec('attr5', 'an example boolean attribute', 'bool')]
         )
         # self.bar_ext_spec = GroupSpec(
         #     doc='A test group specification with a data type',
@@ -653,7 +653,7 @@ class TestObjectMapperExtAttrs(ObjectMapperMixin, TestCase):
             data=list(range(10)),
             attr1='value_inner_inner',
             attr2=10,
-            attr4=False
+            attr5=False
         )
         # ext_bar1_inst = Bar(
         #     name='my_bar',
@@ -677,7 +677,7 @@ class TestObjectMapperExtAttrs(ObjectMapperMixin, TestCase):
             )},
             attributes={'attr1': 'value_inner_inner',
                         'attr2': 10,
-                        'attr4': False,
+                        'attr5': False,
                         'data_type': 'Bar',
                         'namespace': CORE_NAMESPACE,
                         'object_id': ext_bar2_inst.object_id}
@@ -704,7 +704,6 @@ class TestObjectMapperExtAttrs(ObjectMapperMixin, TestCase):
         bar_group_spec = bar_holder_mapper.spec.get_data_type('Bar')
         bar_holder_mapper.map_spec('bars', bar_group_spec)
         builder = bar_holder_mapper.build(bar_holder_inst, self.manager)
-        breakpoint()
         self.assertDictEqual(builder, expected)
         # TODO builder missing extended attributes
 

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -923,7 +923,7 @@ class TestConvertDtype(TestCase):
 
         value = np.array(['a', 'b'])
         msg = "Cannot convert from <class 'numpy.str_'> to 'numeric' specification dtype."
-        with self.assertRaisesWith(ValueError, ''):
+        with self.assertRaisesWith(ValueError, msg):
             ObjectMapper.convert_dtype(spec, value)
 
     def test_bool_spec(self):


### PR DESCRIPTION
This fixes #363. 

This is related to https://github.com/hdmf-dev/hdmf/pull/301 which dealt with attributes in refined spec. I added some tests for #301 as well. 

I also renamed the private method `ObjectMapper.__resolve_dtype` to `ObjectMapper.__resolve_numeric_dtype` by request.