### PR TITLE
Update

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 
 from ...container import Container
-from ...utils import docval, getargs, popargs, call_docval_func, get_docval, get_data_shape, fmt_docval_args
+from ...utils import docval, getargs, popargs, call_docval_func, get_data_shape, fmt_docval_args, get_docval
 from ...data_utils import AbstractDataChunkIterator
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager,\
                      RegionBuilder, ReferenceBuilder, TypeMap, ObjectMapper

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -810,7 +810,7 @@ class HDF5IO(HDMFIO):
         builder.written = True
         return link_obj
 
-    @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},
+    @docval({'name': 'parent', 'type': Group, 'doc': 'the parent HDF5 object'},  # noqa: C901
             {'name': 'builder', 'type': DatasetBuilder, 'doc': 'the DatasetBuilder to write'},
             {'name': 'link_data', 'type': bool,
              'doc': 'If not specified otherwise link (True) or copy (False) HDF5 Datasets', 'default': True},

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1037,9 +1037,12 @@ class HDF5IO(HDMFIO):
             io_settings['maxshape'] = data.maxshape
         if 'dtype' not in io_settings:
             if (options is not None) and ('dtype' in options):
-                io_settings['dtype'] = cls.__dtypes.get(options['dtype'])
+                io_settings['dtype'] = options['dtype']
             else:
                 io_settings['dtype'] = data.dtype
+            if isinstance(io_settings['dtype'], str):
+                # map to real dtype if we were given a string
+                io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 
 from ...container import Container
-from ...utils import docval, getargs, popargs, call_docval_func, get_data_shape
+from ...utils import docval, getargs, popargs, call_docval_func, get_docval, get_data_shape, fmt_docval_args
 from ...data_utils import AbstractDataChunkIterator
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager,\
                      RegionBuilder, ReferenceBuilder, TypeMap, ObjectMapper
@@ -1219,3 +1219,21 @@ class HDF5IO(HDMFIO):
         Return the HDF5 file mode. One of ("w", "r", "r+", "a", "w-", "x").
         """
         return self.__mode
+
+    @classmethod
+    @docval(*get_docval(H5DataIO.__init__))
+    def set_dataio(cls, **kwargs):
+        """
+        Wrap the given Data object with an H5DataIO.
+
+        This method is provided merely for convenience. It is the equivalent
+        of the following:
+
+        ```
+        from hdmf.backends.hdf5 import H5DataIO
+        data = ...
+        data = H5DataIO(data)
+        ```
+        """
+        cargs, ckwargs = fmt_docval_args(H5DataIO.__init__, kwargs)
+        return H5DataIO(*cargs, **ckwargs)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1037,7 +1037,7 @@ class HDF5IO(HDMFIO):
             io_settings['maxshape'] = data.maxshape
         if 'dtype' not in io_settings:
             if (options is not None) and ('dtype' in options):
-                io_settings['dtype'] = options['dtype']
+                io_settings['dtype'] = cls.__dtypes.get(options['dtype'])
             else:
                 io_settings['dtype'] = data.dtype
         try:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -189,6 +189,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         if spec_dtype is None:
             spec_dtype = spec.dtype
+        if spec.name == 'sequence_name':
+            breakpoint()
         ret, ret_dtype = cls.__check_edgecases(spec, value, spec_dtype)
         if ret is not None or ret_dtype is not None:
             return ret, ret_dtype
@@ -217,9 +219,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
             ret_dtype = tmp_dtype
         elif isinstance(value, AbstractDataChunkIterator):
             ret = value
-            if spec_dtype is _unicode:
+            if spec_dtype_type is _unicode:
                 ret_dtype = "utf8"
-            elif spec_dtype is _ascii:
+            elif spec_dtype_type is _ascii:
                 ret_dtype = "ascii"
             else:
                 ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -247,7 +247,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 np.issubdtype(value_dtype, np.integer)):
             raise ValueError("Cannot convert from %s to 'numeric' specification dtype." % value_type)
 
-    @classmethod
+    @classmethod  # noqa: C901
     def __check_edgecases(cls, spec, value, spec_dtype):  # noqa: C901
         """
         Check edge cases in converting data to a dtype

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -217,7 +217,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
             ret_dtype = tmp_dtype
         elif isinstance(value, AbstractDataChunkIterator):
             ret = value
-            ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
+            if spec_dtype is _unicode:
+                ret_dtype = "utf8"
+            elif spec_dtype is _ascii:
+                ret_dtype = "ascii"
+            else:
+                ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
         else:
             if spec_dtype_type in (_unicode, _ascii):
                 ret_dtype = 'ascii'

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -189,8 +189,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         if spec_dtype is None:
             spec_dtype = spec.dtype
-        if spec.name == 'sequence_name':
-            breakpoint()
         ret, ret_dtype = cls.__check_edgecases(spec, value, spec_dtype)
         if ret is not None or ret_dtype is not None:
             return ret, ret_dtype

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -118,6 +118,7 @@ VectorData = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'VectorData')
 VectorIndex = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'VectorIndex')
 ElementIdentifiers = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'ElementIdentifiers')
 DynamicTableRegion = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'DynamicTableRegion')
