### PR TITLE
Improve logging of build and write processes

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -775,6 +775,8 @@ class HDF5IO(HDMFIO):
         # source will indicate target_builder's location
         if parent.file.filename == target_builder.source:
             link_obj = SoftLink(path)
+            self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
+                              % (parent.name, name, link_obj.path))
         elif target_builder.source is not None:
             target_filename = os.path.abspath(target_builder.source)
             parent_filename = os.path.abspath(parent.file.filename)
@@ -782,12 +784,12 @@ class HDF5IO(HDMFIO):
             if target_builder.location is not None:
                 path = target_builder.location + path
             link_obj = ExternalLink(relative_path, path)
+            self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
+                              % (parent.name, name, link_obj.filename, link_obj.path))
         else:
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        self.logger.debug("    Created %s '%s/%s' to '%s://%s'"
-                          % (link_obj.__class__.__name__, parent.name, name, link_obj.filename, link_obj.path))
         builder.written = True
         return link_obj
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -691,13 +691,13 @@ class HDF5IO(HDMFIO):
                         self.__queue_ref(self._make_attr_ref_filler(obj, key, tmp))
                     else:
                         value = np.array(value)
-                self.logger.debug("Setting attribute on %s '%s' attribute '%s' to %s"
+                self.logger.debug("Setting %s '%s' attribute '%s' to %s"
                                   % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
                 obj.attrs[key] = value
             elif isinstance(value, (Container, Builder, ReferenceBuilder)):           # a reference
                 self.__queue_ref(self._make_attr_ref_filler(obj, key, value))
             else:
-                self.logger.debug("Setting attribute on %s '%s' attribute '%s' to %s"
+                self.logger.debug("Setting %s '%s' attribute '%s' to %s"
                                   % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
                 obj.attrs[key] = value                   # a regular scalar
 
@@ -705,7 +705,7 @@ class HDF5IO(HDMFIO):
         '''
             Make the callable for setting references to attributes
         '''
-        self.logger.debug("Queueing set attribute on %s '%s' attribute '%s' to %s"
+        self.logger.debug("Queueing set %s '%s' attribute '%s' to %s"
                           % (obj.__class__.__name__, obj.name, key, value.__class__.__name__))
         if isinstance(value, (tuple, list)):
             def _filler():
@@ -725,7 +725,7 @@ class HDF5IO(HDMFIO):
             returns='the Group that was created', rtype='Group')
     def write_group(self, **kwargs):
         parent, builder, exhaust_dci = getargs('parent', 'builder', 'exhaust_dci', kwargs)
-        self.logger.debug("Writing group builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             group = parent[builder.name]
         else:
@@ -766,7 +766,7 @@ class HDF5IO(HDMFIO):
             returns='the Link that was created', rtype='Link')
     def write_link(self, **kwargs):
         parent, builder = getargs('parent', 'builder', kwargs)
-        self.logger.debug("Writing link builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             return None
         name = builder.name
@@ -786,6 +786,8 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
+        self.logger.debug("    Created %s '%s/%s' to '%s://%s'"
+                          % (link_obj.__class__.__name__, parent.name, name, link_obj.filename, link_obj.path))
         builder.written = True
         return link_obj
 
@@ -803,7 +805,7 @@ class HDF5IO(HDMFIO):
         __scalar_fill__, __list_fill__ and __setup_chunked_dset__ to write the data.
         """
         parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
-        self.logger.debug("Writing dataset builder '%s' to HDF5 Group under parent '%s'" % (builder.name, parent.name))
+        self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             return None
         name = builder.name

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -147,8 +147,9 @@ class BuildManager:
         result = self.__builders.get(container_id)
         source, spec_ext = getargs('source', 'spec_ext', kwargs)
         if result is None:
-            self.logger.debug("Building %s '%s' with extended spec (%s) new"
-                              % (container.__class__.__name__, container.name, spec_ext is not None))
+            self.logger.debug("Building new %s '%s' (container_source: %s, source: %s, extended spec: %s)"
+                              % (container.__class__.__name__, container.name, repr(container.container_source),
+                                 repr(source), spec_ext is not None))
             if container.container_source is None:
                 container.container_source = source
             else:
@@ -163,14 +164,16 @@ class BuildManager:
             self.prebuilt(container, result)
             self.logger.debug("Done building %s '%s'" % (container.__class__.__name__, container.name))
         elif container.modified or spec_ext is not None:
-            self.logger.debug("Building %s '%s' modified (%s) / has extended spec (%s) "
-                              % (container.__class__.__name__, container.name, container.modified,
-                                 spec_ext is not None))
             if isinstance(result, BaseBuilder):
+                self.logger.debug("Rebuilding modified / extended %s '%s' (modified: %s, source: %s, extended spec: %s)"
+                                  % (container.__class__.__name__, container.name, container.modified,
+                                     source, spec_ext is not None))
                 result = self.__type_map.build(container, self, builder=result, source=source, spec_ext=spec_ext)
-                self.logger.debug("Done building %s '%s'" % (container.__class__.__name__, container.name))
+                self.logger.debug("Done rebuilding %s '%s'" % (container.__class__.__name__, container.name))
         else:
-            self.logger.debug("Using prebuilt builder for %s '%s'" % (container.__class__.__name__, container.name))
+            self.logger.debug("Using prebuilt %s '%s' for %s '%s'"
+                              % (result.__class__.__name__, result.name,
+                                 container.__class__.__name__, container.name))
         return result
 
     @docval({"name": "container", "type": AbstractContainer, "doc": "the AbstractContainer to save as prebuilt"},


### PR DESCRIPTION
## Motivation

This PR is cherry-picked from #326 and contains only changes that improve the logging of the build and HDF5 write process. I added more debug statements and made existing ones more detailed. These may clutter the code, but they are actually very useful in tracing the build process and seeing where export goes wrong or other issues.

## How to test the behavior?
Add logging like so:
```python
import logging

logger = logging.getLogger()
logger.setLevel(logging.DEBUG)

ch = logging.FileHandler('test.log', mode='w')
ch.setLevel(logging.DEBUG)
formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
ch.setFormatter(formatter)
logger.addHandler(ch)

```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
