### PR TITLE
Make OrphanContainerWarning an error

### DIFF
--- a/src/hdmf/build/__init__.py
+++ b/src/hdmf/build/__init__.py
@@ -11,3 +11,4 @@ from .manager import BuildManager
 from .manager import TypeMap
 
 from .warnings import MissingRequiredWarning, OrphanContainerWarning, DtypeConversionWarning
+from .errors import BuildError, OrphanContainerBuildError

--- a/src/hdmf/build/errors.py
+++ b/src/hdmf/build/errors.py
@@ -1,0 +1,26 @@
+from .builders import Builder
+from ..container import AbstractContainer
+from ..utils import docval, getargs
+
+
+class BuildError(Exception):
+
+    @docval({'name': 'builder', 'type': Builder, 'doc': 'the builder that cannot be built'},
+            {'name': 'reason', 'type': str, 'doc': 'the reason for the error'})
+    def __init__(self, **kwargs):
+        self.__builder = getargs('builder', kwargs)
+        self.__reason = getargs('reason', kwargs)
+        self.__message = "%s (%s): %s" % (self.__builder.name, self.__builder.path, self.__reason)
+        super().__init__(self.__message)
+
+
+class OrphanContainerBuildError(BuildError):
+
+    @docval({'name': 'builder', 'type': Builder, 'doc': 'the builder containing the broken link'},
+            {'name': 'container', 'type': AbstractContainer, 'doc': 'the container that has no parent'})
+    def __init__(self, **kwargs):
+        builder = getargs('builder', kwargs)
+        self.__container = getargs('container', kwargs)
+        reason = ("Linked %s '%s' has no parent. Remove the link or ensure the linked container is added properly."
+                  % (self.__container.__class__.__name__, self.__container.name))
+        super().__init__(builder=builder, reason=reason)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -71,6 +71,12 @@ class FooBucket(Container):
     def foos(self):
         return self.__foos
 
+    def remove_foo(self, foo_name):
+        foo = self.__foos.pop(foo_name)
+        if foo.parent is self:
+            self._remove_child(foo)
+        return foo
+
 
 def get_temp_filepath():
     # On Windows, h5py cannot truncate an open file in write mode.


### PR DESCRIPTION
## Motivation

Fix #406 

TODO in another PR:
- address case where A links to B. B has a parent but B is not built. This results in A linking to B, which has path '/' and an infinite recursion error. This is a tricky edge case to resolve and requires more refactoring -- probably deferring the resolution of links and references until after everything else has been built. Then you can check whether the link target exists rather than building it when first encountering it.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
