### PR TITLE
Update CHANGELOG.md for HDMF 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # HDMF Changelog
 
-## HDMF 3.0.0 (Upcoming)
+## HDMF 2.1.0 (August 10, 2020)
 
 ### New features
 - Users can now use the `MultiContainerInterface` class to generate custom API classes that contain collections of
-  containers of a specified type. See the user guide
-  https://hdmf.readthedocs.io/en/stable/tutorials/multicontainerinterface.html for more information.
+  containers of a specified type. @bendichter @rly (#399)
+  - See the user guide
+    https://hdmf.readthedocs.io/en/stable/tutorials/multicontainerinterface.html for more information.
 
 ### Internal improvements
 - Add ability to pass callable functions to run when adding or removing items from a ``LabelledDict``.
@@ -37,6 +38,11 @@
   @rly (#388)
 - Users can now call `Container.generate_new_id` to generate new object IDs for the container and all of its children.
   @rly (#401)
+- Use hdmf-common-schema 1.2.0. @ajtritt @rly (#397)
+  - `VectorIndex` now extends `VectorData` instead of `Index`. This change allows `VectorIndex` to index other `VectorIndex` types.
+  - The `Index` data type is now unused and has been removed.
+  - Fix missing dtype for `VectorIndex`.
+  - Add new `VocabData` data type.
 
 ### Breaking changes
 - `Builder` objects no longer have the `written` field which was used by `HDF5IO` to mark the object as written. This


### PR DESCRIPTION
## Motivation

This is the last PR to be merged before releasing HDMF 2.1.0.

We are pushing out this release so that PyNWB can test and make use of the `MultiContainerInterface` that has been moved to and enhanced in HDMF.

This PR also adds an important missing note in the HDMF 2.0.0 changelog that hdmf-common-schema version 1.2.0 is now included in HDMF.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
