### PR TITLE
Add ability to close open links

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -564,7 +564,8 @@ class HDF5IO(HDMFIO):
         """Close all opened, linked-to files.
 
         MacOS and Linux automatically releases the linked-to file after the linking file is closed, but Windows does
-        not, which prevents the linked-to file from being deleted or truncated.
+        not, which prevents the linked-to file from being deleted or truncated. Use this method to close all opened,
+        linked-to files.
         """
         for obj in self.__open_links:
             if obj:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -556,12 +556,18 @@ class HDF5IO(HDMFIO):
                 kwargs = {}
             self.__file = File(self.__path, open_flag, **kwargs)
 
-    def close(self, close_links=False):
+    def close(self, close_links=True):
+        """Close the file.
+
+        :param bool close_links: Whether to explicitly close all opened, linked-to files. MacOS and Linux automatically
+                                 closes opened, linked-to files when the linking file is closed, but Windows does not.
+                                 This flag allows Windows users not to close those linked-to files. Default True.
+        """
         if self.__file is not None:
             self.__file.close()
         if close_links:
-            for f in self.__open_links:
-                f.file.close()
+            for obj in self.__open_links:
+                obj.file.close()
             self.__open_links = []
 
     @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the HDF5 file'},

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -556,20 +556,20 @@ class HDF5IO(HDMFIO):
                 kwargs = {}
             self.__file = File(self.__path, open_flag, **kwargs)
 
-    def close(self, close_links=True):
-        """Close the file.
-
-        :param bool close_links: Whether to explicitly close all opened, linked-to files. MacOS and Linux automatically
-                                 closes opened, linked-to files when the linking file is closed, but Windows does not.
-                                 This flag allows Windows users not to close those linked-to files. Default True.
-        """
+    def close(self):
         if self.__file is not None:
             self.__file.close()
