### PR TITLE
Fix link_data arg not being used for non-root level datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## HDMF 1.6.4 (Upcoming)
 
+### Internal improvements
+- Add ability to close open links. @rly (#383)
+
 ### Bug fixes:
 - Fix validation of empty arrays and scalar attributes. @rly (#377)
 - Fix issue with constructing `DynamicTable` with empty array colnames. @rly (#379)
+- Fix `TestCase.assertContainerEqual` passing wrong arguments. @rly (#385)
+- Fix 'link_data' argument not being used when writing non-root level datasets. @rly (#384)
 
 ## HDMF 1.6.3 (June 9, 2020)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -565,9 +565,9 @@ class HDF5IO(HDMFIO):
     def write_builder(self, **kwargs):
         f_builder, link_data, exhaust_dci = getargs('builder', 'link_data', 'exhaust_dci', kwargs)
         for name, gbldr in f_builder.groups.items():
-            self.write_group(self.__file, gbldr, exhaust_dci=exhaust_dci)
+            self.write_group(self.__file, gbldr, link_data=link_data, exhaust_dci=exhaust_dci)
         for name, dbldr in f_builder.datasets.items():
-            self.write_dataset(self.__file, dbldr, link_data, exhaust_dci=exhaust_dci)
+            self.write_dataset(self.__file, dbldr, link_data=link_data, exhaust_dci=exhaust_dci)
         for name, lbldr in f_builder.links.items():
             self.write_link(self.__file, lbldr)
         self.set_attributes(self.__file, f_builder.attributes)
@@ -720,11 +720,13 @@ class HDF5IO(HDMFIO):
 
     @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
             {'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder to write'},
+            {'name': 'link_data', 'type': bool,
+             'doc': 'If not specified otherwise link (True) or copy (False) HDF5 Datasets', 'default': True},
             {'name': 'exhaust_dci', 'type': bool,
              'doc': 'exhaust DataChunkIterators one at a time. If False, exhaust them concurrently', 'default': True},
             returns='the Group that was created', rtype='Group')
     def write_group(self, **kwargs):
-        parent, builder, exhaust_dci = getargs('parent', 'builder', 'exhaust_dci', kwargs)
+        parent, builder, link_data, exhaust_dci = getargs('parent', 'builder', 'link_data', 'exhaust_dci', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if builder.written:
             group = parent[builder.name]
@@ -735,12 +737,12 @@ class HDF5IO(HDMFIO):
         if subgroups:
             for subgroup_name, sub_builder in subgroups.items():
                 # do not create an empty group without attributes or links
-                self.write_group(group, sub_builder, exhaust_dci=exhaust_dci)
+                self.write_group(group, sub_builder, link_data=link_data, exhaust_dci=exhaust_dci)
         # write all datasets
         datasets = builder.datasets
         if datasets:
             for dset_name, sub_builder in datasets.items():
-                self.write_dataset(group, sub_builder, exhaust_dci=exhaust_dci)
+                self.write_dataset(group, sub_builder, link_data=link_data, exhaust_dci=exhaust_dci)
         # write all links
         links = builder.links
         if links:

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1400,7 +1400,11 @@ class TestReadLink(TestCase):
             io.write_builder(self.root2)
         self.root2.source = self.link_path
 
+        self.ios = []
+
     def tearDown(self):
+        for io in self.ios:
+            io.close_linked_files()
         if os.path.exists(self.target_path):
             os.remove(self.target_path)
         if os.path.exists(self.link_path):
@@ -1411,6 +1415,7 @@ class TestReadLink(TestCase):
         Test that Builder location is set when it is read as a link
         """
         read_io = HDF5IO(self.link_path, manager=_get_manager(), mode='r')
+        self.ios.append(read_io)  # store IO object for closing in tearDown
         bldr = read_io.read_builder()
         self.assertEqual(bldr['link_to_test_group'].builder.location, '/')
         self.assertEqual(bldr['link_to_test_dataset'].builder.location, '/test_group')
@@ -1422,6 +1427,7 @@ class TestReadLink(TestCase):
         """
         link_to_link_path = get_temp_filepath()
         read_io1 = HDF5IO(self.link_path, manager=_get_manager(), mode='r')
+        self.ios.append(read_io1)  # store IO object for closing in tearDown
         bldr1 = read_io1.read_builder()
         root3 = GroupBuilder(name='root')
         root3.add_link(bldr1['link_to_test_group'].builder, 'link_to_link')
@@ -1430,6 +1436,7 @@ class TestReadLink(TestCase):
         read_io1.close()
 
         read_io2 = HDF5IO(link_to_link_path, manager=_get_manager(), mode='r')
+        self.ios.append(read_io2)
         bldr2 = read_io2.read_builder()
         self.assertEqual(bldr2['link_to_link'].builder.source, self.target_path)
         read_io2.close()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1286,6 +1286,7 @@ class H5DataIOValid(TestCase):
 
 
 class TestReadLink(TestCase):
+
     def setUp(self):
         self.target_path = get_temp_filepath()
         self.link_path = get_temp_filepath()
@@ -1304,6 +1305,12 @@ class TestReadLink(TestCase):
         with HDF5IO(self.link_path, manager=_get_manager(), mode='w') as io:
             io.write_builder(self.root2)
         self.root2.source = self.link_path
+
+    def tearDown(self):
+        if os.path.exists(self.target_path):
+            os.remove(self.target_path)
+        if os.path.exists(self.link_path):
+            os.remove(self.link_path)
 
     def test_set_link_loc(self):
         """
@@ -1346,7 +1353,14 @@ class TestLinkData(TestCase):
         with HDF5IO(self.target_path, manager=_get_manager(), mode='w') as io:
             io.write_builder(root1)
 
+    def tearDown(self):
+        if os.path.exists(self.target_path):
+            os.remove(self.target_path)
+        if os.path.exists(self.link_path):
+            os.remove(self.link_path)
+
     def test_link_data_true(self):
+        """Test that the argument link_data=True for write_builder creates an external link."""
         manager = _get_manager()
         with HDF5IO(self.target_path, manager=manager, mode='r') as read_io:
             read_root = read_io.read_builder()
@@ -1361,6 +1375,7 @@ class TestLinkData(TestCase):
             self.assertIsInstance(f.get('link_to_test_dataset', getlink=True), ExternalLink)
 
     def test_link_data_false(self):
+        """Test that the argument link_data=False for write_builder copies the data."""
         manager = _get_manager()
         with HDF5IO(self.target_path, manager=manager, mode='r') as read_io:
             read_root = read_io.read_builder()
@@ -1373,6 +1388,7 @@ class TestLinkData(TestCase):
 
         with File(self.link_path, mode='r') as f:
             self.assertFalse(isinstance(f.get('link_to_test_dataset', getlink=True), ExternalLink))
+            self.assertListEqual(f.get('link_to_test_dataset')[:].tolist(), [1, 2, 3, 4])
 
 
 class TestLoadNamespaces(TestCase):


### PR DESCRIPTION
## Motivation

The `link_data` argument to `HDF5IO.write` / `HDF5IO.write_builder` was not being passed to datasets that resided within a group. This PR fixes that and adds missing tests for the `link_data` argument.

Requires #383 to work on Windows because the unit tests are currently unable to delete the test files.

## How to test the behavior?
See tests.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
