### PR TITLE
Fix `HDF5IO.__get_path` so any `ReferenceBuilder` can be written regardless of root builder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 1.6.4 (Upcoming)
+## HDMF 1.6.4 (June 26, 2020)
 
 ### Internal improvements
 - Add ability to close open links. @rly (#383)
@@ -10,6 +10,10 @@
 - Fix issue with constructing `DynamicTable` with empty array colnames. @rly (#379)
 - Fix `TestCase.assertContainerEqual` passing wrong arguments. @rly (#385)
 - Fix 'link_data' argument not being used when writing non-root level datasets. @rly (#384)
+- Fix handling of ASCII numpy array. @rly (#387)
+- Fix error when optional attribute reference is missing. @rly (#392)
+- Improve testing for `get_data_shape` and fix issue with sets. @rly (#394)
+- Fix inability to write references to HDF5 when the root builder is not named "root". @rly (#395)
 
 ## HDMF 1.6.3 (June 9, 2020)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -769,9 +769,13 @@ class HDF5IO(HDMFIO):
         return group
 
     def __get_path(self, builder):
+        """Get the path to the builder.
+
+        Note that the root of the file has no name - it is just "/". Thus, the name of the root container is ignored.
+        """
         curr = builder
         names = list()
-        while curr is not None and curr.name != ROOT_NAME:
+        while curr.parent is not None:
             names.append(curr.name)
             curr = curr.parent
         delim = "/"


### PR DESCRIPTION
## Motivation

Fix #359. Currently, writing a ReferenceBuilder works only if the root builder of the builder hierarchy is named "root". This PR changes that behavior so that a writing a ReferenceBuilder works regardless of the name of the root builder.

FYI: `HDF5IO.__get_path` is called from `HDF5IO.write_link` and `HDF5IO.__get_ref`

## How to test the behavior?
See example in #359

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
