### PR TITLE
Fix handling of ASCII numpy array

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -243,7 +243,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             raise ValueError("Cannot convert from %s to 'numeric' specification dtype." % value_type)
 
     @classmethod
-    def __check_edgecases(cls, spec, value, spec_dtype):
+    def __check_edgecases(cls, spec, value, spec_dtype):  # noqa: C901
         """
         Check edge cases in converting data to a dtype
         """
@@ -261,9 +261,14 @@ class ObjectMapper(metaclass=ExtenderMeta):
         if spec_dtype is None or spec_dtype == 'numeric' or type(value) in cls.__no_convert:
             # infer type from value
             if hasattr(value, 'dtype'):  # covers numpy types, AbstractDataChunkIterator
-                ret_dtype = value.dtype.type
                 if spec_dtype == 'numeric':
-                    cls.__check_convert_numeric(ret_dtype)
+                    cls.__check_convert_numeric(value.dtype.type)
+                if np.issubdtype(value.dtype, np.str_):
+                    ret_dtype = 'utf8'
+                elif np.issubdtype(value.dtype, np.string_):
+                    ret_dtype = 'ascii'
+                else:
+                    ret_dtype = value.dtype.type
                 return value, ret_dtype
             if isinstance(value, (list, tuple)):
                 if len(value) == 0:

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -848,73 +848,162 @@ class TestConvertDtype(TestCase):
                 with self.assertRaisesWith(ValueError, msg):
                     ObjectMapper.convert_dtype(spec, value)
 
+    def test_text_spec(self):
+        spec_type = 'text'
+        spec = DatasetSpec('an example dataset', spec_type, name='data')
+
+        value = 'a'
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), str)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = b'a'
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, 'a')
+        self.assertIs(type(ret), str)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = ['a', 'b']
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertListEqual(ret, value)
+        self.assertIs(type(ret[0]), str)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = np.array(['a', 'b'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, value)
+        self.assertIs(ret.dtype.type, np.str_)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = np.array(['a', 'b'], dtype='S1')
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, np.array(['a', 'b'], dtype='U1'))
+        self.assertIs(ret.dtype.type, np.str_)
+        self.assertEqual(ret_dtype, 'utf8')
+
+    def test_ascii_spec(self):
+        spec_type = 'ascii'
+        spec = DatasetSpec('an example dataset', spec_type, name='data')
+
+        value = 'a'
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, b'a')
+        self.assertIs(type(ret), bytes)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = b'a'
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, b'a')
+        self.assertIs(type(ret), bytes)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = ['a', 'b']
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertListEqual(ret, [b'a', b'b'])
+        self.assertIs(type(ret[0]), bytes)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = np.array(['a', 'b'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, np.array(['a', 'b'], dtype='S1'))
+        self.assertIs(ret.dtype.type, np.bytes_)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = np.array(['a', 'b'], dtype='S1')
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, value)
+        self.assertIs(ret.dtype.type, np.bytes_)
+        self.assertEqual(ret_dtype, 'ascii')
+
     def test_no_spec(self):
         spec_type = None
         spec = DatasetSpec('an example dataset', spec_type, name='data')
 
         value = [1, 2, 3]
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, int)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0][0]), match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertListEqual(ret, value)
+        self.assertIs(type(ret[0]), int)
+        self.assertEqual(ret_dtype, int)
 
         value = np.uint64(4)
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.uint64)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), np.uint64)
+        self.assertEqual(ret_dtype, np.uint64)
 
         value = 'hello'
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, 'utf8')
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), str)
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), str)
+        self.assertEqual(ret_dtype, 'utf8')
 