-        if close_links:
-            for obj in self.__open_links:
-                if obj:
-                    obj.file.close()
-            self.__open_links = []
+
+    def close_linked_files(self):
+        """Close all opened, linked-to files.
+
+        MacOS and Linux automatically releases the linked-to file after the linking file is closed, but Windows does
+        not, which prevents the linked-to file from being deleted or truncated.
+        """
+        for obj in self.__open_links:
+            if obj:
+                obj.file.close()
+        self.__open_links = []
 
     @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the HDF5 file'},
             {'name': 'link_data', 'type': bool,

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -567,7 +567,8 @@ class HDF5IO(HDMFIO):
             self.__file.close()
         if close_links:
             for obj in self.__open_links:
-                obj.file.close()
+                if obj:
+                    obj.file.close()
             self.__open_links = []
 
     @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the HDF5 file'},

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -844,6 +844,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     sub_builder = GroupBuilder(spec.name, source=source)
                 self.__add_attributes(sub_builder, spec.attributes, container, build_manager, source)
                 self.__add_datasets(sub_builder, spec.datasets, container, build_manager, source)
+                self.__add_links(sub_builder, spec.links, container, build_manager, source)
 
                 # handle subgroups that are not Containers
                 attr_name = self.get_attribute(spec)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1025,7 +1025,7 @@ class TestCloseLinks(TestCase):
         self.assertFalse(read_foofile2.foo_link.my_data)
 
         # should be able to reopen both files
-        with HDF5IO(self.path1, mode='w', manager=_get_manager()) as new_io3:
+        with HDF5IO(self.path1, mode='a', manager=_get_manager()) as new_io3:
             new_io3.read()
 
     def test_double_close_file_with_links(self):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import tempfile
 import warnings
 import numpy as np
 import h5py

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1020,14 +1020,12 @@ class TestCloseLinks(TestCase):
         with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io1:
             read_foofile2 = new_io1.read()  # keep reference to container in memory
 
-        self.assertEqual(read_foofile2.foo_link.name, 'foo1')
+        self.assertTrue(read_foofile2.foo_link.my_data)
+        new_io1.close_linked_files()
         self.assertFalse(read_foofile2.foo_link.my_data)
 
         # should be able to reopen both files
-        with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io2:
-            new_io2.read()
-
-        with HDF5IO(self.path1, mode='a', manager=_get_manager()) as new_io3:
+        with HDF5IO(self.path1, mode='w', manager=_get_manager()) as new_io3:
             new_io3.read()
 
     def test_double_close_file_with_links(self):
@@ -1052,9 +1050,10 @@ class TestCloseLinks(TestCase):
 
         with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io1:
             read_foofile2 = new_io1.read()  # keep reference to container in memory
-            read_foofile2.foo_link.my_data.file.close()  # explicitly close the h5dataset
-            self.assertFalse(read_foofile2.foo_link.my_data)
-        # make sure new_io1.close() does not fail because the linked-to file is already closed
+
+        read_foofile2.foo_link.my_data.file.close()  # explicitly close the file from the h5dataset
+        self.assertFalse(read_foofile2.foo_link.my_data)
+        new_io1.close_linked_files()  # make sure this does not fail because the linked-to file is already closed
 
 
 class HDF5IOInitNoFileTest(TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -12,7 +12,7 @@ from hdmf.backends.hdf5 import H5DataIO
 from hdmf.backends.io import UnsupportedOperation
 from hdmf.build import GroupBuilder, DatasetBuilder, BuildManager, TypeMap, ObjectMapper
 from hdmf.spec.namespace import NamespaceCatalog
-from hdmf.spec.spec import AttributeSpec, DatasetSpec, GroupSpec, ZERO_OR_MANY, ONE_OR_MANY
+from hdmf.spec.spec import AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, ZERO_OR_MANY, ONE_OR_MANY, ZERO_OR_ONE
 from hdmf.spec.namespace import SpecNamespace
 from hdmf.spec.catalog import SpecCatalog
 from hdmf.container import Container
@@ -21,37 +21,42 @@ from hdmf.testing import TestCase
 from h5py import SoftLink, HardLink, ExternalLink, File
 from h5py import filters as h5py_filters
 
-from tests.unit.utils import Foo, FooBucket, CORE_NAMESPACE
+from tests.unit.utils import Foo, FooBucket, CORE_NAMESPACE, get_temp_filepath
 
 
 class FooFile(Container):
 
-    @docval({'name': 'buckets', 'type': list, 'doc': 'the FooBuckets in this file', 'default': list()})
+    @docval({'name': 'buckets', 'type': list, 'doc': 'the FooBuckets in this file', 'default': list()},
+            {'name': 'foo_link', 'type': Foo, 'doc': 'an optional linked Foo', 'default': None})
     def __init__(self, **kwargs):
-        buckets = getargs('buckets', kwargs)
+        buckets, foo_link = getargs('buckets', 'foo_link', kwargs)
         super().__init__(name=ROOT_NAME)  # name is not used - FooFile should be the root container
         self.__buckets = buckets
         for f in self.__buckets:
             f.parent = self
+        self.__foo_link = foo_link
 
     def __eq__(self, other):
         return set(self.buckets) == set(other.buckets)
 
     def __str__(self):
         foo_str = "[" + ",".join(str(f) for f in self.buckets) + "]"
-        return 'buckets=%s' % foo_str
+        return 'buckets=%s, foo_link=%s' % (foo_str, self.foo_link)
 
     @property
     def buckets(self):
         return self.__buckets
 
+    @property
+    def foo_link(self):
+        return self.__foo_link
 
-def get_temp_filepath():
-    # On Windows, h5py cannot truncate an open file in write mode.
-    # The temp file will be closed before h5py truncates it and will be removed during the tearDown step.
-    temp_file = tempfile.NamedTemporaryFile()
-    temp_file.close()
-    return temp_file.name
+    @foo_link.setter
+    def foo_link(self, value):
+        if self.__foo_link is None:
+            self.__foo_link = value
+        else:
+            raise ValueError("can't reset foo_link attribute")
 
 
 class H5IOTest(TestCase):
@@ -697,19 +702,31 @@ def _get_manager():
             foo_spec = foo_holder_spec.get_data_type('Foo')
             self.map_spec('foos', foo_spec)
 
+    file_links_spec = GroupSpec('Foo link group',
+                                name='links',
+                                links=[LinkSpec('Foo link',
+                                                name='foo_link',
+                                                target_type='Foo',
+                                                quantity=ZERO_OR_ONE)]
+                                )
+
     file_spec = GroupSpec("A file of Foos contained in FooBuckets",
                           data_type_def='FooFile',
                           groups=[GroupSpec('Holds the FooBuckets',
                                             name='buckets',
                                             groups=[GroupSpec("One or more FooBuckets",
                                                               data_type_inc='FooBucket',
-                                                              quantity=ONE_OR_MANY)])])
+                                                              quantity=ONE_OR_MANY)]),
+                                  file_links_spec])
 
     class FileMapper(ObjectMapper):
         def __init__(self, spec):
             super().__init__(spec)
             bucket_spec = spec.get_group('buckets').get_data_type('FooBucket')
             self.map_spec('buckets', bucket_spec)
