### PR TITLE
Add tests for columns with `H5DataIO` data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 2.0.1 (Upcoming)
+
+### Internal improvements
+- Add tests for writing table columns with DataIO data, e.g., chunked, compressed data. @rly (#402)
+
 ## HDMF 2.0.0 (July 17, 2020)
 
 ### New features

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,8 +1,7 @@
 import unittest
-from hdmf.common import (DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion, VocabData,
-                         get_manager)
+from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion, VocabData
 from hdmf.testing import TestCase, H5RoundTripMixin
-from hdmf.backends.hdf5 import H5DataIO, HDF5IO
+from hdmf.backends.hdf5 import H5DataIO
 
 from collections import OrderedDict
 import h5py


### PR DESCRIPTION
## Motivation

HDMF 2.0 added the ability to create table columns with chunks, compression, and other HDF5 IO filters. This PR adds roundtrip tests for this functionality.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
