### PR TITLE
Move written flag from builder to HDF5IO, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HDMF Changelog
 
+## HDMF 2.0.0 (Upcoming)
+
+### Internal improvements
+
+#### Breaking changes
+- `Builder` objects no longer have the `written` field which was used by `HDF5IO` to mark the object as written. This
+  is replaced by `HDF5IO.get_written`. @rly (#381)
+
 ## HDMF 1.6.4 (Upcoming)
 
 ### Bug fixes:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -72,6 +72,7 @@ class HDF5IO(HDMFIO):
         self.__ref_queue = deque()  # a queue of the references that need to be added
         self.__dci_queue = deque()  # a queue of DataChunkIterators that need to be exhausted
         ObjectMapper.no_convert(Dataset)
+        self._written_builders = dict()  # keep track of which builders were written (or read) by this IO object
 
     @property
     def comm(self):
@@ -344,6 +345,21 @@ class HDF5IO(HDMFIO):
             self.__read[self.__file] = f_builder
         return f_builder
 
+    def set_written(self, builder):
+        """Mark this builder as written."""
+        # currently all values in self._written_builders are True, so this could be a set but is a dict for
+        # future flexibility
+        builder_id = self.__bldrhash__(builder)
+        self._written_builders[builder_id] = True
+
+    def get_written(self, builder):
+        """Return True if this builder has been written to (or read from) disk by this IO object."""
+        builder_id = self.__bldrhash__(builder)
+        return self._written_builders.get(builder_id, False)
+
+    def __bldrhash__(self, obj):
+        return id(obj)
+
     def __set_built(self, fpath, id, builder):
         """
         Update self.__built to cache the given builder for the given file and id.
@@ -440,7 +456,7 @@ class HDF5IO(HDMFIO):
                         self.__set_built(sub_h5obj.file.filename,  sub_h5obj.file[target_path].id, builder)
                     builder.location = parent_loc
                     link_builder = LinkBuilder(builder, k, source=h5obj.file.filename)
-                    link_builder.written = True
+                    self.set_written(link_builder)
                     kwargs['links'][builder_name] = link_builder
                 else:
                     builder = self.__get_built(sub_h5obj.file.filename, sub_h5obj.id)
@@ -462,7 +478,7 @@ class HDF5IO(HDMFIO):
                 continue
         kwargs['source'] = h5obj.file.filename
         ret = GroupBuilder(name, **kwargs)
-        ret.written = True
+        self.set_written(ret)
         return ret
 
     def __read_dataset(self, h5obj, name=None):
@@ -515,7 +531,7 @@ class HDF5IO(HDMFIO):
         else:
             kwargs["data"] = h5obj
         ret = DatasetBuilder(name, **kwargs)
-        ret.written = True
+        self.set_written(ret)
         return ret
 
     def __read_attrs(self, h5obj):
@@ -573,6 +589,7 @@ class HDF5IO(HDMFIO):
         self.set_attributes(self.__file, f_builder.attributes)
         self.__add_refs()
         self.__exhaust_dcis()
+        self.set_written(f_builder)
 
     def __add_refs(self):
         '''
@@ -726,8 +743,10 @@ class HDF5IO(HDMFIO):
     def write_group(self, **kwargs):
         parent, builder, exhaust_dci = getargs('parent', 'builder', 'exhaust_dci', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             group = parent[builder.name]
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write group '%s' because it already exists." % self.__get_path(builder))
         else:
             group = parent.create_group(builder.name)
         # write all groups
@@ -748,7 +767,7 @@ class HDF5IO(HDMFIO):
                 self.write_link(group, sub_builder)
         attributes = builder.attributes
         self.set_attributes(group, attributes)
-        builder.written = True
+        self.set_written(builder)
         return group
 
     def __get_path(self, builder):
@@ -767,8 +786,10 @@ class HDF5IO(HDMFIO):
     def write_link(self, **kwargs):
         parent, builder = getargs('parent', 'builder', kwargs)
         self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             return None
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write link '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         target_builder = builder.builder
         path = self.__get_path(target_builder)
@@ -790,7 +811,7 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        builder.written = True
+        self.set_written(builder)
         return link_obj
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
@@ -808,8 +829,10 @@ class HDF5IO(HDMFIO):
         """
         parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
         self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
-        if builder.written:
+        if self.get_written(builder):
             return None
+        # elif builder.name in parent:
+        #     raise WriteError("Cannot write dataset '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         data = builder.data
         options = dict()   # dict with additional
@@ -860,7 +883,7 @@ class HDF5IO(HDMFIO):
                     msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)
                     raise Exception(msg) from exc
                 dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