+            self.unmap(spec.get_group('links'))
+            foo_link_spec = spec.get_group('links').get_link('foo_link')
+            self.map_spec('foo_link', foo_link_spec)
 
     spec_catalog = SpecCatalog()
     spec_catalog.register_spec(foo_spec, 'test.yaml')
@@ -897,13 +914,12 @@ class HDF5IOMultiFileTest(TestCase):
 
     def setUp(self):
         numfiles = 3
-        base_name = "test_multifile_hdf5_%d.h5"
-        self.test_temp_files = [base_name % i for i in range(numfiles)]
+        self.paths = [get_temp_filepath() for i in range(numfiles)]
 
         # On Windows h5py cannot truncate an open file in write mode.
         # The temp file will be closed before h5py truncates it
         # and will be removed during the tearDown step.
-        self.io = [HDF5IO(i, mode='a', manager=_get_manager()) for i in self.test_temp_files]
+        self.io = [HDF5IO(i, mode='a', manager=_get_manager()) for i in self.paths]
         self.f = [i._file for i in self.io]
 
     def tearDown(self):
@@ -914,26 +930,24 @@ class HDF5IOMultiFileTest(TestCase):
         self.io = None
         self.f = None
         # Make sure the files have been deleted
-        for tf in self.test_temp_files:
+        for tf in self.paths:
             try:
                 os.remove(tf)
             except OSError:
                 pass
-        self.test_temp_files = None
 
     def test_copy_file_with_external_links(self):
         # Create the first file
         foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
         bucket1 = FooBucket('test_bucket1', [foo1])
-
         foofile1 = FooFile(buckets=[bucket1])
 
         # Write the first file
         self.io[0].write(foofile1)
 
         # Create the second file
-        bucket1_read = self.io[0].read()
-        foo2 = Foo('foo2', bucket1_read.buckets[0].foos[0].my_data, "I am foo2", 34, 6.28)
+        read_foofile1 = self.io[0].read()
+        foo2 = Foo('foo2', read_foofile1.buckets[0].foos[0].my_data, "I am foo2", 34, 6.28)
         bucket2 = FooBucket('test_bucket2', [foo2])
         foofile2 = FooFile(buckets=[bucket2])
         # Write the second file
@@ -943,22 +957,77 @@ class HDF5IOMultiFileTest(TestCase):
 
         # Copy the file
         self.io[2].close()
