### PR TITLE
Make VectorIndex inherit from VectorData

### DIFF
--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -413,21 +413,22 @@ table_double_ragged_col = DynamicTable(
     columns=[col6, col6_ind, col6_ind_ind],
 )
 
+###############################################################################
 # Access the first row using the same syntax as before, except now a list of
-# lists is returned.
+# lists is returned. You can then index the resulting list of lists to access
+# the individual elements.
+
 table_double_ragged_col[0, 'col6']  # returns [['a', 'b', 'c'], ['d', 'e', 'f']]
 table_double_ragged_col['col6'][0]  # same as line above
-
-# You can then index the resulting list of lists to access the individual
-# elements
 table_double_ragged_col['col6'][0][1]  # returns ['d', 'e', 'f']
 
+###############################################################################
 # Accessing the column named 'col6' using square bracket notation will return
-# the top-level :py:class:`~hdmf.common.table.VectorIndex` for the column
-table_double_ragged_col['col6']  # returns col6_ind_ind
-
+# the top-level :py:class:`~hdmf.common.table.VectorIndex` for the column.
 # Accessing the column named 'col6' using dot notation will return the
 # :py:class:`~hdmf.common.table.VectorData` object
+
+table_double_ragged_col['col6']  # returns col6_ind_ind
 table_double_ragged_col.col6  # returns col6
 
 ###############################################################################

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -359,6 +359,58 @@ table['col4'][:2]  # get a list of the 0th and 1st list elements
 #   not recommended because they interact with the internal list of columns.
 
 ###############################################################################
+# Nested ragged array columns
+# ---------------------------
+# A :py:class:`~hdmf.common.table.VectorIndex` object can index another
+# :py:class:`~hdmf.common.table.VectorIndex` object. This is useful if each
+# row of a table contains a different number of elements, and each of those
+# elements contains a different number of sub-elements from other rows. If each
+# row element contained the same number of sub-elements, then a 2-D array could
+# be used as the row element. For example, the first row of a table might
+# be a 2x3 array, the second row might be a 3x2 array, and the third row might
+# be a 1x1 array. This cannot be represented by a singly indexed column.
+
+col5 = VectorData(
+    name='col5',
+    description='column #5',
+    data=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+)
+col5_ind = VectorIndex(
+    name='col5_index',
+    target=col5,
+    data=[3, 6, 8, 10, 12, 13],
+)
+col5_ind_ind = VectorIndex(
+    name='col5_index_index',
+    target=col5_ind,
+    data=[2, 5, 6],
+)
+
+# All indices must be added to the table.
+table_double_ragged_col = DynamicTable(
+    name='my table',
+    description='an example table',
+    columns=[col5, col5_ind, col5_ind_ind],
+)
+
+# Access the first row using the same syntax as before, except now a list of
+# lists is returned.
+table_double_ragged_col[0, 'col5']  # returns [['a', 'b', 'c'], ['d', 'e', 'f']]
+table_double_ragged_col['col5'][0]  # same as line above
+
+# You can then index the resulting list of lists to access the individual
+# elements
+table_double_ragged_col['col5'][0][1]  # returns ['d', 'e', 'f']
+
+# Accessing the column named 'col5' using square bracket notation will return
+# the top-level :py:class:`~hdmf.common.table.VectorIndex` for the column
+table_double_ragged_col['col5']  # returns col5_ind_ind
+
+# Accessing the column named 'col5' using dot notation will return the
+# :py:class:`~hdmf.common.table.VectorData` object
+table_double_ragged_col.col5  # returns col5
+
+###############################################################################
 # Referencing rows of a DynamicTable
 # ----------------------------------
 # TODO

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -361,54 +361,74 @@ table['col4'][:2]  # get a list of the 0th and 1st list elements
 ###############################################################################
 # Nested ragged array columns
 # ---------------------------
-# A :py:class:`~hdmf.common.table.VectorIndex` object can index another
-# :py:class:`~hdmf.common.table.VectorIndex` object. This is useful if each
-# row of a table contains a different number of elements, and each of those
-# elements contains a different number of sub-elements from other rows. If each
-# row element contained the same number of sub-elements, then a 2-D array could
-# be used as the row element. For example, the first row of a table might
-# be a 2x3 array, the second row might be a 3x2 array, and the third row might
-# be a 1x1 array. This cannot be represented by a singly indexed column.
+# Each element within a column can be an n-dimensional array, and this is true
+# for ragged array columns as well.
 
 col5 = VectorData(
     name='col5',
     description='column #5',
-    data=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+    data=[['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']],
 )
 col5_ind = VectorIndex(
     name='col5_index',
     target=col5,
+    data=[2, 3],
+)
+
+###############################################################################
+# The ragged array column above has two rows. The first row has two elements,
+# where each element has 3 sub-elements. This can be thought of as a 2x3 array.
+# The second row has one element with 3 sub-elements, or a 1x3 array. This
+# works only if the data for ``col5`` is a rectangular array, that is, each row
+# element contains the same number of sub-elements. If each row element does
+# not contain the same number of sub-elements, then a nested ragged array
+# approach must be used instead.
+#
+# A :py:class:`~hdmf.common.table.VectorIndex` object can index another
+# :py:class:`~hdmf.common.table.VectorIndex` object. For example, the first row
+# of a table might be a 2x3 array, the second row might be a 3x2 array, and the
+# third row might be a 1x1 array. This cannot be represented by a singly
+# indexed column, but can be represented by a nested ragged array column.
+
+col6 = VectorData(
+    name='col6',
+    description='column #6',
+    data=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+)
+col6_ind = VectorIndex(
+    name='col6_index',
+    target=col6,
     data=[3, 6, 8, 10, 12, 13],
 )
