### PR TITLE
Fix `TestCase.assertContainerEqual` passing wrong arg

### DIFF
--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -58,12 +58,12 @@ class TestCase(unittest.TestCase):
             with self.subTest(field=field, container_type=type1.__name__):
                 f1 = getattr(container1, field)
                 f2 = getattr(container2, field)
-                self._assert_field_equal(f1, f2, ignore_hdmf_attrs)
+                self._assert_field_equal(f1, f2, ignore_hdmf_attrs=ignore_hdmf_attrs)
 
     def _assert_field_equal(self, f1, f2, ignore_hdmf_attrs=False):
         if (isinstance(f1, (tuple, list, np.ndarray, h5py.Dataset))
                 or isinstance(f2, (tuple, list, np.ndarray, h5py.Dataset))):
-            self._assert_array_equal(f1, f2, ignore_hdmf_attrs)
+            self._assert_array_equal(f1, f2, ignore_hdmf_attrs=ignore_hdmf_attrs)
         elif isinstance(f1, dict) and len(f1) and isinstance(f1.values()[0], Container):
             self.assertIsInstance(f2, dict)
             f1_keys = set(f1.keys())
@@ -71,11 +71,11 @@ class TestCase(unittest.TestCase):
             self.assertSetEqual(f1_keys, f2_keys)
             for k in f1_keys:
                 with self.subTest(module_name=k):
-                    self.assertContainerEqual(f1[k], f2[k], ignore_hdmf_attrs)
+                    self.assertContainerEqual(f1[k], f2[k], ignore_hdmf_attrs=ignore_hdmf_attrs)
         elif isinstance(f1, Container):
-            self.assertContainerEqual(f1, f2, ignore_hdmf_attrs)
+            self.assertContainerEqual(f1, f2, ignore_hdmf_attrs=ignore_hdmf_attrs)
         elif isinstance(f1, Data):
-            self._assert_data_equal(f1, f2, ignore_hdmf_attrs)
+            self._assert_data_equal(f1, f2, ignore_hdmf_attrs=ignore_hdmf_attrs)
         elif isinstance(f1, (float, np.floating)):
             np.testing.assert_equal(f1, f2)
         else:
@@ -84,7 +84,7 @@ class TestCase(unittest.TestCase):
     def _assert_data_equal(self, data1, data2, ignore_hdmf_attrs=False):
         self.assertEqual(type(data1), type(data2))
         self.assertEqual(len(data1), len(data2))
-        self._assert_array_equal(data1.data, data2.data, ignore_hdmf_attrs)
+        self._assert_array_equal(data1.data, data2.data, ignore_hdmf_attrs=ignore_hdmf_attrs)
 
     def _assert_array_equal(self, arr1, arr2, ignore_hdmf_attrs=False):
         if isinstance(arr1, (h5py.Dataset, HDMFDataset)):
@@ -107,11 +107,11 @@ class TestCase(unittest.TestCase):
             else:
                 for sub1, sub2 in zip(arr1, arr2):
                     if isinstance(sub1, Container):
-                        self.assertContainerEqual(sub1, sub2, ignore_hdmf_attrs)
+                        self.assertContainerEqual(sub1, sub2, ignore_hdmf_attrs=ignore_hdmf_attrs)
                     elif isinstance(sub1, Data):
-                        self._assert_data_equal(sub1, sub2, ignore_hdmf_attrs)
+                        self._assert_data_equal(sub1, sub2, ignore_hdmf_attrs=ignore_hdmf_attrs)
                     else:
-                        self._assert_array_equal(sub1, sub2, ignore_hdmf_attrs)
+                        self._assert_array_equal(sub1, sub2, ignore_hdmf_attrs=ignore_hdmf_attrs)
 
 
 class H5RoundTripMixin(metaclass=ABCMeta):


### PR DESCRIPTION
## Motivation

The third argument of TestCase.assertContainerEqual is `ignore_name` but within the function, `ignore_hdmf_attrs` is passed in for the third position. This PR fixes that.

## How to test the behavior?

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