+VocabData = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'VocabData')
 CSRMatrix = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'CSRMatrix')
 
 

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -7,8 +7,9 @@ from copy import deepcopy
 CORE_NAMESPACE = 'hdmf-common'
 
 from ..spec import NamespaceCatalog  # noqa: E402
-from ..utils import docval, getargs, call_docval_func  # noqa: E402
+from ..utils import docval, getargs, call_docval_func, get_docval, fmt_docval_args  # noqa: E402
 from ..backends.io import HDMFIO  # noqa: E402
+from ..backends.hdf5 import HDF5IO  # noqa: E402
 from ..validate import ValidatorMap  # noqa: E402
 from ..build import BuildManager, TypeMap  # noqa: E402
 
@@ -193,3 +194,12 @@ def validate(**kwargs):
     builder = io.read_builder()
     validator = ValidatorMap(io.manager.namespace_catalog.get_namespace(name=namespace))
     return validator.validate(builder)
+
+
+@docval(*get_docval(HDF5IO.__init__), is_method=False)
+def get_hdf5io(**kwargs):
+    manager = getargs('manager', kwargs)
+    if manager is None:
+        kwargs['manager'] = get_manager()
+    cargs, ckwargs = fmt_docval_args(HDF5IO.__init__, kwargs)
+    return HDF5IO(*cargs, **ckwargs)

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -199,6 +199,9 @@ def validate(**kwargs):
 
 @docval(*get_docval(HDF5IO.__init__), is_method=False)
 def get_hdf5io(**kwargs):
+    """
+    A convenience method for getting an HDF5IO object
+    """
     manager = getargs('manager', kwargs)
     if manager is None:
         kwargs['manager'] = get_manager()

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -17,7 +17,7 @@ class DynamicTableMap(ObjectMapper):
 
     @ObjectMapper.object_attr('colnames')
     def attr_columns(self, container, manager):
-        if all(len(col) == 0 for col in container.columns):
+        if all(not col for col in container.columns):
             return tuple()
         return container.colnames
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -863,12 +863,6 @@ class DynamicTableRegion(VectorData):
         dat = self.data
         if isinstance(dat, DataIO):
             dat = dat.data
-        if not isinstance(dat, AbstractDataChunkIterator):
-            for idx in self.data:
-                if idx < 0 or idx >= len(val):
-                    raise IndexError('The index ' + str(idx) +
-                                     ' is out of range for this DynamicTable of length '
-                                     + str(len(val)))
         self.fields['table'] = val
 
     def __getitem__(self, key):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -881,8 +881,8 @@ class DynamicTableRegion(VectorData):
             arg1 = key[0]
             arg2 = key[1]
             return self.table[self.data[arg1], arg2]
-        elif isinstance(key, (int, slice)):
-            if isinstance(key, int) and key >= len(self.data):
+        elif isinstance(key, slice) or np.issubdtype(type(key), np.integer):
+            if np.issubdtype(type(key), np.integer) and key >= len(self.data):
                 raise IndexError('index {} out of bounds for data of length {}'.format(key, len(self.data)))
             return self.table[self.data[key]]
         else:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -556,7 +556,7 @@ class DynamicTable(Container):
         cls = VectorData
 
         # Add table if it's been specified
