### PR TITLE
Remove breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # HDMF Changelog
 
-## HDMF 2.0.1 (Upcoming)
+## HDMF 2.0.1 (July 20, 2020)
 
 ### Internal improvements
 - Add tests for writing table columns with DataIO data, e.g., chunked, compressed data. @rly (#402)
+- Add CI to check for breakpoints and print statements. @rly (#403)
+
+### Bug fixes:
+- Remove breakpoint. @rly (#403)
 
 ## HDMF 2.0.0 (July 17, 2020)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 codecov==2.1.8
 coverage==5.2
 flake8==3.8.3
-flake8-breakpoint==1.1.0
+flake8-debugger==3.1.0
 flake8-print==3.1.4
 python-dateutil==2.8.1
 tox==3.17.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 codecov==2.1.8
 coverage==5.2
 flake8==3.8.3
+flake8-breakpoint==1.1.0
+flake8-print==3.1.4
 python-dateutil==2.8.1
 tox==3.17.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,14 +20,18 @@ exclude =
   src/hdmf/common/hdmf-common-schema,
   docs/source/conf.py
   versioneer.py
+  src/hdmf/_version.py
 per-file-ignores =
   docs/gallery/*:E402,
+  docs/source/tutorials/*:E402
   src/hdmf/__init__.py:F401
   src/hdmf/backends/__init__.py:F401
   src/hdmf/backends/hdf5/__init__.py:F401
   src/hdmf/build/__init__.py:F401
   src/hdmf/spec/__init__.py:F401
   src/hdmf/validate/__init__.py:F401
+  setup.py:T001
+  test.py:T001
 
 [metadata]
 description-file = README.rst

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -822,7 +822,6 @@ class HDF5IO(HDMFIO):
             return cls.__dtypes.get(dtype['reftype'])
         elif isinstance(dtype, np.dtype):
             # NOTE: some dtypes may not be supported, but we need to support writing of read-in compound types
-            breakpoint()
             return dtype
         else:
             return np.dtype([(x['name'], cls.__resolve_dtype_helper__(x['dtype'])) for x in dtype])


### PR DESCRIPTION
## Motivation

Somehow a `breakpoint` snuck through. This PR 
1) removes the breakpoint
2) adds new developer requirements [flake8-debugger](https://pypi.org/project/flake8-debugger/) and [flake8-print](https://pypi.org/project/flake8-print/) which are plugins to flake8 that check for breakpoint and print statements

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