-        value = bytes('hello', encoding='utf-8')
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, 'ascii')
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), bytes)
+        value = b'hello'
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), bytes)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = np.array(['aa', 'bb'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, value)
+        self.assertIs(type(ret[0]), np.str_)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = np.array(['aa', 'bb'], dtype='S2')
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        np.testing.assert_array_equal(ret, value)
+        self.assertIs(type(ret[0]), np.bytes_)
+        self.assertEqual(ret_dtype, 'ascii')
 
         value = DataChunkIterator(data=[1, 2, 3])
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.dtype(int).type)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(ret[0].dtype.type, match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(ret.dtype.type, np.dtype(int).type)
+        self.assertIs(type(ret.data[0]), int)
+        self.assertEqual(ret_dtype, np.dtype(int).type)
 
-        value = DataChunkIterator(data=[1., 2., 3.])
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.dtype(float).type)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(ret[0].dtype.type, match[1])
+        value = DataChunkIterator(data=['a', 'b'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(ret.dtype.type, np.str_)
+        self.assertIs(type(ret.data[0]), str)
+        self.assertEqual(ret_dtype, 'utf8')
 
         value = H5DataIO(np.arange(30).reshape(5, 2, 3))
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.dtype(int).type)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(ret[0].dtype.type, match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(ret.data.dtype.type, np.dtype(int).type)
+        self.assertEqual(ret_dtype, np.dtype(int).type)
 
-        value = H5DataIO(['foo' 'bar'])
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, 'utf8')
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0].data[0]), str)
+        value = H5DataIO(['foo', 'bar'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret.data[0]), str)
+        self.assertEqual(ret_dtype, 'utf8')
+
+        value = H5DataIO([b'foo', b'bar'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret.data[0]), bytes)
+        self.assertEqual(ret_dtype, 'ascii')
 
     def test_numeric_spec(self):
         spec_type = 'numeric'
         spec = DatasetSpec('an example dataset', spec_type, name='data')
 
         value = np.uint64(4)
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.uint64)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), np.uint64)
+        self.assertEqual(ret_dtype, np.uint64)
 
         value = DataChunkIterator(data=[1, 2, 3])
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.dtype(int).type)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(ret[0].dtype.type, match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(ret.dtype.type, np.dtype(int).type)
+        self.assertIs(type(ret.data[0]), int)
+        self.assertEqual(ret_dtype, np.dtype(int).type)
 
         value = ['a', 'b']
         msg = "Cannot convert from <class 'str'> to 'numeric' specification dtype."
@@ -931,16 +1020,16 @@ class TestConvertDtype(TestCase):
         spec = DatasetSpec('an example dataset', spec_type, name='data')
 
         value = np.bool_(True)
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.bool_)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), np.bool_)
+        self.assertEqual(ret_dtype, np.bool_)
 
         value = True
-        ret = ObjectMapper.convert_dtype(spec, value)
-        match = (value, np.bool_)
-        self.assertTupleEqual(ret, match)
-        self.assertIs(type(ret[0]), match[1])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(ret, value)
+        self.assertIs(type(ret), np.bool_)
+        self.assertEqual(ret_dtype, np.bool_)
 
     def test_override_type_int_restrict_precision(self):
         spec = DatasetSpec('an example dataset', 'int8', name='data')

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -873,13 +873,11 @@ class TestConvertDtype(TestCase):
         value = np.array(['a', 'b'])
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, value)
-        self.assertIs(ret.dtype.type, np.str_)
         self.assertEqual(ret_dtype, 'utf8')
 
         value = np.array(['a', 'b'], dtype='S1')
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, np.array(['a', 'b'], dtype='U1'))
-        self.assertIs(ret.dtype.type, np.str_)
         self.assertEqual(ret_dtype, 'utf8')
 
     def test_ascii_spec(self):
@@ -907,13 +905,11 @@ class TestConvertDtype(TestCase):
         value = np.array(['a', 'b'])
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, np.array(['a', 'b'], dtype='S1'))
-        self.assertIs(ret.dtype.type, np.bytes_)
         self.assertEqual(ret_dtype, 'ascii')
 
         value = np.array(['a', 'b'], dtype='S1')
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, value)
-        self.assertIs(ret.dtype.type, np.bytes_)
         self.assertEqual(ret_dtype, 'ascii')
 
     def test_no_spec(self):
@@ -947,13 +943,11 @@ class TestConvertDtype(TestCase):
         value = np.array(['aa', 'bb'])
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, value)
-        self.assertIs(type(ret[0]), np.str_)
         self.assertEqual(ret_dtype, 'utf8')
 
         value = np.array(['aa', 'bb'], dtype='S2')
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, value)
-        self.assertIs(type(ret[0]), np.bytes_)
         self.assertEqual(ret_dtype, 'ascii')
 
         value = DataChunkIterator(data=[1, 2, 3])


### PR DESCRIPTION
## Motivation

Fix #386 

When spec dtype is None and a numpy array was passed in with unicode or ascii data, then np.str_ or np.bytes_ was returned as the dtype instead of 'utf8' and 'bytes'.

## How to test the behavior?
```python
from hdmf.backends.hdf5 import HDF5IO
from hdmf.common import DynamicTable
import hdmf.common as hc
import numpy as np

fixed_string_data = np.array(['aa', 'bb'], dtype='S2')
dt = DynamicTable('name', 'desc', id=[0,1])
dt.add_column('test_s2','desc', data=fixed_string_data)

with HDF5IO('test_s2.nwb', manager=hc.get_type_map(), mode='w') as io:
    io.write(dt)
```

```python
spec = DatasetSpec('an example dataset', dtype=None, name='data')

value = np.array(['aa', 'bb'])
ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
np.testing.assert_array_equal(ret, value)
self.assertEqual(ret_dtype, 'utf8')

value = np.array(['aa', 'bb'], dtype='S2')
ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
np.testing.assert_array_equal(ret, value)
self.assertEqual(ret_dtype, 'ascii')
```
## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