-        if table and index:
+        if table and vocab:
             raise ValueError("column '%s' cannot be both a table region and come from a controlled vocabulary" % name)
         if table is not False:
             cls = DynamicTableRegion

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -860,11 +860,15 @@ class DynamicTableRegion(VectorData):
         if 'table' in self.fields:
             msg = "can't set attribute 'table' -- already set"
             raise AttributeError(msg)
-        for idx in self.data:
-            if idx < 0 or idx >= len(val):
-                raise IndexError('The index ' + str(idx) +
-                                 ' is out of range for this DynamicTable of length '
-                                 + str(len(val)))
+        dat = self.data
+        if isinstance(dat, DataIO):
+            dat = dat.data
+        if not isinstance(dat, AbstractDataChunkIterator):
+            for idx in self.data:
+                if idx < 0 or idx >= len(val):
+                    raise IndexError('The index ' + str(idx) +
+                                     ' is out of range for this DynamicTable of length '
+                                     + str(len(val)))
         self.fields['table'] = val
 
     def __getitem__(self, key):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -963,7 +963,7 @@ class DynamicTableRegion(VectorData):
         self.fields['table'] = val
 
     def __getitem__(self, arg):
-        return self.get(key)
+        return self.get(arg)
 
     def get(self, arg, index=False):
         """

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -767,6 +767,11 @@ class DynamicTable(Container):
                                 ret[k] = list(ret[k])
                             else:
                                 raise ValueError('unable to convert selection to DataFrame')
+                    elif isinstance(ret[k], list):
+                        if len(id_index) == 1:
+                            # k is a multi-dimension column, and
+                            # only one element has been selected
+                            ret[k] = [ret[k]]
                 ret = pd.DataFrame(ret, index=pd.Index(name=self.id.name, data=id_index), columns=self.colnames)
             else:
                 ret = list(ret.values())

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -949,8 +949,8 @@ class VocabData(VectorData):
         super().__init__(**kwargs)
         self.vocabulary = np.asarray(vocab)
         # get minimum uint precision needed for vocabulary
-        uint = np.dtype('uint%d' % 8 * int((2 **np.ceil((np.ceil(np.log2(len(vocab))) - 8)/8)))).type
-        self.__revidx = { t[1]: uint(t[0]) for t in enumerate(self.vocabulary) }
+        uint = np.dtype('uint%d' % 8 * int((2 ** np.ceil((np.ceil(np.log2(len(vocab))) - 8)/8)))).type
+        self.__revidx = {t[1]: uint(t[0]) for t in enumerate(self.vocabulary)}
 
     def __getitem__(self, arg):
         return self.get(arg, index=False)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -538,7 +538,7 @@ class DynamicTable(Container):
         """
         return self.to_dataframe().equals(other.to_dataframe())
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorData'},
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorData'},  # noqa: C901
             {'name': 'description', 'type': str, 'doc': 'a description for this column'},
             {'name': 'data', 'type': ('array_data', 'data'),
              'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()},
@@ -674,7 +674,7 @@ class DynamicTable(Container):
             raise KeyError(key)
         return self.get(key)
 
-    def get(self, key, df=True, **kwargs):  # noqa: C901
+    def get(self, key, default=None, df=True, **kwargs):  # noqa: C901
         """
         Select a subset from the table
 
@@ -708,7 +708,7 @@ class DynamicTable(Container):
             elif key in self.__indices:
                 ret = self.__indices[key]
             else:
-                return None
+                return default
         else:
             # index by int, list, or slice --> return pandas Dataframe consisting of one or more rows
             # determine the key. If the key is an int, then turn it into a slice to reduce the number of cases below
@@ -972,7 +972,7 @@ class DynamicTableRegion(VectorData):
         :param arg: 1) tuple consisting of (str, int) where the string defines the column to select
                        and the int selects the row, 2) int or slice to select a subset of rows
 
-        :return: Result from self.table[....] with the approbritate selection based on the
+        :return: Result from self.table[....] with the appropritate selection based on the
                  rows selected by this DynamicTableRegion
         """
         # treat the list of indices as data that can be indexed. then pass the

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -669,6 +669,9 @@ class DynamicTable(Container):
         return DynamicTableRegion(name, region, desc, self)
 
     def __getitem__(self, key):
+        ret = self.get(key)
+        if ret is None:
+            raise KeyError(key)
         return self.get(key)
 
     def get(self, key, df=True, **kwargs):  # noqa: C901
@@ -703,7 +706,7 @@ class DynamicTable(Container):
             elif key in self.__indices:
                 ret = self.__indices[key]
             else:
-                raise KeyError(key)
+                return None
         else:
             # index by int, list, or slice --> return pandas Dataframe consisting of one or more rows
             # determine the key. If the key is an int, then turn it into a slice to reduce the number of cases below

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -549,7 +549,7 @@ class DynamicTable(Container):
             {'name': 'vocab', 'type': (bool, 'array_data'), 'default': False,
              'doc': ('whether or not this column contains data from a '
                      'controlled vocabulary or the controlled vocabulary')})
