### PR TITLE
Add doc for iterating over rows of a `DynamicTable`, improve index out of bounds error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 ## HDMF 2.2.0 (August 14, 2020)
 
 ### New features
-- Add ability to get list of tuples when indexing a DynamicTable. i.e. disable conversion to pandas.DataFrame @ajtritt (#418)
+- Add ability to get list of tuples when indexing a `DynamicTable`. i.e. disable conversion to `pandas.DataFrame`.
+  @ajtritt (#418)
 
 ### Internal improvements
-- Fix error when constructing DynamicTable with DataChunkIterators as columns @ajtritt (#418)
+- Improve documentation and index out of bounds error message for `DynamicTable`. @rly (#419)
+
+### Bug fixes:
+- Fix error when constructing `DynamicTable` with `DataChunkIterators` as columns. @ajtritt (#418)
 
 ## HDMF 2.1.0 (August 10, 2020)
 

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -290,6 +290,20 @@ table[np.s_[0:10:2]]  # equivalent to table[0:10:2, 'col1']
 #   the second element.
 
 ###############################################################################
+# Iterating over rows
+# --------------------
+# To iterate over the rows of a :py:class:`~hdmf.common.table.DynamicTable`,
+# first convert the :py:class:`~hdmf.common.table.DynamicTable` to a
+# :py:class:`~pandas.DataFrame` using
+# :py:meth:`DynamicTable.to_dataframe <hdmf.common.table.DynamicTable>`.
+# For more information on iterating over a :py:class:`~pandas.DataFrame`,
+# see https://pandas.pydata.org/pandas-docs/stable/user_guide/basics.html#iteration
+
+df = table.to_dataframe()
+for row in df.itertuples():
+    print(row)
+
+###############################################################################
 # Accessing the column data types
 # -------------------------------
 # To access the :py:class:`~hdmf.common.table.VectorData` or

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -470,6 +470,10 @@ class DynamicTable(Container):
         """Number of rows in the table"""
         return len(self.id)
 
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+
     @docval({'name': 'data', 'type': dict, 'doc': 'the data to put in this row', 'default': None},
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},
             {'name': 'enforce_unique_id', 'type': bool, 'doc': 'enforce that the id in the table must be unique',

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -471,10 +471,6 @@ class DynamicTable(Container):
         """Number of rows in the table"""
         return len(self.id)
 
-    def iter_rows(self):
-        for i in range(len(self)):
-            yield i, self[i]
-
     @docval({'name': 'data', 'type': dict, 'doc': 'the data to put in this row', 'default': None},
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},
             {'name': 'enforce_unique_id', 'type': bool, 'doc': 'enforce that the id in the table must be unique',

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -6,6 +6,7 @@ the storage and use of dynamic data tables as part of the hdmf-common schema
 from h5py import Dataset
 import numpy as np
 import pandas as pd
+import re
 from collections import OrderedDict
 from warnings import warn
 
@@ -719,42 +720,58 @@ class DynamicTable(Container):
             # index by int, list, or slice --> return pandas Dataframe consisting of one or more rows
             # determine the key. If the key is an int, then turn it into a slice to reduce the number of cases below
             arg = key
-            if np.issubdtype(type(arg), np.integer):
-                ret = OrderedDict()
-                ret['id'] = self.id.data[arg]
-                for name in self.colnames:
-                    col = self.__df_cols[self.__colids[name]]
-                    ret[name] = col[arg]
-            # index with a python slice (or single integer) to select one or multiple rows
-            elif isinstance(arg, slice):
-                ret = OrderedDict()
-                ret['id'] = self.id.data[arg]
-                for name in self.colnames:
-                    col = self.__df_cols[self.__colids[name]]
-                    if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
+            try:
+                if np.issubdtype(type(arg), np.integer):
+                    ret = OrderedDict()
+                    ret['id'] = self.id.data[arg]
+                    for name in self.colnames:
+                        col = self.__df_cols[self.__colids[name]]
                         ret[name] = col[arg]
-                    else:
-                        currdata = col[arg]
-                        ret[name] = currdata
-            # index by a list of ints, return multiple rows
-            elif isinstance(arg, (tuple, list, np.ndarray)):
-                if isinstance(arg, np.ndarray):
-                    if len(arg.shape) != 1:
-                        raise ValueError("cannot index DynamicTable with multiple dimensions")
-                ret = OrderedDict()
-                ret['id'] = (self.id.data[arg]
-                             if isinstance(self.id.data, np.ndarray)
-                             else [self.id.data[i] for i in arg])
-                for name in self.colnames:
-                    col = self.__df_cols[self.__colids[name]]
-                    if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
-                        ret[name] = [x for x in col[arg]]
-                    elif isinstance(col.data, np.ndarray):
-                        ret[name] = col[arg]
-                    else:
-                        ret[name] = [col[i] for i in arg]
-            else:
-                raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
+                # index with a python slice (or single integer) to select one or multiple rows
+                elif isinstance(arg, slice):
+                    ret = OrderedDict()
+                    ret['id'] = self.id.data[arg]
+                    for name in self.colnames:
+                        col = self.__df_cols[self.__colids[name]]
+                        if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
+                            ret[name] = col[arg]
+                        else:
+                            currdata = col[arg]
+                            ret[name] = currdata
+                # index by a list of ints, return multiple rows
+                elif isinstance(arg, (tuple, list, np.ndarray)):
+                    if isinstance(arg, np.ndarray):
+                        if len(arg.shape) != 1:
+                            raise ValueError("cannot index DynamicTable with multiple dimensions")
+                    ret = OrderedDict()
+                    ret['id'] = (self.id.data[arg]
+                                 if isinstance(self.id.data, np.ndarray)
+                                 else [self.id.data[i] for i in arg])
+                    for name in self.colnames:
+                        col = self.__df_cols[self.__colids[name]]
+                        if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
+                            ret[name] = [x for x in col[arg]]
+                        elif isinstance(col.data, np.ndarray):
+                            ret[name] = col[arg]
+                        else:
+                            ret[name] = [col[i] for i in arg]
+                else:
+                    raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
+            except ValueError as ve:
+                x = re.match(r"^Index \((.*)\) out of range \(.*\)$", str(ve))
+                if x:
+                    msg = ("Row index %s out of range for %s '%s' (length %d)."
+                           % (x.groups()[0], self.__class__.__name__, self.name, len(self)))
+                    raise IndexError(msg)
+                else:  # pragma: no cover
+                    raise ve
+            except IndexError as ie:
+                if str(ie) == 'list index out of range':
+                    msg = ("Row index out of range for %s '%s' (length %d)."
+                           % (self.__class__.__name__, self.name, len(self)))
+                    raise IndexError(msg)
+                else:  # pragma: no cover
+                    raise ie
 
             if df:
                 # reformat objects to fit into a pandas DataFrame

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -471,9 +471,9 @@ class DynamicTable(Container):
         """Number of rows in the table"""
         return len(self.id)
 
-    def __iter__(self):
+    def iter_rows(self):
         for i in range(len(self)):
-            yield self[i]
+            yield i, self[i]
 
     @docval({'name': 'data', 'type': dict, 'doc': 'the data to put in this row', 'default': None},
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -464,6 +464,12 @@ Fields:
             self.assertTrue(isinstance(row, pd.DataFrame))
             self.assertTrue(table[i].equals(row))
 
+    def test_index_out_of_bounds(self):
+        table = self.with_columns_and_data()
+        msg = "Row index out of range for DynamicTable 'with_columns_and_data' (length 5)."
+        with self.assertRaisesWith(IndexError, msg):
+            table[5]
+
 
 class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 
@@ -483,6 +489,12 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
         for i, row in enumerate(table):
             self.assertTrue(isinstance(row, pd.DataFrame))
             self.assertTrue(table[i].equals(row))
+
+    def test_index_out_of_bounds(self):
+        table = self.roundtripContainer()
+        msg = "Row index 5 out of range for DynamicTable 'root' (length 2)."
+        with self.assertRaisesWith(IndexError, msg):
+            table[5]
 
 
 class TestEmptyDynamicTableRoundTrip(H5RoundTripMixin, TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -458,6 +458,12 @@ Fields:
         self.assertTupleEqual(table.colnames, tuple())
         self.assertTupleEqual(table.columns, tuple())
 
+    def test_iter(self):
+        table = self.with_columns_and_data()
+        for i, row in enumerate(table):
+            self.assertTrue(isinstance(row, pd.DataFrame))
+            self.assertTrue(table[i].equals(row))
+
 
 class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 
@@ -471,6 +477,12 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
         table.add_row(foo=27, bar=28.0, baz="cat", qux=True, quux='a')
         table.add_row(foo=37, bar=38.0, baz="dog", qux=False, quux='b')
         return table
+
+    def test_iter(self):
+        table = self.roundtripContainer()
+        for i, row in enumerate(table):
+            self.assertTrue(isinstance(row, pd.DataFrame))
+            self.assertTrue(table[i].equals(row))
 
 
 class TestEmptyDynamicTableRoundTrip(H5RoundTripMixin, TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -458,9 +458,9 @@ Fields:
         self.assertTupleEqual(table.colnames, tuple())
         self.assertTupleEqual(table.columns, tuple())
 
-    def test_iter(self):
+    def test_iterrows(self):
         table = self.with_columns_and_data()
-        for i, row in enumerate(table):
+        for i, row in table.iter_rows():
             self.assertTrue(isinstance(row, pd.DataFrame))
             self.assertTrue(table[i].equals(row))
 
@@ -486,7 +486,7 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 
     def test_iter(self):
         table = self.roundtripContainer()
-        for i, row in enumerate(table):
+        for i, row in table.iter_rows():
             self.assertTrue(isinstance(row, pd.DataFrame))
             self.assertTrue(table[i].equals(row))
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -458,12 +458,6 @@ Fields:
         self.assertTupleEqual(table.colnames, tuple())
         self.assertTupleEqual(table.columns, tuple())
 
-    def test_iterrows(self):
-        table = self.with_columns_and_data()
-        for i, row in table.iter_rows():
-            self.assertTrue(isinstance(row, pd.DataFrame))
-            self.assertTrue(table[i].equals(row))
-
     def test_index_out_of_bounds(self):
         table = self.with_columns_and_data()
         msg = "Row index out of range for DynamicTable 'with_columns_and_data' (length 5)."
@@ -483,12 +477,6 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
         table.add_row(foo=27, bar=28.0, baz="cat", qux=True, quux='a')
         table.add_row(foo=37, bar=38.0, baz="dog", qux=False, quux='b')
         return table
-
-    def test_iter(self):
-        table = self.roundtripContainer()
-        for i, row in table.iter_rows():
-            self.assertTrue(isinstance(row, pd.DataFrame))
-            self.assertTrue(table[i].equals(row))
 
     def test_index_out_of_bounds(self):
         table = self.roundtripContainer()


### PR DESCRIPTION
## Motivation

1. Add documentation for iterating over rows of a `DynamicTable` by converting it to a `pandas.DataFrame` first.
   - We could add native support for iterating over rows of a `DynamicTable` where a `pandas.DataFrame` object of length 1 is yielded on each iteration, but that seems horribly inefficient. It would be better for the user to have a dataframe with all the rows and then iterate over that if they so choose.
   - See also https://stackoverflow.com/a/55557758/20177

2. Reformat list/index out of bounds error message

Close #417. Fix #416.

TODO: 
- [x] Merge #418 to dev, merge dev to this PR, update changelog.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
