### PR TITLE
Fix validator for empty arrays and scalar attributes

### DIFF
--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -323,7 +323,10 @@ class AttributeValidator(Validator):
                     pass
             shape = get_data_shape(value)
             if not check_shape(spec.shape, shape):
-                ret.append(ShapeError(self.get_spec_loc(spec), spec.shape, shape))
+                if shape is None:
+                    ret.append(ExpectedArrayError(self.get_spec_loc(self.spec), self.spec.shape, str(value)))
+                else:
+                    ret.append(ShapeError(self.get_spec_loc(spec), spec.shape, shape))
         return ret
 
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -95,6 +95,10 @@ def _check_isodatetime(s, default=None):
     return default
 
 
+class EmptyArrayError(Exception):
+    pass
+
+
 def get_type(data):
     if isinstance(data, str):
         return _check_isodatetime(data, 'utf')
@@ -105,6 +109,8 @@ def get_type(data):
     elif isinstance(data, ReferenceBuilder):
         return 'object'
     elif isinstance(data, np.ndarray):
+        if data.size == 0:
+            raise EmptyArrayError()
         return get_type(data[0])
     if not hasattr(data, '__len__'):
         return type(data).__name__
@@ -114,7 +120,7 @@ def get_type(data):
                 return get_type(data[0])
             return data.dtype
         if len(data) == 0:
-            raise ValueError('cannot determine type for empty data')
+            raise EmptyArrayError()
         return get_type(data[0])
 
 
@@ -295,7 +301,12 @@ class AttributeValidator(Validator):
             elif isinstance(spec.dtype, RefSpec):
                 if not isinstance(value, BaseBuilder):
                     expected = '%s reference' % spec.dtype.reftype
-                    ret.append(DtypeError(self.get_spec_loc(spec), expected, get_type(value)))
+                    try:
+                        value_type = get_type(value)
+                        ret.append(DtypeError(self.get_spec_loc(spec), expected, value_type))
+                    except EmptyArrayError:
+                        # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
+                        pass
                 else:
                     target_spec = self.vmap.namespace.catalog.get_spec(spec.dtype.target_type)
                     data_type = value.attributes.get(target_spec.type_key())
@@ -303,9 +314,13 @@ class AttributeValidator(Validator):
                     if spec.dtype.target_type not in hierarchy:
                         ret.append(IncorrectDataType(self.get_spec_loc(spec), spec.dtype.target_type, data_type))
             else:
-                dtype = get_type(value)
-                if not check_type(spec.dtype, dtype):
-                    ret.append(DtypeError(self.get_spec_loc(spec), spec.dtype, dtype))
+                try:
+                    dtype = get_type(value)
+                    if not check_type(spec.dtype, dtype):
+                        ret.append(DtypeError(self.get_spec_loc(spec), spec.dtype, dtype))
+                except EmptyArrayError:
+                    # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
+                    pass
             shape = get_data_shape(value)
             if not check_shape(spec.shape, shape):
                 ret.append(ShapeError(self.get_spec_loc(spec), spec.shape, shape))
@@ -358,10 +373,14 @@ class DatasetValidator(BaseStorageValidator):
         ret = super().validate(builder)
         data = builder.data
         if self.spec.dtype is not None:
-            dtype = get_type(data)
-            if not check_type(self.spec.dtype, dtype):
-                ret.append(DtypeError(self.get_spec_loc(self.spec), self.spec.dtype, dtype,
-                                      location=self.get_builder_loc(builder)))
+            try:
+                dtype = get_type(data)
+                if not check_type(self.spec.dtype, dtype):
+                    ret.append(DtypeError(self.get_spec_loc(self.spec), self.spec.dtype, dtype,
+                                          location=self.get_builder_loc(builder)))
+            except EmptyArrayError:
+                # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
+                pass
         shape = get_data_shape(data)
         if not check_shape(self.spec.shape, shape):
             if shape is None:

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -292,3 +292,54 @@ class TestDtypeValidation(TestCase):
         expected_errors = {"Bar/attr1 (my_bar.attr1): incorrect type - expected 'numeric', got 'bool'",
                            "Bar/data (my_bar/data): incorrect type - expected 'numeric', got 'bool'"}
         self.assertEqual(result_strings, expected_errors)
+
+
+class Test1DArrayValidation(TestCase):
+
+    def set_up_spec(self, dtype):
+        spec_catalog = SpecCatalog()
+        spec = GroupSpec('A test group specification with a data type',
+                         data_type_def='Bar',
+                         datasets=[DatasetSpec('an example dataset', dtype, name='data', shape=(None, ))],
+                         attributes=[AttributeSpec('attr1', 'an example attribute', dtype, shape=(None, ))])
+        spec_catalog.register_spec(spec, 'test.yaml')
+        self.namespace = SpecNamespace(
+            'a test namespace', CORE_NAMESPACE, [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
+        self.vmap = ValidatorMap(self.namespace)
+
+    def test_scalar(self):
+        """Test that validator does not allow a scalar where an array is specified."""
+        self.set_up_spec('text')
+        value = 'a string'
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        result_strings = set([str(s) for s in results])
+        expected_errors = {("Bar/attr1 (my_bar.attr1): incorrect shape - expected an array of shape '(None,)', "
+                            "got non-array data 'a string'"),
+                           ("Bar/data (my_bar/data): incorrect shape - expected an array of shape '(None,)', "
+                            "got non-array data 'a string'")}
+        self.assertEqual(result_strings, expected_errors)
+
+    def test_empty_list(self):
+        """Test that validator allows an empty list where an array is specified."""
+        self.set_up_spec('text')
+        value = []
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
+    def test_empty_nparray(self):
+        """Test that validator allows an empty numpy array where an array is specified."""
+        self.set_up_spec('text')
+        value = np.array([])  # note: dtype is float64
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
+    # TODO test shape validation more completely


### PR DESCRIPTION
## Motivation

Fix #375 and fix #376 

## How to test the behavior?
```
See validator tests
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