-    def add_column(self, **kwargs):
+    def add_column(self, **kwargs): # noqa: C901
         """
         Add a column to this table.
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from warnings import warn
 
 from ..utils import docval, getargs, ExtenderMeta, call_docval_func, popargs, pystr
+from ..data_utils import DataIO, AbstractDataChunkIterator
 from ..container import Container, Data
 
 from . import register_class
@@ -200,7 +201,7 @@ class DynamicTable(Container):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table'},
-            {'name': 'id', 'type': ('array_data', ElementIdentifiers), 'doc': 'the identifiers for this table',
+            {'name': 'id', 'type': ('array_data', 'data', ElementIdentifiers), 'doc': 'the identifiers for this table',
              'default': None},
             {'name': 'columns', 'type': (tuple, list), 'doc': 'the columns in this table', 'default': None},
             {'name': 'colnames', 'type': 'array_data',
@@ -244,6 +245,11 @@ class DynamicTable(Container):
             for c in columns:  # remove all VectorData objects that have an associated VectorIndex from colset
                 if isinstance(c, VectorIndex):
                     colset.pop(c.target.name)
+                _data = c.data
+                if isinstance(_data, DataIO):
+                    _data = _data.data
+                if isinstance(_data, AbstractDataChunkIterator):
+                    colset.pop(c.name, None)
             lens = [len(c) for c in colset.values()]
             if not all(i == lens[0] for i in lens):
                 raise ValueError("columns must be the same length")

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -986,7 +986,7 @@ class DynamicTableRegion(VectorData):
                 raise IndexError('index {} out of bounds for data of length {}'.format(arg, len(self.data)))
             ret = self.data[arg]
             if not index:
-                ret =  self.table[self.data[arg]]
+                ret = self.table[self.data[arg]]
             return ret
         else:
             raise ValueError("unrecognized argument: '%s'" % arg)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -956,9 +956,12 @@ class VocabData(VectorData):
         idx = self.data[arg]
         if indices:
             return idx
-        orig_shape = idx.shape
-        ret = self.vocabulary[idx.ravel()]
-        ret = ret.reshape(orig_shape)
-        if join:
-            ret = ''.join(ret.ravel())
+        if not np.isscalar(idx):
+            orig_shape = idx.shape
+            ret = self.vocabulary[idx.ravel()]
+            ret = ret.reshape(orig_shape)
+            if join:
+                ret = ''.join(ret.ravel())
+        else:
+            ret = self.vocabulary[idx]
         return ret

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -937,16 +937,19 @@ class VocabData(VectorData):
         vocab = popargs('vocabulary', kwargs)
         super().__init__(**kwargs)
         self.vocabulary = np.asarray(vocab)
+        # get minimum uint precision needed for vocabulary
+        uint = np.dtype('uint%d' % 8 * int((2 **np.ceil((np.ceil(np.log2(len(vocab))) - 8)/8)))).type
+        self.__revidx = { t[1]: uint(t[0]) for t in enumerate(self.vocabulary) }
 
     def __getitem__(self, arg):
-        return self.get(arg, indices=False)
+        return self.get(arg, index=False)
 
-    def get(self, arg, indices=False, join=False):
+    def get(self, arg, index=False, join=False):
         """
         Return vocabulary elements for the given argument.
 
         Args:
-            indices (bool):    Return indices, do not return CV elements
+            index (bool):      Return indices, do not return CV elements
             join (bool):       Concatenate elements together into a single string
 
         Returns:
@@ -954,7 +957,7 @@ class VocabData(VectorData):
             elements if *join* is True.
         """
         idx = self.data[arg]
-        if indices:
+        if index:
             return idx
         if not np.isscalar(idx):
             orig_shape = idx.shape
@@ -965,3 +968,17 @@ class VocabData(VectorData):
         else:
             ret = self.vocabulary[idx]
         return ret
+
+    @docval({'name': 'val', 'type': None, 'doc': 'the value to add to this column'},
+            {'name': 'index', 'type': bool, 'doc': 'whether or not the value being added is an index',
+             'default': False})
+    def add_row(self, **kwargs):
+        """Append a data value to this VocabData column
+
+        If a controlled-vocabulary is provided for *val* (i.e. *index* is False), the correct
+        index value will be determined. Otherwise, *val* will be added as provided.
+        """
+        val, index = getargs('val', 'index', kwargs)
+        if not index:
+            val = self.__revidx[val]
+        super().append(val)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -82,9 +82,9 @@ class VectorIndex(Index):
         self.target = getargs('target', kwargs)
         self.__uint = np.uint8
         self.__maxval = 255
-        if len(self.data) > 0:
-            self.__check_precision(len(self.target))
         if isinstance(self.data, (list, np.ndarray)):
+            if len(self.data) > 0:
+                self.__check_precision(len(self.target))
             # adjust precision for types that we can adjust precision for
             self.__adjust_precision(self.__uint)
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -637,7 +637,7 @@ class DynamicTable(Container):
     def __getitem__(self, key):
         return self.get(key)
 
-    def get(self, key, df=True, **kwargs):
+    def get(self, key, df=True, **kwargs):  # noqa: C901
         """
         Select a subset from the table
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -95,15 +95,16 @@ class VectorIndex(Index):
         """
         self.add_vector(arg)
 
-    def __getitem_helper(self, arg):
+    def __getitem_helper(self, arg, **kwargs):
         """
         Internal helper function used by __getitem__ to retrieve a data value from self.target
 
         :param arg: Integer index into this VectorIndex indicating the element we want to retrieve from the target
+        :param kwargs: keyword arguments to pass into *self.target.get*
         """
         start = 0 if arg == 0 else self.data[arg-1]
         end = self.data[arg]
-        return self.target[start:end]
+        return self.target.get(slice(start, end), **kwargs)
 
     def __getitem__(self, arg):
         """
@@ -112,14 +113,24 @@ class VectorIndex(Index):
         :param arg: slice or integer index indicating the elements we want to select in this VectorIndex
         :return: Scalar or list of values retrieved
         """
+        return self.get(arg)
+
+    def get(self, arg, **kwargs):
+        """
+        Select elements in this VectorIndex and retrieve the corrsponding data from the self.target VectorData
+
+        :param arg: slice or integer index indicating the elements we want to select in this VectorIndex
+        :param kwargs: keyword arguments to pass into *target.get*
+        :return: Scalar or list of values retrieved
+        """
         if isinstance(arg, slice):
             indices = list(range(*arg.indices(len(self.data))))
             ret = list()
             for i in indices:
-                ret.append(self.__getitem_helper(i))
+                ret.append(self.__getitem_helper(i, **kwargs))
             return ret
         else:
-            return self.__getitem_helper(arg)
+            return self.__getitem_helper(arg, **kwargs)
 
 
 @register_class('ElementIdentifiers')

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -549,7 +549,7 @@ class DynamicTable(Container):
             {'name': 'vocab', 'type': (bool, 'array_data'), 'default': False,
              'doc': ('whether or not this column contains data from a '
                      'controlled vocabulary or the controlled vocabulary')})
-    def add_column(self, **kwargs): # noqa: C901
+    def add_column(self, **kwargs):  # noqa: C901
         """
         Add a column to this table.
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -380,7 +380,7 @@ class Data(AbstractContainer):
     """
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
-            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the source of the data'})
+            {'name': 'data', 'type': ('scalar_data', 'array_data', 'data'), 'doc': 'the source of the data'})
     def __init__(self, **kwargs):
         call_docval_func(super().__init__, kwargs)
         self.__data = getargs('data', kwargs)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -418,6 +418,7 @@ class Data(AbstractContainer):
         """
         func = getargs('func', kwargs)
         self.__data = func(self.__data)