-        HDF5IO.copy_file(source_filename=self.test_temp_files[1],
-                         dest_filename=self.test_temp_files[2],
+        HDF5IO.copy_file(source_filename=self.paths[1],
+                         dest_filename=self.paths[2],
                          expand_external=True,
                          expand_soft=False,
                          expand_refs=False)
 
         # Test that everything is working as expected
         # Confirm that our original data file is correct
-        f1 = File(self.test_temp_files[0], 'r')
+        f1 = File(self.paths[0], 'r')
         self.assertIsInstance(f1.get('/buckets/test_bucket1/foo_holder/foo1/my_data', getlink=True), HardLink)
         # Confirm that we successfully created and External Link in our second file
-        f2 = File(self.test_temp_files[1], 'r')
+        f2 = File(self.paths[1], 'r')
         self.assertIsInstance(f2.get('/buckets/test_bucket2/foo_holder/foo2/my_data', getlink=True), ExternalLink)
         # Confirm that we successfully resolved the External Link when we copied our second file
-        f3 = File(self.test_temp_files[2], 'r')
+        f3 = File(self.paths[2], 'r')
         self.assertIsInstance(f3.get('/buckets/test_bucket2/foo_holder/foo2/my_data', getlink=True), HardLink)
+
+
+class TestOpenLinks(TestCase):
+
+    def setUp(self):
+        self.path1 = get_temp_filepath()
+        self.path2 = get_temp_filepath()
+        import logging
+
+        logger = logging.getLogger()
+        logger.setLevel(logging.DEBUG)
+
+        ch = logging.FileHandler('test.log', mode='w')
+        ch.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+
+    def tearDown(self):
+        if self.path1 is not None:
+            os.remove(self.path1)  # linked file may not be closed
+        if self.path2 is not None:
+            os.remove(self.path2)
+
+    def test_close_file_with_links(self):
+        # Create the first file
+        foo1 = Foo('foo1', [0, 1, 2, 3, 4], "I am foo1", 17, 3.14)
+        bucket1 = FooBucket('test_bucket1', [foo1])
+        foofile1 = FooFile(buckets=[bucket1])
+
+        # Write the first file
+        with HDF5IO(self.path1, mode='w', manager=_get_manager()) as io:
+            io.write(foofile1)
+
+        # Create the second file
+        manager = _get_manager()  # use the same manager for read and write so that links work
+        with HDF5IO(self.path1, mode='r', manager=manager) as read_io:
+            read_foofile1 = read_io.read()
+            foofile2 = FooFile(foo_link=read_foofile1.buckets[0].foos[0])  # cross-file link
+
+            # Write the second file
+            with HDF5IO(self.path2, mode='w', manager=manager) as write_io:
+                write_io.write(foofile2)
+
+        with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io1:
+            read_foofile2 = new_io1.read()  # keep reference to container in memory
+
+        self.assertEqual(read_foofile2.foo_link.name, 'foo1')
+
+        # should be able to reopen both files
+        with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io2:
+            new_io2.read()
+
+        with HDF5IO(self.path1, mode='a', manager=_get_manager()) as new_io3:
+            new_io3.read()
 
 
 class HDF5IOInitNoFileTest(TestCase):

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from hdmf.utils import docval, getargs
 from hdmf.container import Container
 
@@ -69,3 +71,11 @@ class FooBucket(Container):
     @property
     def foos(self):
         return self.__foos
+
+
+def get_temp_filepath():
+    # On Windows, h5py cannot truncate an open file in write mode.
+    # The temp file will be closed before h5py truncates it and will be removed during the tearDown step.
+    temp_file = tempfile.NamedTemporaryFile()
+    temp_file.close()
+    return temp_file.name


### PR DESCRIPTION
Current behavior:
If file A links to dataset D in file B and file A is closed, then file B is still open. H5Dataset D can still be accessed. On Mac/Linux, file B can be deleted or overwritten, but on Windows, trying to delete or overwrite file B results in an error. 

This PR adds a new function `HDF5IO.close_linked_files` which will close all linked-to files that were opened by this `HDF5IO` instance.

Practically speaking, this is useful only for Windows users to get around the inconsistent behavior of h5py and in CI on Windows.

This also fixes an issue where links are not added to unnamed groups (e.g., `NWBFile.acquisition`).