-                builder.written = True
+                self.set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing references. attributes: %s"
                                   % (name, list(attributes.keys())))
 
@@ -884,10 +907,10 @@ class HDF5IO(HDMFIO):
         # NOTE: we can ignore options['io_settings'] for scalar data
         elif self.__is_ref(options['dtype']):
             _dtype = self.__dtypes.get(options['dtype'])
+            self.set_written(builder)
             # Write a scalar data region reference dataset
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
-                builder.written = True
                 self.logger.debug("Queueing set attribute on dataset '%s' containing a region reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -900,7 +923,6 @@ class HDF5IO(HDMFIO):
             # Write a scalar object reference dataset
             elif isinstance(data, ReferenceBuilder):
                 dset = parent.require_dataset(name, dtype=_dtype, shape=())
-                builder.written = True
                 self.logger.debug("Queueing set attribute on dataset '%s' containing an object reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -915,7 +937,6 @@ class HDF5IO(HDMFIO):
                 # Write a array of region references
                 if options['dtype'] == 'region':
                     dset = parent.require_dataset(name, dtype=_dtype, shape=(len(data),), **options['io_settings'])
-                    builder.written = True
                     self.logger.debug("Queueing set attribute on dataset '%s' containing region references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 
@@ -929,8 +950,7 @@ class HDF5IO(HDMFIO):
                         self.set_attributes(dset, attributes)
                 # Write array of object references
                 else:
-                    dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, ** options['io_settings'])
-                    builder.written = True
+                    dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
                     self.logger.debug("Queueing set attribute on dataset '%s' containing object references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 
@@ -964,10 +984,9 @@ class HDF5IO(HDMFIO):
         # Validate the attributes on the linked dataset
         elif len(attributes) > 0:
             pass
-        builder.written = True
+        self.set_written(builder)
         if exhaust_dci:
             self.__exhaust_dcis()
-        return
 
     @classmethod
     def __scalar_fill__(cls, parent, name, data, options=None):
@@ -1202,3 +1221,7 @@ class HDF5IO(HDMFIO):
         Return the HDF5 file mode. One of ("w", "r", "r+", "a", "w-", "x").
         """
         return self.__mode
+
+
+class WriteError(Exception):
+    pass

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1221,7 +1221,3 @@ class HDF5IO(HDMFIO):
         Return the HDF5 file mode. One of ("w", "r", "r+", "a", "w-", "x").
         """
         return self.__mode
-
-
-class WriteError(Exception):
-    pass

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -354,7 +354,7 @@ class HDF5IO(HDMFIO):
         """
         # currently all values in self._written_builders are True, so this could be a set but is a dict for
         # future flexibility
-        builder_id = self.__bldrhash__(builder)
+        builder_id = self.__builderhash(builder)
         self._written_builders[builder_id] = True
 
     def get_written(self, builder):
@@ -365,10 +365,10 @@ class HDF5IO(HDMFIO):
 
         :return: True if the builder is found in self._written_builders using the builder ID, False otherwise
         """
-        builder_id = self.__bldrhash__(builder)
+        builder_id = self.__builderhash(builder)
         return self._written_builders.get(builder_id, False)
 
-    def __bldrhash__(self, obj):
+    def __builderhash(self, obj):
         """Return the ID of a builder for use as a unique hash."""
         return id(obj)
 
@@ -913,10 +913,10 @@ class HDF5IO(HDMFIO):
         # NOTE: we can ignore options['io_settings'] for scalar data
         elif self.__is_ref(options['dtype']):
             _dtype = self.__dtypes.get(options['dtype'])
-            self.__set_written(builder)
             # Write a scalar data region reference dataset
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
+                self.__set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing a region reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -929,6 +929,7 @@ class HDF5IO(HDMFIO):
             # Write a scalar object reference dataset
             elif isinstance(data, ReferenceBuilder):
                 dset = parent.require_dataset(name, dtype=_dtype, shape=())
+                self.__set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing an object reference. "
                                   "attributes: %s" % (name, list(attributes.keys())))
 
@@ -943,6 +944,7 @@ class HDF5IO(HDMFIO):
                 # Write a array of region references
                 if options['dtype'] == 'region':
                     dset = parent.require_dataset(name, dtype=_dtype, shape=(len(data),), **options['io_settings'])
+                    self.__set_written(builder)
                     self.logger.debug("Queueing set attribute on dataset '%s' containing region references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 
@@ -957,6 +959,7 @@ class HDF5IO(HDMFIO):
                 # Write array of object references
                 else:
                     dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
+                    self.__set_written(builder)
                     self.logger.debug("Queueing set attribute on dataset '%s' containing object references. "
                                       "attributes: %s" % (name, list(attributes.keys())))
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -757,8 +757,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             group = parent[builder.name]
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write group '%s' because it already exists." % self.__get_path(builder))
         else:
             group = parent.create_group(builder.name)
         # write all groups
@@ -800,8 +798,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             return None
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write link '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         target_builder = builder.builder
         path = self.__get_path(target_builder)
@@ -843,8 +839,6 @@ class HDF5IO(HDMFIO):
         self.logger.debug("Writing DatasetBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
             return None
-        # elif builder.name in parent:
-        #     raise WriteError("Cannot write dataset '%s' because it already exists." % self.__get_path(builder))
         name = builder.name
         data = builder.data
         options = dict()   # dict with additional

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -345,19 +345,31 @@ class HDF5IO(HDMFIO):
             self.__read[self.__file] = f_builder
         return f_builder
 
-    def set_written(self, builder):
-        """Mark this builder as written."""
+    def __set_written(self, builder):
+        """
+        Mark this builder as written.
+
+        :param builder: Builder object to be marked as written
+        :type builder: Builder
+        """
         # currently all values in self._written_builders are True, so this could be a set but is a dict for
         # future flexibility
         builder_id = self.__bldrhash__(builder)
         self._written_builders[builder_id] = True
 
     def get_written(self, builder):
-        """Return True if this builder has been written to (or read from) disk by this IO object."""
+        """Return True if this builder has been written to (or read from) disk by this IO object, False otherwise.
+
+        :param builder: Builder object to get the written flag for
+        :type builder: Builder
+
+        :return: True if the builder is found in self._written_builders using the builder ID, False otherwise
+        """
         builder_id = self.__bldrhash__(builder)
         return self._written_builders.get(builder_id, False)
 
     def __bldrhash__(self, obj):
+        """Return the ID of a builder for use as a unique hash."""
         return id(obj)
 
     def __set_built(self, fpath, id, builder):
@@ -456,7 +468,7 @@ class HDF5IO(HDMFIO):
                         self.__set_built(sub_h5obj.file.filename,  sub_h5obj.file[target_path].id, builder)
                     builder.location = parent_loc
                     link_builder = LinkBuilder(builder, k, source=h5obj.file.filename)
-                    self.set_written(link_builder)
+                    self.__set_written(link_builder)
                     kwargs['links'][builder_name] = link_builder
                 else:
                     builder = self.__get_built(sub_h5obj.file.filename, sub_h5obj.id)
@@ -478,7 +490,7 @@ class HDF5IO(HDMFIO):
                 continue
         kwargs['source'] = h5obj.file.filename
         ret = GroupBuilder(name, **kwargs)
-        self.set_written(ret)
+        self.__set_written(ret)
         return ret
 
     def __read_dataset(self, h5obj, name=None):
@@ -531,7 +543,7 @@ class HDF5IO(HDMFIO):
         else:
             kwargs["data"] = h5obj
         ret = DatasetBuilder(name, **kwargs)
-        self.set_written(ret)
+        self.__set_written(ret)
         return ret
 
     def __read_attrs(self, h5obj):
@@ -589,7 +601,7 @@ class HDF5IO(HDMFIO):
         self.set_attributes(self.__file, f_builder.attributes)
         self.__add_refs()
         self.__exhaust_dcis()
-        self.set_written(f_builder)
+        self.__set_written(f_builder)
 
     def __add_refs(self):
         '''
@@ -767,7 +779,7 @@ class HDF5IO(HDMFIO):
                 self.write_link(group, sub_builder)
         attributes = builder.attributes
         self.set_attributes(group, attributes)
-        self.set_written(builder)
+        self.__set_written(builder)
         return group
 
     def __get_path(self, builder):
@@ -811,7 +823,7 @@ class HDF5IO(HDMFIO):
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
         parent[name] = link_obj
-        self.set_written(builder)
+        self.__set_written(builder)
         return link_obj
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
@@ -883,7 +895,7 @@ class HDF5IO(HDMFIO):
                     msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)
                     raise Exception(msg) from exc
                 dset = parent.require_dataset(name, shape=(len(data),), dtype=_dtype, **options['io_settings'])
-                self.set_written(builder)
+                self.__set_written(builder)
                 self.logger.debug("Queueing set attribute on dataset '%s' containing references. attributes: %s"
                                   % (name, list(attributes.keys())))
 
@@ -907,7 +919,7 @@ class HDF5IO(HDMFIO):
         # NOTE: we can ignore options['io_settings'] for scalar data
         elif self.__is_ref(options['dtype']):
             _dtype = self.__dtypes.get(options['dtype'])
-            self.set_written(builder)
+            self.__set_written(builder)
             # Write a scalar data region reference dataset
             if isinstance(data, RegionBuilder):
                 dset = parent.require_dataset(name, shape=(), dtype=_dtype)
@@ -984,7 +996,7 @@ class HDF5IO(HDMFIO):
         # Validate the attributes on the linked dataset
         elif len(attributes) > 0:
             pass
-        self.set_written(builder)
+        self.__set_written(builder)
         if exhaust_dci:
             self.__exhaust_dcis()
 

--- a/src/hdmf/build/builders.py
+++ b/src/hdmf/build/builders.py
@@ -28,7 +28,6 @@ class Builder(dict, metaclass=ABCMeta):
             self.__source = parent.source
         else:
             self.__source = None
-        self.__written = False
 
     @property
     def path(self):
@@ -41,17 +40,6 @@ class Builder(dict, metaclass=ABCMeta):
             s.append(c.name)
             c = c.parent
         return "/".join(s[::-1])
-
-    @property
-    def written(self):
-        ''' The source of this Builder '''
-        return self.__written
-
-    @written.setter
-    def written(self, s):
-        if self.__written and not s:
-            raise ValueError("cannot change written to not written")
-        self.__written = s
 
     @property
     def name(self):

--- a/tests/unit/test_io_hdf5.py
+++ b/tests/unit/test_io_hdf5.py
@@ -221,15 +221,6 @@ class TestHDF5Writer(GroupBuilderTestCase):
         self.assertBuilderEqual(builder, self.builder)
         io.close()
 
-    def test_overwrite_written(self):
-        self.maxDiff = None
-        io = HDF5IO(self.path, manager=self.manager, mode='a')
-        io.write_builder(self.builder)
-        builder = io.read_builder()
-        with self.assertRaisesWith(ValueError, "cannot change written to not written"):
-            builder.written = False
-        io.close()
-
     def test_dataset_shape(self):
         self.maxDiff = None
         io = HDF5IO(self.path, manager=self.manager, mode='a')

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -895,17 +895,17 @@ class TestMultiWrite(TestCase):
             os.remove(self.path)
 
     def test_write_write_unwritten(self):
-        """Test writing a container, adding to the in-memory container, then writing it again."""
+        """Test writing a container, adding to the in-memory container, then overwriting the same file."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
-        # append new container
+        # append new container to in-memory container
         foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
         new_bucket1 = FooBucket('new_bucket1', [foo3])
         self.foofile.buckets.append(new_bucket1)
         new_bucket1.parent = self.foofile
 
-        # write to same file with same manager
+        # write to same file with same manager, overwriting existing file
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -847,19 +847,6 @@ class TestCacheSpec(TestCase):
             read_types = self.__get_types(ns_catalog)
             self.assertSetEqual(source_types, read_types)
 
-    def test_double_cache_spec(self):
-        # Setup all the data we need
-        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
-        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
-        foobucket = FooBucket('test_bucket', [foo1, foo2])
-        foofile = FooFile([foobucket])
-
-        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile)
-
-        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
-            io.write(foofile)
-
     def __get_types(self, catalog):
         types = set()
         for ns_name in catalog.namespaces:
@@ -891,6 +878,98 @@ class TestNoCacheSpec(TestCase):
 
         with File(self.path, 'r') as f:
             self.assertNotIn('specifications', f)
+
+
+class TestMultiWrite(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_write_append_same_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        # NOTE: self.manager has a build builders cache
+        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_manager(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            io.write(read_foofile)  # no changes
+
+    def test_write_append_new_bucket(self):
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 2)
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+    def test_append_double_write(self):
+        """Test using the same IO object to append to a file twice."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(self.foofile)
+
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+        foo4 = Foo('foo4', [10, 20], "I am foo4", 2, 0.1)
+        new_bucket2 = FooBucket('new_bucket2', [foo4])
+
+        new_manager = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+            read_foofile = io.read()
+            read_foofile.buckets.append(new_bucket1)
+            new_bucket1.parent = read_foofile
+            io.write(read_foofile)
+
+            read_foofile.buckets.append(new_bucket2)
+            new_bucket2.parent = read_foofile
+            io.write(read_foofile)
+
+        new_manager2 = BuildManager(self.manager.type_map)
+        with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
+            read_foofile = io.read()
+            self.assertEqual(len(read_foofile.buckets), 3)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
+
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket2':
+                    break
+            self.assertContainerEqual(bucket, new_bucket2)
 
 
 class HDF5IOMultiFileTest(TestCase):
@@ -1167,7 +1246,7 @@ class HDF5IOWriteFileExists(TestCase):
     def test_write_a(self):
         with HDF5IO(self.path, manager=_get_manager(), mode='a') as io:
             # even though foofile1 and foofile2 have different names, writing a
-            # root object into a file that already has a root object, in r+ mode
+            # root object into a file that already has a root object, in a mode
             # should throw an error
             with self.assertRaisesWith(ValueError, "Unable to create group (name already exists)"):
                 io.write(self.foofile2)
@@ -1188,6 +1267,41 @@ class HDF5IOWriteFileExists(TestCase):
                                        ("Cannot write to file %s in mode 'r'. "
                                         "Please use mode 'r+', 'w', 'w-', 'x', or 'a'") % self.path):
                 io.write(self.foofile2)
+
+
+class TestWritten(TestCase):
+
+    def setUp(self):
+        self.manager = _get_manager()
+        self.path = get_temp_filepath()
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        foo2 = Foo('foo2', [5, 6, 7, 8, 9], "I am foo2", 34, 6.28)
+        foobucket = FooBucket('test_bucket', [foo1, foo2])
+        self.foofile = FooFile([foobucket])
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_set_written_on_write(self):
+        """Test that write_builder changes the written flag of the builder and its children from False to True."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            builder = self.manager.build(container=self.foofile, source=self.path)
+            self.assertFalse(io.get_written(builder))
+            self._check_written_children(io, builder, False)
+            io.write_builder(builder)
+            self.assertTrue(io.get_written(builder))
+            self._check_written_children(io, builder, True)
+
+    def _check_written_children(self, io, builder, val):
+        """Test whether the io object has the written flag of the child builders set to val."""
+        for group_bldr in builder.groups.values():
+            self.assertEqual(io.get_written(group_bldr), val)
+            self._check_written_children(io, group_bldr, val)
+        for dset_bldr in builder.datasets.values():
+            self.assertEqual(io.get_written(dset_bldr), val)
+        for link_bldr in builder.links.values():
+            self.assertEqual(io.get_written(link_bldr), val)
 
 
 class H5DataIOValid(TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -894,25 +894,33 @@ class TestMultiWrite(TestCase):
         if os.path.exists(self.path):
             os.remove(self.path)
 
-    def test_write_append_same_manager(self):
+    def test_write_write_unwritten(self):
+        """Test writing a container, adding to the in-memory container, then writing it again."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
-        # NOTE: self.manager has a build builders cache
-        with HDF5IO(self.path, manager=self.manager, mode='a') as io:
-            read_foofile = io.read()
-            io.write(read_foofile)  # no changes
+        # append new container
+        foo3 = Foo('foo3', [10, 20], "I am foo3", 2, 0.1)
+        new_bucket1 = FooBucket('new_bucket1', [foo3])
+        self.foofile.buckets.append(new_bucket1)
+        new_bucket1.parent = self.foofile
 
-    def test_write_append_new_manager(self):
+        # write to same file with same manager
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
+        # check that new bucket was written
         new_manager = BuildManager(self.manager.type_map)
-        with HDF5IO(self.path, manager=new_manager, mode='a') as io:
+        with HDF5IO(self.path, manager=new_manager, mode='r') as io:
             read_foofile = io.read()
-            io.write(read_foofile)  # no changes
+            self.assertEqual(len(read_foofile.buckets), 2)
+            for bucket in read_foofile.buckets:
+                if bucket.name == 'new_bucket1':
+                    break
+            self.assertContainerEqual(bucket, new_bucket1)
 
-    def test_write_append_new_bucket(self):
+    def test_append_bucket(self):
+        """Test appending a container to a file."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
@@ -922,10 +930,12 @@ class TestMultiWrite(TestCase):
         new_manager = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager, mode='a') as io:
             read_foofile = io.read()
+            # append to read container and call write
             read_foofile.buckets.append(new_bucket1)
             new_bucket1.parent = read_foofile
             io.write(read_foofile)
 
+        # check that new bucket was written
         new_manager2 = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
             read_foofile = io.read()
@@ -935,8 +945,8 @@ class TestMultiWrite(TestCase):
                     break
             self.assertContainerEqual(bucket, new_bucket1)
 
-    def test_append_double_write(self):
-        """Test using the same IO object to append to a file twice."""
+    def test_append_bucket_double_write(self):
+        """Test using the same IO object to append a container to a file twice."""
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(self.foofile)
 
@@ -948,14 +958,17 @@ class TestMultiWrite(TestCase):
         new_manager = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager, mode='a') as io:
             read_foofile = io.read()
+            # append to read container and call write
             read_foofile.buckets.append(new_bucket1)
             new_bucket1.parent = read_foofile
             io.write(read_foofile)
 
+            # append to read container again and call write again
             read_foofile.buckets.append(new_bucket2)
             new_bucket2.parent = read_foofile
             io.write(read_foofile)
 
+        # check that both new buckets were written
         new_manager2 = BuildManager(self.manager.type_map)
         with HDF5IO(self.path, manager=new_manager2, mode='r') as io:
             read_foofile = io.read()


### PR DESCRIPTION
## Motivation

Required for the export PR: #326. 

Currently, `Builder` objects have a field `written` that is used only by `HDF5IO` to mark whether the `Builder` object has been written to disk so that it does not get written multiple times in case of links and references. `Builder` objects should contain minimal state information such as whether it has been written, and this should really be information stored in the IO object. Refactoring to make `HDF5IO` track whether a builder has been written by that object will allow us to use a different `HDF5IO` instance to write the *same builder* to a different file.

Note:
- `HDF5IO.__set_written` is private because no other class should be able to change whether a builder has been written by this IO object. `HDF5IO.get_written` is public because other backends and code may want to be able to know whether a builder has been written to disk, but this could be made private. 
- I replaced the test `test_double_cache_spec` with a new set of tests for writing/appending to check that the written flag is used correctly.

Close #380. 

## How to test the behavior?

See tests.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