+        return self
 
     def __bool__(self):
         if self.data is not None:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -431,6 +431,9 @@ class Data(AbstractContainer):
         return len(self.__data)
 
     def __getitem__(self, args):
+        return self.get(args)
+
+    def get(self, args):
         if isinstance(self.data, (tuple, list)) and isinstance(args, (tuple, list)):
             return [self.data[i] for i in args]
         return self.data[args]

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -408,6 +408,8 @@ class Data(AbstractContainer):
         self.__data = dataio
 
     def __bool__(self):
+        if self.data:
+            return True
         return len(self.data) != 0
 
     def __len__(self):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -408,9 +408,12 @@ class Data(AbstractContainer):
         self.__data = dataio
 
     def __bool__(self):
-        if self.data:
-            return True
-        return len(self.data) != 0
+        if self.data is not None:
+            if isinstance(self.data, (np.ndarray, tuple, list)):
+                return len(self.data) != 0
+            if self.data:
+                return True
+        return False
 
     def __len__(self):
         return len(self.__data)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -5,6 +5,7 @@ from .utils import docval, get_docval, call_docval_func, getargs, ExtenderMeta, 
 from .data_utils import DataIO
 from warnings import warn
 import h5py
+import types
 
 
 class AbstractContainer(metaclass=ExtenderMeta):
@@ -406,6 +407,17 @@ class Data(AbstractContainer):
         dataio = getargs('dataio', kwargs)
         dataio.data = self.__data
         self.__data = dataio
+
+    @docval({'name': 'func', 'type': types.FunctionType, 'doc': 'a function to transform *data*'})
+    def transform(self, **kwargs):
+        """
+        Transform data from the current underlying state.
+
+        This function can be used to permanently load data from disk, or convert to a different
+        representation, such as a torch.Tensor
+        """
+        func = getargs('func', kwargs)
+        self.__data = func(self.__data)
 
     def __bool__(self):
         if self.data is not None:

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -158,6 +158,12 @@ class DataChunkIterator(AbstractDataChunkIterator):
             self.__dtype = self.__next_chunk.data.dtype
             self.__first_chunk_shape = get_data_shape(self.__next_chunk.data)
 
+        # This should be done as a last resort only
+        if self.__first_chunk_shape is None and self.__maxshape is not None:
+            tmp = list(self.__maxshape)
+            tmp[0] = 1
+            self.__first_chunk_shape = tuple(tmp)
+
         if self.__dtype is None:
             raise Exception('Data type could not be determined. Please specify dtype in DataChunkIterator init.')
 
@@ -620,7 +626,11 @@ class DataIO:
         return len(self.data)
 
     def __bool__(self):
-        return self.valid and len(self) > 0
+        if self.valid:
+            if isinstance(self.data, AbstractDataChunkIterator):
+                return True
+            return len(self) > 0
+        return False
 
     def __getattr__(self, attr):
         """Delegate attribute lookup to data object"""

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -160,9 +160,7 @@ class DataChunkIterator(AbstractDataChunkIterator):
 
         # This should be done as a last resort only
         if self.__first_chunk_shape is None and self.__maxshape is not None:
-            tmp = list(self.__maxshape)
-            tmp[0] = 1
-            self.__first_chunk_shape = tuple(tmp)
+            self.__first_chunk_shape = tuple(1 if i is None else i for i in self.__maxshape)
 
         if self.__dtype is None:
             raise Exception('Data type could not be determined. Please specify dtype in DataChunkIterator init.')

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 __macros = {
     'array_data': [np.ndarray, list, tuple, h5py.Dataset],
-    'scalar_data': [str, int, float],
+    'scalar_data': [str, int, float, bytes],
 }
 
 # code to signify how to handle positional arguments in docval

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -421,7 +421,7 @@ class GroupValidator(BaseStorageValidator):
         for spec in self.spec.links:
             self.__include_dts[spec.data_type_inc] = spec
 
-    @docval({"name": "builder", "type": GroupBuilder, "doc": "the builder to validate"},
+    @docval({"name": "builder", "type": GroupBuilder, "doc": "the builder to validate"},  # noqa: C901
             returns='a list of Errors', rtype=list)
     def validate(self, **kwargs):  # noqa: C901
         builder = getargs('builder', kwargs)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -418,8 +418,9 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
         table.add_column('bar', 'a float column')
         table.add_column('baz', 'a string column')
         table.add_column('qux', 'a boolean column')
-        table.add_row(foo=27, bar=28.0, baz="cat", qux=True)
-        table.add_row(foo=37, bar=38.0, baz="dog", qux=False)
+        table.add_column('quux', 'a vocab column', vocab=True)
+        table.add_row(foo=27, bar=28.0, baz="cat", qux=True, quux='a')
+        table.add_row(foo=37, bar=38.0, baz="dog", qux=False, quux='b')
         return table
 
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,3 +1,4 @@
+import unittest
 from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion, VocabData
 from hdmf.testing import TestCase, H5RoundTripMixin
 
@@ -546,6 +547,7 @@ class TestDynamicTableRegion(TestCase):
         except AttributeError:
             self.fail("DynamicTableRegion table setter raised AttributeError unexpectedly!")
 
+    @unittest.skip('we no longer check data contents for performance reasons')
     def test_dynamic_table_region_set_with_bad_data(self):
         table = self.with_columns_and_data()
         dynamic_table_region = DynamicTableRegion('dtr', [5, 1], 'desc')   # index 5 is out of range

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,4 +1,4 @@
-from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion
+from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion, VocabData
 from hdmf.testing import TestCase, H5RoundTripMixin
 
 import pandas as pd
@@ -832,3 +832,44 @@ class TestDynamicTableClassColumns(TestCase):
         msg = "'columns' contains columns with duplicate names: ['col1', 'col1']"
         with self.assertRaisesWith(ValueError, msg):
             SubTable(name='subtable', description='subtable description', columns=[col1_ind, col1])
+
+
+class TestVocabData(TestCase):
+
+    def test_init(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
+        self.assertIsInstance(vd.vocabulary, np.ndarray)
+
+    def test_get(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
+        dat = vd[2]
+        self.assertEqual(dat, 'b')
+        dat = vd[-1]
+        self.assertEqual(dat, 'c')
+        dat = vd[0]
+        self.assertEqual(dat, 'a')
+
+    def test_get_list(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
+        dat = vd[[0, 1, 2]]
+        np.testing.assert_array_equal(dat, ['a', 'a', 'b'])
+
+    def test_get_list_join(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
+        dat = vd.get([0, 1, 2], join=True)
+        self.assertEqual(dat, 'aab')
+
+    def test_get_list_indices(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
+        dat = vd.get([0, 1, 2], indices=True)
+        np.testing.assert_array_equal(dat, [0, 0, 1])
+
+    def test_get_2d(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([[0, 0], [1, 1], [2, 2]]))
+        dat = vd[0]
+        np.testing.assert_array_equal(dat, ['a', 'a'])
+
+    def test_get_2d_w_2d(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([[0, 0], [1, 1], [2, 2]]))
+        dat = vd[[0, 1]]
+        np.testing.assert_array_equal(dat, [['a', 'a'], ['b', 'b']])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -861,7 +861,7 @@ class TestVocabData(TestCase):
 
     def test_get_list_indices(self):
         vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([0, 0, 1, 1, 2, 2]))
-        dat = vd.get([0, 1, 2], indices=True)
+        dat = vd.get([0, 1, 2], index=True)
         np.testing.assert_array_equal(dat, [0, 0, 1])
 
     def test_get_2d(self):
@@ -873,3 +873,17 @@ class TestVocabData(TestCase):
         vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([[0, 0], [1, 1], [2, 2]]))
         dat = vd[[0, 1]]
         np.testing.assert_array_equal(dat, [['a', 'a'], ['b', 'b']])
+
+    def test_add_row(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'])
+        vd.add_row('b')
+        vd.add_row('a')
+        vd.add_row('c')
+        np.testing.assert_array_equal(vd.data, np.array([1, 0, 2], dtype=np.uint8))
+
+    def test_add_row_index(self):
+        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'])
+        vd.add_row(1, index=True)
+        vd.add_row(0, index=True)
+        vd.add_row(2, index=True)
+        np.testing.assert_array_equal(vd.data, np.array([1, 0, 2], dtype=np.uint8))

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -865,12 +865,16 @@ class TestVocabData(TestCase):
         np.testing.assert_array_equal(dat, [0, 0, 1])
 
     def test_get_2d(self):
-        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([[0, 0], [1, 1], [2, 2]]))
+        vd = VocabData('cv_data', 'a test VocabData',
+                       vocabulary=['a', 'b', 'c'],
+                       data=np.array([[0, 0], [1, 1], [2, 2]]))
         dat = vd[0]
         np.testing.assert_array_equal(dat, ['a', 'a'])
 
     def test_get_2d_w_2d(self):
-        vd = VocabData('cv_data', 'a test VocabData', vocabulary=['a', 'b', 'c'], data=np.array([[0, 0], [1, 1], [2, 2]]))
+        vd = VocabData('cv_data', 'a test VocabData',
+                       vocabulary=['a', 'b', 'c'],
+                       data=np.array([[0, 0], [1, 1], [2, 2]]))
         dat = vd[[0, 1]]
         np.testing.assert_array_equal(dat, [['a', 'a'], ['b', 'b']])
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -121,6 +121,12 @@ class TestContainer(TestCase):
 
 class TestData(TestCase):
 
+    def test_constructor_scalar(self):
+        """Test that __bool__ method works correctly on data with len
+        """
+        data_obj = Data('my_data', 'foobar')
+        self.assertEqual(data_obj.data, 'foobar')
+
     def test_bool_true(self):
         """Test that __bool__ method works correctly on data with len
         """

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -122,7 +122,7 @@ class TestContainer(TestCase):
 class TestData(TestCase):
 
     def test_constructor_scalar(self):
-        """Test that __bool__ method works correctly on data with len
+        """Test that constructor works correctly on scalar data
         """
         data_obj = Data('my_data', 'foobar')
         self.assertEqual(data_obj.data, 'foobar')


### PR DESCRIPTION
## Motivation

The original motivation for this PR was to add the ability to write table columns from DataChunkIterators. This work went stale and when it was brought up to date, some other issues arose. In response to those issues, a couple more features were added.

1. Add ability to write `DynamicTable` columns from a `DataChunkIterator`
2. Add `DynamicTable.get` method. This method behaves like `__getitem__`/`[]`, but can take optional arguments to modify the behavior. Currently, the only argument that exists is `df`, which will control if a selection is returned as a `pandas.DataFrame`. 
    - The work of selecting from a DynamicTable is carried out by `DynamicTable.get`. `DynamicTable.__getitem__` calls `DynamicTable.get` with whatever options are necessary to provide familiar functionality. Moving forward, this pattern with `get`/`__getitem__` will be used to provide more flexibility for selecting data from a `DynamicTable`. See `VocabData` for another example.
3. `DynamicTable.__getitem__` functionality wasn't fully tested and had some issues. One major issue was that returning a `pd.DataFrame` did not work if one of the columns was multi-dimensional or ragged. This PR will resolve those issues.
4. Add `VocabData` column type for storing controlled-vocabulary data. 