### PR TITLE
Get multi container interface

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -569,7 +569,7 @@ class TypeMap:
             if f == 'help':  # (legacy) do not add help to any part of class object
                 continue
 
-            if getattr(field_spec, 'quantity', None) in ('*', '?'):
+            if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):
                 # if its a MultiContainerInterface, also build clsconf
                 clsconf.append(dict(
                     attr=f,

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -516,7 +516,7 @@ class TypeMap:
         for f, field_spec in addl_fields.items():
             docval_arg = dict(name=f, doc=field_spec.doc)
             if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):
-                docval_arg.update(type=(list, tuple))
+                docval_arg.update(type=(list, tuple, dict, self.__get_type(field_spec)))
             else:
                 dtype = self.__get_type(field_spec)
                 if dtype is None:

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -502,7 +502,7 @@ class TypeMap:
                 if x['name'] == 'name':
                     x['default'] = default_name
 
-    def build_docval(self, base, addl_fields, name=None, default_name=None):
+    def _build_docval(self, base, addl_fields, name=None, default_name=None):
         """Build docval for auto-generated class
 
         :param base: The base class of the new class
@@ -594,7 +594,7 @@ class TypeMap:
         if len(clsconf):
             classdict.update(__clsconf__=clsconf)
 
-        docval_args = self.build_docval(base, addl_fields, name, default_name)
+        docval_args = self._build_docval(base, addl_fields, name, default_name)
 
         if len(fields) or name is not None:
             @docval(*docval_args)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -503,7 +503,7 @@ class TypeMap:
                     x['default'] = default_name
 
     def build_docval(self, base, addl_fields, name=None, default_name=None):
-        """Build docval for new class
+        """Build docval for auto-generated class
 
         :param base: The base class of the new class
         :param addl_fields: Dict of additional fields that are not in the base class

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -514,7 +514,7 @@ class TypeMap:
         docval_args = list(get_docval(base.__init__))
         for f, field_spec in addl_fields.items():
             docval_arg = dict(name=f, doc=field_spec.doc)
-            if getattr(field_spec, 'quantity', None) in ('*', '?'):
+            if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):
                 docval_arg.update(type=(list, tuple))
             else:
                 dtype = self.__get_type(field_spec)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -533,29 +533,29 @@ class TypeMap:
 
         # add new fields to docval and class fields
         for f, field_spec in addl_fields.items():
-            if not f == 'help':  # (legacy) do not all help to any part of class object
-                # build docval arguments for generated constructor
-                dtype = self.__get_type(field_spec)
-                if dtype is None:
-                    raise ValueError("Got \"None\" for field specification: {}".format(field_spec))
+            if f == 'help':  # (legacy) do not add help to any part of class object
+                continue
+            # build docval arguments for generated constructor
+            dtype = self.__get_type(field_spec)
+            if dtype is None:
+                raise ValueError("Got \"None\" for field specification: {}".format(field_spec))
 
-                docval_arg = {'name': f, 'type': dtype, 'doc': field_spec.doc}
-                if hasattr(field_spec, 'shape') and field_spec.shape is not None:
-                    docval_arg.update(shape=field_spec.shape)
-                    # docval_arg['shape'] = field_spec.shape
-                if not field_spec.required:
-                    docval_arg['default'] = getattr(field_spec, 'default_value', None)
-                docval_args.append(docval_arg)
+            docval_arg = {'name': f, 'type': dtype, 'doc': field_spec.doc}
+            if getattr(field_spec, 'shape', None) is not None:
+                docval_arg.update(shape=field_spec.shape)
+            if not field_spec.required:
+                docval_arg['default'] = getattr(field_spec, 'default_value', None)
+            docval_args.append(docval_arg)
 
-                # auto-initialize arguments not found in superclass
-                if f not in existing_args:
-                    new_args.append(f)
+            # auto-initialize arguments not found in superclass
+            if f not in existing_args:
+                new_args.append(f)
 
-                # add arguments not found in superclass to fields for getter/setter generation
-                if self.__ischild(dtype):
-                    fields.append({'name': f, 'child': True})
-                else:
-                    fields.append(f)
+            # add arguments not found in superclass to fields for getter/setter generation
+            if self.__ischild(dtype):
+                fields.append({'name': f, 'child': True})
+            else:
+                fields.append(f)
 
         # if spec provides a fixed name for this type, remove the 'name' arg from docval_args so that values cannot
         # be passed for a name positional or keyword arg

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -6,7 +6,8 @@ import logging
 
 from ..utils import docval, getargs, ExtenderMeta, get_docval, call_docval_func, fmt_docval_args
 from ..container import AbstractContainer, Container, Data, DataRegion, MultiContainerInterface
-from ..spec import AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NamespaceCatalog, RefSpec, SpecReader
+from ..spec import (AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NamespaceCatalog, RefSpec, SpecReader,
+                   ZERO_OR_MANY, ONE_OR_MANY)
 from ..spec.spec import BaseStorageSpec
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, BaseBuilder
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -1,6 +1,6 @@
 import numpy as np
 from collections import OrderedDict
-from copy import copy
+from copy import copy, deepcopy
 from datetime import datetime
 import logging
 
@@ -511,7 +511,7 @@ class TypeMap:
         :param default_name: Default name of instances of this class, or None if not specified
         :return:
         """
-        docval_args = list(get_docval(base.__init__))
+        docval_args = list(deepcopy(get_docval(base.__init__)))
         for f, field_spec in addl_fields.items():
             docval_arg = dict(name=f, doc=field_spec.doc)
             if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -607,8 +607,7 @@ class TypeMap:
 
                 for f in new_args:
                     arg_val = kwargs.get(f, None)
-                    if arg_val is not None:
-                        setattr(self, f, arg_val)
+                    setattr(self, f, arg_val)
 
             classdict.update(__init__=__init__)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -6,9 +6,8 @@ import logging
 
 from ..utils import docval, getargs, ExtenderMeta, get_docval, call_docval_func, fmt_docval_args
 from ..container import AbstractContainer, Container, Data, DataRegion, MultiContainerInterface
-from ..spec import (AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NamespaceCatalog, RefSpec, SpecReader,
-                   ZERO_OR_MANY, ONE_OR_MANY)
-from ..spec.spec import BaseStorageSpec
+from ..spec import AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NamespaceCatalog, RefSpec, SpecReader
+from ..spec.spec import BaseStorageSpec, ZERO_OR_MANY, ONE_OR_MANY
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, BaseBuilder
 
 
@@ -594,6 +593,8 @@ class TypeMap:
 
         if len(fields):
             classdict.update({base._fieldsname: tuple(fields)})
+        if len(clsconf):
+            classdict.update(__clsconf__=clsconf)
 
         docval_args = self.build_docval(base, addl_fields, name, default_name)
 
@@ -612,8 +613,6 @@ class TypeMap:
 
             classdict.update(__init__=__init__)
 
-        if len(clsconf):
-            classdict.update(__clsconf__=clsconf)
         return classdict
 
     @docval({"name": "namespace", "type": str, "doc": "the namespace containing the data_type"},

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -518,8 +518,6 @@ class TypeMap:
                 docval_arg.update(type=(list, tuple, dict, self.__get_type(field_spec)))
             else:
                 dtype = self.__get_type(field_spec)
-                if dtype is None:
-                    raise ValueError("Got \"None\" for field specification: {}".format(field_spec))
                 docval_arg.update(type=dtype)
                 if getattr(field_spec, 'shape', None) is not None:
                     docval_arg.update(shape=field_spec.shape)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -503,6 +503,14 @@ class TypeMap:
                     x['default'] = default_name
 
     def build_docval(self, base, addl_fields, name=None, default_name=None):
+        """Build docval for new class
+
+        :param base: The base class of the new class
+        :param addl_fields: Dict of additional fields that are not in the base class
+        :param name: Fixed name of instances of this class, or None if name is not fixed to a particular value
+        :param default_name: Default name of instances of this class, or None if not specified
+        :return:
+        """
         docval_args = list(get_docval(base.__init__))
         for f, field_spec in addl_fields.items():
             docval_arg = dict(name=f, doc=field_spec.doc)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -563,7 +563,8 @@ class TypeMap:
         clsconf = list()
         # add new fields to docval and class fields
         for f, field_spec in addl_fields.items():
-            if f == 'help':  # (legacy) do not add help to any part of class object
+            if f == 'help':  # pragma: no cover
+                # (legacy) do not add field named 'help' to any part of class object
                 continue
 
             if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -406,6 +406,17 @@ class TestDynamicContainer(TestCase):
                 self.assertTupleEqual(arg['type'], (float, np.float32, np.float64, np.int8, np.int16, np.int32,
                                                     np.int64, int, np.uint8, np.uint16, np.uint32, np.uint64))
 
+    def test_dynamic_container_shape(self):
+        baz_spec = GroupSpec('A test extension with no Container class',
+                             data_type_def='Baz', data_type_inc=self.bar_spec,
+                             attributes=[AttributeSpec('attr3', 'an example numeric attribute', 'numeric',
+                                                       shape=[None])])
+        self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
+        cls = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz')
+        for arg in get_docval(cls.__init__):
+            if arg['name'] == 'attr3':
+                self.assertListEqual(arg['shape'], [None])
+
     def test_multi_container_spec(self):
         multi_spec = GroupSpec('A test extension that contains a multi',
                                data_type_def='Multi',

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -417,6 +417,20 @@ class TestDynamicContainer(TestCase):
             if arg['name'] == 'attr3':
                 self.assertListEqual(arg['shape'], [None])
 
+    def test_dynamic_container_default(self):
+        """Test that dynamic class generation for an extended type with an overridden default value works."""
+        baz_spec = GroupSpec('A test extension with no Container class',
+                             data_type_def='Baz', data_type_inc=self.bar_spec,
+                             attributes=[AttributeSpec('attr3', 'an example numeric attribute', 'float',
+                                                       required=False, default_value=10.0)])
+        self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
+        Baz = self.type_map.get_container_cls(CORE_NAMESPACE, 'Baz')
+        for arg in get_docval(Baz.__init__):
+            if arg['name'] == 'attr3':
+                self.assertEqual(arg['default'], 10.0)
+        obj = Baz('My Bar', [1, 2, 3, 4], 'string attribute', attr2=1000)
+        self.assertEqual(obj.attr3, 10.0)
+
     def test_multi_container_spec(self):
         multi_spec = GroupSpec('A test extension that contains a multi',
                                data_type_def='Multi',

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -442,6 +442,7 @@ class TestDynamicContainer(TestCase):
         self.spec_catalog.register_spec(multi_spec, 'extension.yaml')
         Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
         Multi = self.type_map.get_container_cls(CORE_NAMESPACE, 'Multi')
+        assert issubclass(Multi, MultiContainerInterface)
         assert Multi.__clsconf__[0] == dict(
             attr='bars',
             type=Bar,

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -4,9 +4,10 @@ from hdmf.build import (GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager
 from hdmf.container import MultiContainerInterface
 from hdmf import Container
 from hdmf.utils import docval, getargs, get_docval
-from hdmf.data_utils import DataChunkIterator
+from hdmf.data_utils import DataChunkIterator, DataIO, AbstractDataChunkIterator
 from hdmf.backends.hdf5 import H5DataIO
 from hdmf.testing import TestCase
+from hdmf.query import HDMFDataset
 
 from abc import ABCMeta, abstractmethod
 import numpy as np
@@ -464,11 +465,11 @@ class TestDynamicContainer(TestCase):
         )
         docval = self.type_map._build_docval(Bar, addl_fields)
 
-        assert list(docval) == [
+        self.assertEqual(list(docval), [
+            {'doc': 'the name of this Bar', 'name': 'name', 'type': str},
             {'name': 'data',
-             'type': (
-                 hdmf.data_utils.DataIO, np.ndarray, list, tuple, h5py.Dataset,
-                 hdmf.query.HDMFDataset, hdmf.data_utils.AbstractDataChunkIterator),
+             'type': (DataIO, np.ndarray, list, tuple, h5py.Dataset,
+                      HDMFDataset, AbstractDataChunkIterator),
              'doc': 'some data'},
             {'name': 'attr1', 'type': str,
              'doc': 'an attribute'},
@@ -481,7 +482,7 @@ class TestDynamicContainer(TestCase):
             {'name': 'foo', 'type': 'Foo', 'doc': 'a group', 'default': None},
             {'name': 'attr4', 'doc': 'another example float attribute',
              'type': (float, np.float32, np.float64)}
-        ]
+        ])
 
 
 class ObjectMapperMixin(metaclass=ABCMeta):

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -406,6 +406,28 @@ class TestDynamicContainer(TestCase):
                 self.assertTupleEqual(arg['type'], (float, np.float32, np.float64, np.int8, np.int16, np.int32,
                                                     np.int64, int, np.uint8, np.uint16, np.uint32, np.uint64))
 
+    def test_multi_container_spec(self):
+        multi_spec = GroupSpec('A test extension that contains a multi',
+                               data_type_def='Multi',
+                               groups=[GroupSpec(
+                                   data_type_inc=self.bar_spec,
+                                   doc='test multi',
+                                   quantity='*')]
+                               )
+        self.spec_catalog.register_spec(multi_spec, 'extension.yaml')
+        Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
+        Multi = self.type_map.get_container_cls(CORE_NAMESPACE, 'Multi')
+        assert Multi.__clsconf__[0] == dict(
+            attr='bars',
+            type=Bar,
+            add='add_bars',
+            get='get_bars',
+            create='create_bars'
+        )
+
+        multi = Multi(bars=[Bar('my_bar', list(range(10)), 'value1', 10)])
+        assert multi.bars['my_bar'] == Bar('my_bar', list(range(10)), 'value1', 10)
+
 
 class ObjectMapperMixin(metaclass=ABCMeta):
 


### PR DESCRIPTION
## Motivation

Use `get_class` to automatically generate a `MultiContainerInterface`.

address https://github.com/NeurodataWithoutBorders/pynwb/issues/888
## How to test the behavior?
```python
multi_spec = GroupSpec('A test extension that contains a multi',
                               data_type_def='Multi',
                               groups=[GroupSpec(
                                   data_type_inc=self.bar_spec,
                                   doc='test multi',
                                   quantity='*')]
                               )
        self.spec_catalog.register_spec(multi_spec, 'extension.yaml')
        Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
        Multi = self.type_map.get_container_cls(CORE_NAMESPACE, 'Multi')
        assert Multi.__clsconf__[0] == dict(
            attr='bars',
            type=Bar,
            add='add_bars',
            get='get_bars',
            create='create_bars'
        )

        multi = Multi(bars=[Bar('my_bar', list(range(10)), 'value1', 10)])
        assert multi.bars['my_bar'] == Bar('my_bar', list(range(10)), 'value1', 10)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
