### PR TITLE
Prepare release 1.6.3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,6 +1,6 @@
-# Prepare a release
+Prepare for release of HDMF [version]
 
-Before merging:
+### Before merging:
 - [ ] Minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`, `requirements-doc.txt`, `requirements-min.txt` as needed. See https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`, and any other locations as needed
 - [ ] Update `setup.py` as needed
@@ -14,7 +14,7 @@ Before merging:
 - [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
   build docs for new branch): https://readthedocs.org/projects/hdmf/builds/
 
-After merging:
+### After merging:
 1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
 2. After the CI bot creates the new release (wait ~10 min), update the release notes on the [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
 3. Check that the readthedocs "latest" and "stable" builds run and succeed

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,21 @@
+# Prepare a release
+
+Before merging:
+- [ ] Minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`, `requirements-doc.txt`, `requirements-min.txt` as needed. See https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
+- [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`, and any other locations as needed
+- [ ] Update `setup.py` as needed
+- [ ] Update `README.rst` as needed
+- [ ] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number manually.
+- [ ] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
+- [ ] Run tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
+- [ ] Run PyNWB tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
+- [ ] Test docs locally (`make apidoc`, `make html`)
+- [ ] Push changes to this PR and make sure all PRs to be included in this release have been merged
+- [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
+  build docs for new branch): https://readthedocs.org/projects/hdmf/builds/
+
+After merging:
+1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
+2. After the CI bot creates the new release (wait ~10 min), update the release notes on the [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
+3. Check that the readthedocs "latest" and "stable" builds run and succeed
+4. Update [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,16 @@
----
-name: Pull request
-about: Create a pull request to help us improve
-title: ''
-labels: ''
-assignees: ''
-
----
-
 ## Motivation
 
 What was the reasoning behind this change? Please explain the changes briefly.
 
 ## How to test the behavior?
 ```
-Show here how to reproduce the new behavior (can be a bug fix or a new feature)
+Show how to reproduce the new behavior (can be a bug fix or a new feature)
 ```
 
 ## Checklist
 
 - [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
-- [ ] Have you ensured the PR description clearly describes problem and the solution?
-- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
+- [ ] Have you ensured the PR clearly describes the problem and the solution?
+- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
 - [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
-- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ? By including "Fix #XXX" you allow GitHub to close the corresponding issue.
+- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # HDMF Changelog
 
-## HDMF 1.6.3 (Upcoming)
+## HDMF 1.6.3 (June 9, 2020)
 
 ### Internal improvements
 - Improve documentation of `DynamicTable`. @rly (#371)
+- Add user guide / tutorial for `DynamicTable`. @rly (#372)
+- Improve logging of build and write processes. @rly (#373)
 
 ### Bug fixes:
 - Fix adding of optional predefined columns to `DynamicTable`. @rly (#371)
+- Use dtype from dataset data_type definition when extended spec lacks dtype. @rly (#364)
 
 ## HDMF 1.6.2 (May 26, 2020)
 

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -944,7 +944,7 @@ class TestConvertDtype(TestCase):
 
     def test_override_type_int_restrict_precision(self):
         spec = DatasetSpec('an example dataset', 'int8', name='data')
-        res = ObjectMapper.convert_dtype(spec, 1, 'int64')
+        res = ObjectMapper.convert_dtype(spec, np.int64(1), 'int64')
         self.assertTupleEqual(res, (np.int64(1), np.int64))
 
     def test_override_type_numeric_to_uint(self):


### PR DESCRIPTION
Prepare for release of HDMF 1.6.3

### Before merging:
- [x] Minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`, `requirements-doc.txt`, `requirements-min.txt` as needed. See https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
- [x] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`, and any other locations as needed
- [x] Update `setup.py` as needed
- [x] Update `README.rst` as needed
- [x] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number manually.
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
- [x] Run PyNWB tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
- [x] Test docs locally (`make apidoc`, `make html`)
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/hdmf/builds/

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
3. Check that the readthedocs "latest" and "stable" builds run and succeed
4. Update [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock)
