### PR TITLE
Fix adding of optional predefined columns to `DynamicTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HDMF Changelog
 
+## HDMF 1.6.3 (Upcoming)
+
+### Internal improvements
+- Improve documentation of `DynamicTable`. @rly (#371)
+
+### Bug fixes:
+- Fix adding of optional predefined columns to `DynamicTable`. @rly (#371)
+
 ## HDMF 1.6.2 (May 26, 2020)
 
 ### Internal improvements:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -365,6 +365,7 @@ class DynamicTable(Container):
                     # set the table attributes for not yet init optional predefined columns
                     setattr(self, col['name'], None)
                     if col.get('index', False):
+                        self.__uninit_cols[col['name'] + '_index'] = col
                         setattr(self, col['name'] + '_index', None)
 
     @staticmethod
@@ -535,6 +536,8 @@ class DynamicTable(Container):
         col.parent = self
         columns = [col]
         self.__set_table_attr(col)
+        if col in self.__uninit_cols:
+            self.__uninit_cols.pop(col)
 
         # Add index if it's been specified
         if index is not False:
@@ -555,6 +558,8 @@ class DynamicTable(Container):
             col = col_index
             self.__indices[col_index.name] = col_index
             self.__set_table_attr(col_index)
+            if col_index in self.__uninit_cols:
+                self.__uninit_cols.pop(col_index)
 
         if len(col) != len(self.id):
             raise ValueError("column must have the same number of rows as 'id'")

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -504,16 +504,18 @@ class DynamicTable(Container):
         if name in self.__uninit_cols:  # column is a predefined optional column from the spec
             # check the given values against the predefined optional column spec. if they do not match, raise a warning
             # and ignore the given arguments. users should not be able to override these values
+            table_bool = table or not isinstance(table, bool)
             spec_table = self.__uninit_cols[name].get('table', False)
-            if table != spec_table:
+            if table_bool != spec_table:
                 msg = ("Column '%s' is predefined in %s with table=%s which does not match the entered "
                        "table argument. The entered table argument will be ignored."
                        % (name, self.__class__.__name__, spec_table))
                 warn(msg)
                 table = spec_table
 
+            index_bool = index or not isinstance(index, bool)
             spec_index = self.__uninit_cols[name].get('index', False)
-            if index != spec_index:
+            if index_bool != spec_index:
                 msg = ("Column '%s' is predefined in %s with index=%s which does not match the entered "
                        "index argument. The entered index argument will be ignored."
                        % (name, self.__class__.__name__, spec_index))

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -203,7 +203,8 @@ class DynamicTable(Container):
             {'name': 'id', 'type': ('array_data', ElementIdentifiers), 'doc': 'the identifiers for this table',
              'default': None},
             {'name': 'columns', 'type': (tuple, list), 'doc': 'the columns in this table', 'default': None},
-            {'name': 'colnames', 'type': 'array_data', 'doc': 'the names of the columns in this table',
+            {'name': 'colnames', 'type': 'array_data',
+             'doc': 'the ordered names of the columns in this table. columns must also be provided.',
              'default': None})
     def __init__(self, **kwargs):  # noqa: C901
         id, columns, desc, colnames = popargs('id', 'columns', 'description', 'colnames', kwargs)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -498,6 +498,10 @@ class DynamicTable(Container):
         name, data, description = getargs('name', 'data', 'description', kwargs)
         index, table = popargs('index', 'table', kwargs)
 
+        if isinstance(index, VectorIndex):
+            warn("Passing a VectorIndex in for index may lead to unexpected behavior. This functionality will be "
+                 "deprecated in a future version of HDMF.", FutureWarning)
+
         if name in self.__colids:  # column has already been added
             msg = "column '%s' already exists in %s '%s'" % (name, self.__class__.__name__, self.name)
             raise ValueError(msg)
@@ -509,19 +513,21 @@ class DynamicTable(Container):
             spec_table = self.__uninit_cols[name].get('table', False)
             if table_bool != spec_table:
                 msg = ("Column '%s' is predefined in %s with table=%s which does not match the entered "
-                       "table argument. The entered table argument will be ignored."
+                       "table argument. The predefined table spec will be ignored. "
+                       "Please ensure the new column complies with the spec. "
+                       "This will raise an error in a future version of HDMF."
                        % (name, self.__class__.__name__, spec_table))
                 warn(msg)
-                table = spec_table
 
             index_bool = index or not isinstance(index, bool)
             spec_index = self.__uninit_cols[name].get('index', False)
             if index_bool != spec_index:
                 msg = ("Column '%s' is predefined in %s with index=%s which does not match the entered "
-                       "index argument. The entered index argument will be ignored."
+                       "index argument. The predefined index spec will be ignored. "
+                       "Please ensure the new column complies with the spec. "
+                       "This will raise an error in a future version of HDMF."
                        % (name, self.__class__.__name__, spec_index))
                 warn(msg)
-                index = spec_index
 
         ckwargs = dict(kwargs)
         cls = VectorData

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -233,6 +233,10 @@ class DynamicTable(Container):
             if len(all_names) != len(set(all_names)):
                 raise ValueError("'columns' contains columns with duplicate names: %s" % all_names)
 
+            # TODO: check columns against __columns__
+            # mismatches should raise an error (e.g., a VectorData cannot be passed in with the same name as a
+            # prespecified table region column)
+
             # check column lengths against each other and id length
             # set ids if non-zero cols are provided and ids is empty
             colset = {c.name: c for c in columns}

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -748,7 +748,7 @@ class TestDynamicTableClassColumns(TestCase):
         self.assertTrue(hasattr(table, 'col1'))
 
     def test_init_columns_add_req_column_mismatch_index(self):
-        """Test that passing a required column to init works."""
+        """Test that passing a required column that does not match the predefined column specs raises an error."""
         col1 = VectorData(name='col1', description='column #1')  # override __columns__ description
         col1_ind = VectorIndex(name='col1_index', data=list(), target=col1)
 
@@ -756,7 +756,7 @@ class TestDynamicTableClassColumns(TestCase):
         SubTable(name='subtable', description='subtable description', columns=[col1_ind, col1])
 
     def test_init_columns_add_req_column_mismatch_table(self):
-        """Test that passing a required column to init works."""
+        """Test that passing a required column that does not match the predefined column specs raises an error."""
         dummy_table = DynamicTable(name='dummy', description='dummy table')
         col1 = DynamicTableRegion(name='col1', data=list(), description='column #1', table=dummy_table)
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -85,6 +85,19 @@ class TestDynamicTable(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             DynamicTable("with_columns", 'a test table', id=[0, 1], columns=columns)
 
+    def test_constructor_bad_columns(self):
+        columns = ['bad_column']
+        msg = "'columns' must be a list of dict, VectorData, DynamicTableRegion, or VectorIndex"
+        with self.assertRaisesWith(ValueError, msg):
+            DynamicTable("with_columns", 'a test table', columns=columns)
+
+    def test_constructor_unequal_length_columns(self):
+        columns = [VectorData(name='col1', description='desc', data=[1, 2, 3]),
+                   VectorData(name='col2', description='desc', data=[1, 2])]
+        msg = "columns must be the same length"
+        with self.assertRaisesWith(ValueError, msg):
+            DynamicTable("with_columns", 'a test table', columns=columns)
+
     def add_rows(self, table):
         table.add_row({'foo': 1, 'bar': 10.0, 'baz': 'cat'})
         table.add_row({'foo': 2, 'bar': 20.0, 'baz': 'dog'})

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -677,25 +677,55 @@ class TestDynamicTableClassColumns(TestCase):
         table.add_column(name='col8', description='column #8', index=True, table=True)
         self.assertEqual(table.col8.description, 'column #8')
 
-    def test_add_opt_column_mismatched_table(self):
+    def test_add_opt_column_mismatched_table_true(self):
         """Test that adding an optional column from __columns__ with non-matched table raises a warning."""
         table = SubTable(name='subtable', description='subtable description')
         msg = ("Column 'col2' is predefined in SubTable with table=False which does not match the entered table "
-               "argument. The entered table argument will be ignored.")
+               "argument. The predefined table spec will be ignored. "
+               "Please ensure the new column complies with the spec. "
+               "This will raise an error in a future version of HDMF.")
         with self.assertWarnsWith(UserWarning, msg):
             table.add_column(name='col2', description='column #2', table=True)
         self.assertEqual(table.col2.description, 'column #2')
-        self.assertEqual(type(table.col2), VectorData)  # not DynamicTableRegion
+        self.assertEqual(type(table.col2), DynamicTableRegion)  # not VectorData
 
-    def test_add_opt_column_mismatched_index(self):
+    def test_add_opt_column_mismatched_table_table(self):
+        """Test that adding an optional column from __columns__ with non-matched table raises a warning."""
+        table = SubTable(name='subtable', description='subtable description')
+        msg = ("Column 'col2' is predefined in SubTable with table=False which does not match the entered table "
+               "argument. The predefined table spec will be ignored. "
+               "Please ensure the new column complies with the spec. "
+               "This will raise an error in a future version of HDMF.")
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col2', description='column #2', table=DynamicTable('dummy', 'dummy'))
+        self.assertEqual(table.col2.description, 'column #2')
+        self.assertEqual(type(table.col2), DynamicTableRegion)  # not VectorData
+
+    def test_add_opt_column_mismatched_index_true(self):
         """Test that adding an optional column from __columns__ with non-matched table raises a warning."""
         table = SubTable(name='subtable', description='subtable description')
         msg = ("Column 'col2' is predefined in SubTable with index=False which does not match the entered index "
-               "argument. The entered index argument will be ignored.")
+               "argument. The predefined index spec will be ignored. "
+               "Please ensure the new column complies with the spec. "
+               "This will raise an error in a future version of HDMF.")
         with self.assertWarnsWith(UserWarning, msg):
             table.add_column(name='col2', description='column #2', index=True)
         self.assertEqual(table.col2.description, 'column #2')
-        self.assertEqual(type(table.get('col2')), VectorData)  # not VectorIndex
+        self.assertEqual(type(table.get('col2')), VectorIndex)  # not VectorData
+
+    def test_add_opt_column_mismatched_index_data(self):
+        """Test that adding an optional column from __columns__ with non-matched table raises a warning."""
+        table = SubTable(name='subtable', description='subtable description')
+        table.add_row(col1='a', col3='c', col5='e', col7='g')
+        table.add_row(col1='a', col3='c', col5='e', col7='g')
+        msg = ("Column 'col2' is predefined in SubTable with index=False which does not match the entered index "
+               "argument. The predefined index spec will be ignored. "
+               "Please ensure the new column complies with the spec. "
+               "This will raise an error in a future version of HDMF.")
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col2', description='column #2', data=[1, 2, 3], index=[1, 2])
+        self.assertEqual(table.col2.description, 'column #2')
+        self.assertEqual(type(table.get('col2')), VectorIndex)  # not VectorData
 
     def test_add_opt_column_twice(self):
         """Test that adding an optional column from __columns__ twice fails the second time."""

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -610,13 +610,16 @@ class TestDynamicTableClassColumns(TestCase):
         self.assertEqual(table['col1'].description, 'required column')
         # self.assertEqual(table['col3'].description, 'required, indexed column')  # TODO this should work
 
-        # col2, col4 are not yet accessible
+        self.assertIsNone(table.col2)
+        self.assertIsNone(table.col4)
+        self.assertIsNone(table.col4_index)
+        self.assertIsNone(table.col6)
+        self.assertIsNone(table.col8)
+        self.assertIsNone(table.col8_index)
+
+        # uninitialized optional predefined columns cannot be accessed in this manner
         with self.assertRaisesWith(KeyError, "'col2'"):
             table['col2']
-
-        msg = "'SubTable' object has no attribute 'col2'"
-        with self.assertRaisesWith(AttributeError, msg):
-            table.col2
 
     def test_gather_columns_inheritance(self):
         """Test that gathering columns across a type hierarchy works."""

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -145,6 +145,16 @@ class TestDynamicTable(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             table.add_column(name='qux', description='qux column')
 
+    def test_add_column_vectorindex(self):
+        table = self.with_spec()
+        table.add_column(name='qux', description='qux column')
+        ind = VectorIndex(name='bar', data=list(), target=table['qux'])
+
+        msg = ("Passing a VectorIndex in for index may lead to unexpected behavior. This functionality will be "
+               "deprecated in a future version of HDMF.")
+        with self.assertWarnsWith(FutureWarning, msg):
+            table.add_column(name='bad', description='bad column', index=ind)
+
     def test_getitem_row_num(self):
         table = self.with_spec()
         self.add_rows(table)


### PR DESCRIPTION
## Motivation

Fix #370, fix #357.

Also do minor refactoring, add comments, and improve table test coverage. Total coverage is up 0.5%!

## How to test the behavior?

See `test_table.py`

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
