### PR TITLE
Enhance LabelledDict with add callable, remove callable, and restricted methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Internal improvements
 - Add tests for writing table columns with DataIO data, e.g., chunked, compressed data. @rly (#402)
 - Add CI to check for breakpoints and print statements. @rly (#403)
+- Add ability to pass a callable function to run when removing items from a LabelledDict. Raise an error when using
+  unsupported functionality in LabelledDict. @rly (#405)
 
 ### Bug fixes:
 - Remove breakpoint. @rly (#403)

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -805,8 +805,8 @@ class LabelledDict(dict):
     returned, not a set.
 
     LabelledDict does not support changing items that have already been set. A TypeError will be raised when using
-    __setitem__ on keys that already exist in the dict. The __delitem__, setdefault, and update methods are not
-    supported. A TypeError will be raised when these are called.
+    __setitem__ on keys that already exist in the dict. The setdefault and update methods are not supported. A
+    TypeError will be raised when these are called.
 
     A callable function may be passed to the constructor to be run on an item after adding it to this dict using
     the __setitem__ and add methods.

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -927,8 +927,11 @@ class LabelledDict(dict):
             self.popitem()
 
     def __delitem__(self, k):
-        """__delitem__ is not supported. A TypeError will be raised."""
-        raise TypeError('__delitem__ is not supported for %s' % self.__class__.__name__)
+        """Remove an item that matches the key. If pop_callable was initialized, call that on the matching value."""
+        item = self[k]
+        super().__delitem__(k)
+        if self.__pop_callable:
+            self.__pop_callable(item)
 
     def setdefault(self, k):
         """setdefault is not supported. A TypeError will be raised."""

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -929,7 +929,7 @@ class LabelledDict(dict):
 
         Note: popitem returns a tuple (key, value) but the remove_callable will be called only on the value.
 
-        Note: in Python 3.5, dictionaries and not ordered, so popitem removes an arbitrary item.
+        Note: in Python 3.5 and earlier, dictionaries are not ordered, so popitem removes an arbitrary item.
         """
         ret = super().popitem()
         if self.__remove_callable:

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -192,6 +192,15 @@ class TestLabelledDict(TestCase):
         self.assertEqual(self.signal, obj1)
         self.assertEqual(ld, dict())
 
+    def test_clear_nocallback(self):
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+        obj1 = MyTestClass('a', 'b')
+        obj2 = MyTestClass('d', 'b')
+        ld.add(obj1)
+        ld.add(obj2)
+        ld.clear()
+        self.assertEqual(ld, dict())
+
     def test_clear_callback(self):
         self.signal = list()
 
@@ -207,13 +216,27 @@ class TestLabelledDict(TestCase):
         self.assertListEqual(self.signal, [obj2, obj1])
         self.assertEqual(ld, dict())
 
-    def test_delitem_callback(self):
+    def test_delitem_nocallback(self):
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
 
-        with self.assertRaisesWith(TypeError, "__delitem__ is not supported for LabelledDict"):
-            del ld['a']
+        del ld['a']
+        self.assertEqual(ld, dict())
+
+    def test_delitem_callback(self):
+        self.signal = None
+
+        def func(v):
+            self.signal = v
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        del ld['a']
+        self.assertEqual(self.signal, obj1)
+        self.assertEqual(ld, dict())
 
     def test_update_callback(self):
         ld = LabelledDict(label='all_objects', key_attr='prop1')

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -111,6 +111,32 @@ class TestLabelledDict(TestCase):
         with self.assertRaisesRegex(KeyError, err_msg):
             ld['b'] = obj1
 
+    def test_add_callable(self):
+        """Test that add properly adds the object and calls the add_callable function."""
+        self.signal = None
+
+        def func(v):
+            self.signal = v
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', add_callable=func)
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+        self.assertIs(ld['a'], obj1)
+        self.assertIs(self.signal, obj1)
+
+    def test_setitem_callable(self):
+        """Test that setitem properly sets the object and calls the add_callable function."""
+        self.signal = None
+
+        def func(v):
+            self.signal = v
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', add_callable=func)
+        obj1 = MyTestClass('a', 'b')
+        ld['a'] = obj1
+        self.assertIs(ld['a'], obj1)
+        self.assertIs(self.signal, obj1)
+
     def test_getitem_eqeq_nonempty(self):
         """Test that dict[key_attr == val] returns the single matching object."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
@@ -159,7 +185,7 @@ class TestLabelledDict(TestCase):
         def func(v):
             self.signal = v
 
-        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        ld = LabelledDict(label='all_objects', key_attr='prop1', remove_callable=func)
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
 
@@ -183,7 +209,7 @@ class TestLabelledDict(TestCase):
         def func(v):
             self.signal = v
 
-        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        ld = LabelledDict(label='all_objects', key_attr='prop1', remove_callable=func)
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
 
@@ -202,18 +228,18 @@ class TestLabelledDict(TestCase):
         self.assertEqual(ld, dict())
 
     def test_clear_callback(self):
-        self.signal = list()
+        self.signal = set()
 
         def func(v):
-            self.signal.append(v)
+            self.signal.add(v)
 
-        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        ld = LabelledDict(label='all_objects', key_attr='prop1', remove_callable=func)
         obj1 = MyTestClass('a', 'b')
         obj2 = MyTestClass('d', 'b')
         ld.add(obj1)
         ld.add(obj2)
         ld.clear()
-        self.assertListEqual(self.signal, [obj2, obj1])
+        self.assertSetEqual(self.signal, {obj2, obj1})
         self.assertEqual(ld, dict())
 
     def test_delitem_nocallback(self):
@@ -230,7 +256,7 @@ class TestLabelledDict(TestCase):
         def func(v):
             self.signal = v
 
-        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        ld = LabelledDict(label='all_objects', key_attr='prop1', remove_callable=func)
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
 

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -79,10 +79,10 @@ class TestLabelledDict(TestCase):
 
     def test_add_value_missing_key(self):
         """Test that add raises an error if the value being set does not have the attribute key_attr."""
-        ld = LabelledDict(label='all_objects', key_attr='prop3')
+        ld = LabelledDict(label='all_objects', key_attr='unknown_key')
         obj1 = MyTestClass('a', 'b')
 
-        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'prop3'\."
+        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'unknown_key'\."
         with self.assertRaisesRegex(ValueError, err_msg):
             ld.add(obj1)
 
@@ -95,10 +95,10 @@ class TestLabelledDict(TestCase):
 
     def test_setitem_value_missing_key(self):
         """Test that setitem raises an error if the value being set does not have the attribute key_attr."""
-        ld = LabelledDict(label='all_objects', key_attr='prop3')
+        ld = LabelledDict(label='all_objects', key_attr='unknown_key')
         obj1 = MyTestClass('a', 'b')
 
-        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'prop3'\."
+        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'unknown_key'\."
         with self.assertRaisesRegex(ValueError, err_msg):
             ld['a'] = obj1
 
@@ -110,6 +110,18 @@ class TestLabelledDict(TestCase):
         err_msg = r"Key 'b' must equal attribute 'prop1' of '<.*>'\."
         with self.assertRaisesRegex(KeyError, err_msg):
             ld['b'] = obj1
+
+    def test_setitem_value_duplicate_key(self):
+        """Test that setitem raises an error if the key already exists in the dict."""
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+        obj1 = MyTestClass('a', 'b')
+        obj2 = MyTestClass('a', 'c')
+
+        ld['a'] = obj1
+
+        err_msg = "Key 'a' is already in this dict. Cannot reset items in a LabelledDict."
+        with self.assertRaisesWith(TypeError, err_msg):
+            ld['a'] = obj2
 
     def test_add_callable(self):
         """Test that add properly adds the object and calls the add_callable function."""

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -20,93 +20,90 @@ class MyTestClass:
 class TestLabelledDict(TestCase):
 
     def test_constructor(self):
-        """Test that constructor sets arguments properly"""
+        """Test that constructor sets arguments properly."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         self.assertEqual(ld.label, 'all_objects')
         self.assertEqual(ld.key_attr, 'prop1')
 
     def test_constructor_default(self):
-        """Test that constructor sets default key attribute"""
+        """Test that constructor sets default key attribute."""
         ld = LabelledDict(label='all_objects')
         self.assertEqual(ld.key_attr, 'name')
 
     def test_set_key_attr(self):
-        """Test that the key attribute cannot be set after initialization"""
+        """Test that the key attribute cannot be set after initialization."""
         ld = LabelledDict(label='all_objects')
         with self.assertRaisesWith(AttributeError, "can't set attribute"):
             ld.key_attr = 'another_name'
 
     def test_getitem_unknown_val(self):
-        """Test that dict[val] raises an error if there are no matches for val"""
+        """Test that dict[unknown_key] where the key unknown_key is not in the dict raises an error."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
-        with self.assertRaisesWith(KeyError, "'unknown_val'"):
-            ld['unknown_val']
+        with self.assertRaisesWith(KeyError, "'unknown_key'"):
+            ld['unknown_key']
 
     def test_getitem_eqeq_unknown_val(self):
-        """Test that dict[key_attr == val] raises an error if there are no matches for val"""
+        """Test that dict[unknown_attr == val] where there are no query matches returns an empty set."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
-        with self.assertRaisesWith(KeyError, "'unknown_val'"):
-            ld['prop1 == unknown_val']
+        self.assertSetEqual(ld['unknown_attr == val'], set())
 
-    def test_getitem_eqeq_other_key_attr(self):
-        """Test that dict[key_attr == val] raises an error if there are no matches for other_attr == val"""
+    def test_getitem_eqeq_other_key(self):
+        """Test that dict[other_attr == val] where there are no query matches returns an empty set."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
-        with self.assertRaisesWith(KeyError, "'unknown_val'"):
-            ld['other_attr == unknown_val']
+        self.assertSetEqual(ld['prop2 == val'], set())
 
     def test_getitem_eqeq_no_key_attr(self):
-        """Test that dict[key_attr == val] raises an error if key_attr is not given"""
+        """Test that dict[key_attr == val] raises an error if key_attr is not given."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         with self.assertRaisesWith(ValueError, "An attribute name is required before '=='."):
             ld[' == unknown_key']
 
     def test_getitem_eqeq_no_val(self):
-        """Test that dict[key_attr == val] raises an error if val is not given"""
+        """Test that dict[key_attr == val] raises an error if val is not given."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         with self.assertRaisesWith(ValueError, "A value is required after '=='."):
             ld['prop1 == ']
 
     def test_getitem_eqeq_no_key_attr_no_val(self):
-        """Test that dict[key_attr == val] raises an error if key_attr is not given and val is not given"""
+        """Test that dict[key_attr == val] raises an error if key_attr is not given and val is not given."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         with self.assertRaisesWith(ValueError, "An attribute name is required before '=='."):
             ld[' == ']
 
     def test_add_basic(self):
-        """Test add function on object with correct key_attr"""
+        """Test add method on object with correct key_attr."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
         self.assertIs(ld['a'], obj1)
 
     def test_add_value_missing_key(self):
-        """Test that add raises an error if the value being set does not have the attribute key_attr"""
+        """Test that add raises an error if the value being set does not have the attribute key_attr."""
         ld = LabelledDict(label='all_objects', key_attr='prop3')
         obj1 = MyTestClass('a', 'b')
 
-        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have key 'prop3'\."
+        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'prop3'\."
         with self.assertRaisesRegex(ValueError, err_msg):
             ld.add(obj1)
 
     def test_setitem_getitem_basic(self):
-        """Test that setitem and getitem properly set and get the object"""
+        """Test that setitem and getitem properly set and get the object."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
         self.assertIs(ld['a'], obj1)
 
     def test_setitem_value_missing_key(self):
-        """Test that setitem raises an error if the value being set does not have the attribute key_attr"""
+        """Test that setitem raises an error if the value being set does not have the attribute key_attr."""
         ld = LabelledDict(label='all_objects', key_attr='prop3')
         obj1 = MyTestClass('a', 'b')
 
-        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have key 'prop3'\."
+        err_msg = r"Cannot set value '<.*>' in LabelledDict\. Value must have attribute 'prop3'\."
         with self.assertRaisesRegex(ValueError, err_msg):
             ld['a'] = obj1
 
-    def test_setitem_value_wrong_value(self):
-        """Test that setitem raises an error if the value being set has a different value for attribute key_attr
-        than the given key"""
+    def test_setitem_value_inconsistent_key(self):
+        """Test that setitem raises an error if the value being set has an inconsistent key."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
 
@@ -114,39 +111,30 @@ class TestLabelledDict(TestCase):
         with self.assertRaisesRegex(KeyError, err_msg):
             ld['b'] = obj1
 
-    def test_addval_getitem_eqeq(self):
-        """Test that dict[key_attr == val] returns the single matching object"""
+    def test_getitem_eqeq_nonempty(self):
+        """Test that dict[key_attr == val] returns the single matching object."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
         self.assertIs(ld['prop1 == a'], obj1)
 
-    def test_addval_getitem_eqeq_unknown_val(self):
-        """Test that dict[key_attr == val] with an unknown val raises an error even if there are other objects in
-        dict"""
+    def test_getitem_eqeq_nonempty_key_attr_no_match(self):
+        """Test that dict[key_attr == unknown_val] where a matching value is not found raises a KeyError."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
         with self.assertRaisesWith(KeyError, "'unknown_val'"):
-            ld['prop1 == unknown_val']
+            ld['prop1 == unknown_val']  # same as ld['unknown_val']
 
-    def test_addval_getitem_eqeq_unknown_key_val(self):
-        """Test that dict[key_attr == val] where prop3 does not match any objects in the dict raises an error"""
+    def test_getitem_eqeq_nonempty_unknown_attr(self):
+        """Test that dict[unknown_attr == val] where unknown_attr is not a field on the values raises an error."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld['a'] = obj1
-        with self.assertRaisesWith(KeyError, "'unknown_val'"):
-            ld['prop3 == unknown_val']
+        self.assertSetEqual(ld['unknown_attr == unknown_val'], set())
 
-    def test_addval_getitem_other_key(self):
-        """Test that dict[other_key == val] returns a list of matching objects"""
-        ld = LabelledDict(label='all_objects', key_attr='prop1')
-        obj1 = MyTestClass('a', 'b')
-        ld.add(obj1)
-        self.assertSetEqual(ld['prop2 == b'], {obj1})
-
-    def test_addval_getitem_other_key_multi(self):
-        """Test that dict[other_key == val] returns a list of matching objects"""
+    def test_getitem_nonempty_other_key(self):
+        """Test that dict[other_key == val] returns a set of matching objects."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         obj2 = MyTestClass('d', 'b')
@@ -154,17 +142,87 @@ class TestLabelledDict(TestCase):
         ld.add(obj1)
         ld.add(obj2)
         ld.add(obj3)
-        self.assertSetEqual(ld['prop2 == b'], set([obj1, obj2]))
+        self.assertSetEqual(ld['prop2 == b'], {obj1, obj2})
 
-    def test_addval_getitem_other_key_none(self):
-        """Test that dict[other_key == val] raises an error if val does not equal any of the other_key attribute values
-        in the dict, even when the other_key attribute exists"""
+    def test_pop_nocallback(self):
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        ret = ld.pop('a')
+        self.assertEqual(ret, obj1)
+        self.assertEqual(ld, dict())
+
+    def test_pop_callback(self):
+        self.signal = None
+
+        def func(v):
+            self.signal = v
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        ret = ld.pop('a')
+        self.assertEqual(ret, obj1)
+        self.assertEqual(self.signal, obj1)
+        self.assertEqual(ld, dict())
+
+    def test_popitem_nocallback(self):
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        ret = ld.popitem()
+        self.assertEqual(ret, ('a', obj1))
+        self.assertEqual(ld, dict())
+
+    def test_popitem_callback(self):
+        self.signal = None
+
+        def func(v):
+            self.signal = v
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        ret = ld.popitem()
+        self.assertEqual(ret, ('a', obj1))
+        self.assertEqual(self.signal, obj1)
+        self.assertEqual(ld, dict())
+
+    def test_clear_callback(self):
+        self.signal = list()
+
+        def func(v):
+            self.signal.append(v)
+
+        ld = LabelledDict(label='all_objects', key_attr='prop1', pop_callable=func)
+        obj1 = MyTestClass('a', 'b')
         obj2 = MyTestClass('d', 'b')
-        obj3 = MyTestClass('f', 'e')
         ld.add(obj1)
         ld.add(obj2)
-        ld.add(obj3)
-        with self.assertRaisesWith(KeyError, "'c'"):
-            ld['prop2 == c']
+        ld.clear()
+        self.assertListEqual(self.signal, [obj2, obj1])
+        self.assertEqual(ld, dict())
+
+    def test_delitem_callback(self):
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+        obj1 = MyTestClass('a', 'b')
+        ld.add(obj1)
+
+        with self.assertRaisesWith(TypeError, "__delitem__ is not supported for LabelledDict"):
+            del ld['a']
+
+    def test_update_callback(self):
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+
+        with self.assertRaisesWith(TypeError, "update is not supported for LabelledDict"):
+            ld.update(object())
+
+    def test_setdefault_callback(self):
+        ld = LabelledDict(label='all_objects', key_attr='prop1')
+
+        with self.assertRaisesWith(TypeError, "setdefault is not supported for LabelledDict"):
+            ld.setdefault(object())


### PR DESCRIPTION
## Motivation

This is technically a breaking change on `LabelledDict`, but `LabelledDict` is not used within HDMF or by PyNWB. 

Fix #404, implementing option 1

## How to test the behavior?
```
# removing. these will now call a function that is passed in to __init__ that calls parent._remove_child(child)
del nwbfile.acquisition['my_time_series']
nwbfile.acquisition.pop('my_time_series')
nwbfile.acquisition.popitem()
nwbfile.acquisition.clear()

# adding. these will now call a function that is passed in to __init__ that calls child.parent = parent
nwbfile.acquisition['new_key'] = xx
nwbfile.acquisition.add(xx)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
