### PR TITLE
Fix double write/append

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -775,7 +775,7 @@ class HDF5IO(HDMFIO):
         if self.get_written(builder):
             group = parent[builder.name]
         else:
-            group = parent.create_group(builder.name)
+            group = parent.require_group(builder.name)
         # write all groups
         subgroups = builder.groups
         if subgroups:
@@ -1032,7 +1032,7 @@ class HDF5IO(HDMFIO):
                 msg = 'cannot add %s to %s - could not determine type' % (name, parent.name)
                 raise Exception(msg) from exc
         try:
-            dset = parent.create_dataset(name, data=data, shape=None, dtype=dtype, **io_settings)
+            dset = parent.require_dataset(name, data=data, shape=None, dtype=dtype, **io_settings)
         except Exception as exc:
             msg = "Could not create scalar dataset %s in %s" % (name, parent.name)
             raise Exception(msg) from exc
@@ -1073,7 +1073,7 @@ class HDF5IO(HDMFIO):
             else:
                 io_settings['dtype'] = data.dtype
         try:
-            dset = parent.create_dataset(name, **io_settings)
+            dset = parent.require_dataset(name, **io_settings)
         except Exception as exc:
             raise Exception("Could not create dataset %s in %s" % (name, parent.name)) from exc
         return dset
@@ -1160,7 +1160,7 @@ class HDF5IO(HDMFIO):
             data_shape = get_data_shape(data)
         # Create the dataset
         try:
-            dset = parent.create_dataset(name, shape=data_shape, dtype=dtype, **io_settings)
+            dset = parent.require_dataset(name, shape=data_shape, dtype=dtype, **io_settings)
         except Exception as exc:
             msg = "Could not create dataset %s in %s with shape %s, dtype %s, and iosettings %s. %s" % \
                   (name, parent.name, str(data_shape), str(dtype), str(io_settings), str(exc))


### PR DESCRIPTION
## Motivation

This helps resolve the edge case where a user cannot write an in-memory container to the same file multiple times using new IO objects. For example:
```python
nwbfile = NWBFile(
    session_description='session_description',
    identifier='identifier',
    session_start_time=datetime.datetime.now(datetime.timezone.utc)
)

filename = 'nwbfile.nwb'

with NWBHDF5IO(filename, 'w') as io:
    io.write(nwbfile)

# do stuff with nwbfile

with NWBHDF5IO(filename, 'a') as io:
    io.write(nwbfile)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
