### PR TITLE
Work around codecov.io connection failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ jobs:
       fi
     displayName: 'Run coverage tests if coverageToxEnv != ""'
     env: |
-      CODECOV_TOKEN: $(CODECOV_TOKEN)
+      CODECOV_TOKEN: $(MY_CODECOV_TOKEN)
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,8 @@ jobs:
         tox -e $(coverageToxEnv)
       fi
     displayName: 'Run coverage tests if coverageToxEnv != ""'
+    env: |
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
         tox -e $(coverageToxEnv)
       fi
     displayName: 'Run coverage tests if coverageToxEnv != ""'
-    env: |
+    env:
       CODECOV_TOKEN: $(MY_CODECOV_TOKEN)
 
   - bash: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-codecov==2.1.3
+codecov==2.1.7
 coverage==5.1
 flake8==3.7.9
 python-dateutil==2.8.1

--- a/tests/coverage/upload_codecov.py
+++ b/tests/coverage/upload_codecov.py
@@ -11,8 +11,8 @@ if __name__ == '__main__':
     rc = call(cmd, shell=True)
     while rc != 0 and num_tries < max_tries:
         time.sleep(5)
-        rc = call(cmd, shell=True)
         os.remove(os.path.join(os.getcwd(), "coverage.xml"))
+        rc = call(cmd, shell=True)
         num_tries += 1
 
     raise SystemExit(rc)

--- a/tests/coverage/upload_codecov.py
+++ b/tests/coverage/upload_codecov.py
@@ -7,10 +7,10 @@ if __name__ == '__main__':
     max_tries = 10
     num_tries = 1
     cmd = 'codecov --required'
-    rc = call(cmd)
+    rc = call(cmd, shell=True)
     while rc != 0 and num_tries < max_tries:
         time.sleep(5)
-        rc = call(cmd)
+        rc = call(cmd, shell=True)
         num_tries += 1
 
     raise SystemExit(rc)

--- a/tests/coverage/upload_codecov.py
+++ b/tests/coverage/upload_codecov.py
@@ -2,6 +2,7 @@
 
 from subprocess import call
 import time
+import os
 
 if __name__ == '__main__':
     max_tries = 10
@@ -11,6 +12,7 @@ if __name__ == '__main__':
     while rc != 0 and num_tries < max_tries:
         time.sleep(5)
         rc = call(cmd, shell=True)
+        os.remove(os.path.join(os.getcwd(), "coverage.xml"))
         num_tries += 1
 
     raise SystemExit(rc)

--- a/tests/coverage/upload_codecov.py
+++ b/tests/coverage/upload_codecov.py
@@ -1,0 +1,16 @@
+#!/bin/env/python
+
+from subprocess import call
+import time
+
+if __name__ == '__main__':
+    max_tries = 10
+    num_tries = 1
+    cmd = 'codecov --required'
+    rc = call(cmd)
+    while rc != 0 and num_tries < max_tries:
+        time.sleep(5)
+        rc = call(cmd)
+        num_tries += 1
+
+    raise SystemExit(rc)

--- a/tests/coverage/upload_codecov.py
+++ b/tests/coverage/upload_codecov.py
@@ -5,12 +5,13 @@ import time
 import os
 
 if __name__ == '__main__':
-    max_tries = 10
+    max_tries = 3
     num_tries = 1
     cmd = 'codecov --required'
     rc = call(cmd, shell=True)
     while rc != 0 and num_tries < max_tries:
-        time.sleep(5)
+        print("Try #%d/%d failed. Sleeping for 60 seconds and trying again..." % (num_tries, max_tries))
+        time.sleep(60)
         os.remove(os.path.join(os.getcwd(), "coverage.xml"))
         rc = call(cmd, shell=True)
         num_tries += 1

--- a/tox.ini
+++ b/tox.ini
@@ -71,8 +71,7 @@ basepython = python3.8
 commands =
     python -m coverage run test.py -u
     coverage report -m
-    # codecov is flaky with no known fix, so this is a workaround
-    codecov --required || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required)
+    - python tests/coverage/upload_codecov.py  # do not report error if codecov upload fails
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands = {[testenv:build]commands}
 
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
-passenv = CI CIRCLECI CIRCLE_*
+passenv = CI CIRCLECI CIRCLE_* CODECOV_TOKEN
 basepython = python3.8
 commands =
     python -m coverage run test.py -u

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,8 @@ basepython = python3.8
 commands =
     python -m coverage run test.py -u
     coverage report -m
-    codecov
+    # codecov is flaky with no known fix, so this is a workaround
+    codecov --required || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required)
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]


### PR DESCRIPTION
## Motivation

codecov.io has known random connection issues such that around 10% of the time, coverage reports from CI services fail to be uploaded to codecov.io. See:
https://github.com/codecov/codecov-python/issues/158
https://community.codecov.io/t/unreliable-coverage-report-uploads/322
https://community.codecov.io/t/github-pr-not-being-updated-with-final-coverage-data/1425/15
https://github.com/h5py/h5py/issues/1398

The most likely issue is that the codecov server is randomly blocking requests from the CI machine. This could be due to rate limiting or a long-term ban on the IP address. When testing this PR, re-running the codecov script on failure did not seem to resolve the issue: (`Error: HTTPSConnectionPool(host='codecov.io', port=443): Max retries exceeded with url: /upload/v4<...>(Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x000001FA35482DC0>: Failed to establish a new connection: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond')`)
`) 

The error may also result from proxy issues or network issues, though this seems less likely given the repeated failures and other people's experiences. **So, this might not be solvable on our end.** The only resolution might be to re-run the CI if uploading to codecov fails. 

This PR tries re-running the codecov script on failure, after a delay to get around rate limits and intermittent network failures, but really, I think the problem needs to be addressed by codecov.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