-col5_ind_ind = VectorIndex(
-    name='col5_index_index',
-    target=col5_ind,
+col6_ind_ind = VectorIndex(
+    name='col6_index_index',
+    target=col6_ind,
     data=[2, 5, 6],
 )
 
-# All indices must be added to the table.
+# All indices must be added to the table
 table_double_ragged_col = DynamicTable(
     name='my table',
     description='an example table',
-    columns=[col5, col5_ind, col5_ind_ind],
+    columns=[col6, col6_ind, col6_ind_ind],
 )
 
 # Access the first row using the same syntax as before, except now a list of
 # lists is returned.
-table_double_ragged_col[0, 'col5']  # returns [['a', 'b', 'c'], ['d', 'e', 'f']]
-table_double_ragged_col['col5'][0]  # same as line above
+table_double_ragged_col[0, 'col6']  # returns [['a', 'b', 'c'], ['d', 'e', 'f']]
+table_double_ragged_col['col6'][0]  # same as line above
 
 # You can then index the resulting list of lists to access the individual
 # elements
-table_double_ragged_col['col5'][0][1]  # returns ['d', 'e', 'f']
+table_double_ragged_col['col6'][0][1]  # returns ['d', 'e', 'f']
 
-# Accessing the column named 'col5' using square bracket notation will return
+# Accessing the column named 'col6' using square bracket notation will return
 # the top-level :py:class:`~hdmf.common.table.VectorIndex` for the column
-table_double_ragged_col['col5']  # returns col5_ind_ind
+table_double_ragged_col['col6']  # returns col6_ind_ind
 
-# Accessing the column named 'col5' using dot notation will return the
+# Accessing the column named 'col6' using dot notation will return the
 # :py:class:`~hdmf.common.table.VectorData` object
-table_double_ragged_col.col5  # returns col5
+table_double_ragged_col.col6  # returns col6
 
 ###############################################################################
 # Referencing rows of a DynamicTable

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -11,9 +11,7 @@ class DynamicTableMap(ObjectMapper):
     def __init__(self, spec):
         super().__init__(spec)
         vector_data_spec = spec.get_data_type('VectorData')
-        vector_index_spec = spec.get_data_type('VectorIndex')
         self.map_spec('columns', vector_data_spec)
-        self.map_spec('columns', vector_index_spec)
 
     @ObjectMapper.object_attr('colnames')
     def attr_columns(self, container, manager):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -376,6 +376,7 @@ class DynamicTable(Container):
 
                 # loop through nested indices to get to non-index column
                 curr_col = col
+                self.__set_table_attr(curr_col)
                 while isinstance(curr_col.target, VectorIndex):
                     curr_col = curr_col.target
                     # check if index has been added. if not, add it
@@ -385,7 +386,8 @@ class DynamicTable(Container):
 
                 # use target vectordata name at end of indexing chain as key to get to the top level index
                 col_dict[curr_col.target.name] = col
-                self.__set_table_attr(col)
+                if not hasattr(self, curr_col.target.name):
+                    self.__set_table_attr(curr_col.target)
 
         self.__df_cols = [self.id] + [col_dict[name] for name in self.colnames]
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -64,7 +64,7 @@ class VectorData(Data):
 
 
 @register_class('VectorIndex')
-class VectorIndex(Index):
+class VectorIndex(VectorData):
     """
     When paired with a VectorData, this allows for storing arrays of varying
     length in a single cell of the DynamicTable by indexing into this VectorData.
@@ -72,14 +72,18 @@ class VectorIndex(Index):
     VectorData[VectorIndex(0)+1:VectorIndex(1)+1], and so on.
     """
 
+    __fields__ = ("target",)
+
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorIndex'},
             {'name': 'data', 'type': ('array_data', 'data'),
              'doc': 'a 1D dataset containing indexes that apply to VectorData object'},
             {'name': 'target', 'type': VectorData,
              'doc': 'the target dataset that this index applies to'})
     def __init__(self, **kwargs):
+        target = getargs('target', kwargs)
+        kwargs['description'] = "Index for VectorData '%s'" % target.name
         call_docval_func(super().__init__, kwargs)
-        self.target = getargs('target', kwargs)
+        self.target = target
         self.__uint = np.uint8
         self.__maxval = 255
         if isinstance(self.data, (list, np.ndarray)):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -368,7 +368,7 @@ class DynamicTable(Container):
                 else:
                     col_dict[col.name] = col
                     self.__set_table_attr(col)
-            elif isinstance(col, VectorIndex):
+            else:  # col is a vectorindex
                 # if index has already been added because it is part of a nested index chain, ignore this column
                 if col.name in self.__indices:
                     continue

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -274,6 +274,10 @@ class DynamicTable(Container):
             if len(all_names) != len(set(all_names)):
                 raise ValueError("'columns' contains columns with duplicate names: %s" % all_names)
 
+            all_targets = [c.target.name for c in columns if isinstance(c, VectorIndex)]
+            if len(all_targets) != len(set(all_targets)):
+                raise ValueError("'columns' contains index columns with the same target: %s" % all_targets)
+
             # TODO: check columns against __columns__
             # mismatches should raise an error (e.g., a VectorData cannot be passed in with the same name as a
             # prespecified table region column)
@@ -358,13 +362,9 @@ class DynamicTable(Container):
         self.__indices = dict()
         for col in self.columns:
             if isinstance(col, VectorData) and not isinstance(col, VectorIndex):
-                existing = col_dict.get(col.name)
                 # if we added this column using its index, ignore this column
-                if existing is not None:
-                    if isinstance(existing, VectorIndex):
-                        continue
-                    else:
-                        raise ValueError("duplicate column found: '%s'" % col.name)
+                if col.name in col_dict:
+                    continue
                 else:
                     col_dict[col.name] = col
                     self.__set_table_attr(col)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -979,7 +979,7 @@ class TestVectorIndex(TestCase):
     def test_init_data(self):
         foo = VectorData(name='foo', description='foo column', data=['a', 'b', 'c'])
         foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3])
-        self.assertListEqual(foo_ind.data, [2, 4])
+        self.assertListEqual(foo_ind.data, [2, 3])
         self.assertListEqual(foo_ind[0], ['a', 'b'])
         self.assertListEqual(foo_ind[1], ['c'])
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1012,6 +1012,7 @@ class TestDTDoubleIndex(TestCase):
         table = DynamicTable('table0', 'an example table', columns=[foo, foo_ind, foo_ind_ind])
 
         self.assertIs(table['foo'], foo_ind_ind)
+        self.assertIs(table.foo, foo)
         self.assertListEqual(table['foo'][0], [['a11', 'a12'], ['a21']])
         self.assertListEqual(table[0, 'foo'], [['a11', 'a12'], ['a21']])
         self.assertListEqual(table[1, 'foo'], [['b11']])
@@ -1027,6 +1028,7 @@ class TestDTDoubleIndexReverse(TestCase):
         table = DynamicTable('table0', 'an example table', columns=[foo_ind_ind, foo_ind, foo])
 
         self.assertIs(table['foo'], foo_ind_ind)
+        self.assertIs(table.foo, foo)
         self.assertListEqual(table['foo'][0], [['a11', 'a12'], ['a21']])
         self.assertListEqual(table[0, 'foo'], [['a11', 'a12'], ['a21']])
         self.assertListEqual(table[1, 'foo'], [['b11']])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -126,7 +126,7 @@ class TestDynamicTable(TestCase):
         ind = VectorIndex(name='foo_index', data=list(), target=cols[0])
         cols.insert(0, ind)  # put index before its target
         table = DynamicTable("with_columns", 'a test table', columns=cols, colnames=['baz', 'bar', 'foo'])
-        self.assertTupleEqual(table.columns, (cols[2], cols[1], ind, cols[0]))
+        self.assertTupleEqual(table.columns, (cols[3], cols[2], ind, cols[1]))
 
     def test_constructor_dup_index(self):
         """Test that passing two indices for the same column raises an error."""


### PR DESCRIPTION
## Motivation

- [x] Requires https://github.com/hdmf-dev/hdmf-common-schema/pull/37 to be merged and the hdmf-common-schema submodule to be updated.

~~Tests do not pass because of #359.~~

## How to test the behavior?
```python
foo = VectorData(name='foo', description='foo column', data=['a11', 'a12', 'a21', 'b11'])
foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3, 4])
foo_ind_ind = VectorIndex(name='foo_index_index', target=foo_ind, data=[2, 3])

self.assertListEqual(foo_ind_ind[0][0], ['a11', 'a12'])
self.assertListEqual(foo_ind_ind[0][1], ['a21'])
self.assertListEqual(foo_ind_ind[1][0], ['b11'])

table = DynamicTable('table0', 'an example table', columns=[foo_ind_ind, foo_ind, foo])

self.assertIs(table['foo'], foo_ind_ind)
self.assertIs(table.foo, foo)
self.assertListEqual(table['foo'][0], [['a11', 'a12'], ['a21']])
self.assertListEqual(table[0, 'foo'], [['a11', 'a12'], ['a21']])
self.assertListEqual(table[1, 'foo'], [['b11']])
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
