### PR TITLE
add capability to add a row to a column after IO

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -91,7 +91,7 @@ class VectorIndex(VectorData):
     def __check_precision(self, idx):
         """
         Check precision of current dataset and, if
-        necessary, adjust precision to accomodate new value.
+        necessary, adjust precision to accommodate new value.
 
         Returns:
             unsigned integer encoding of idx

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -5,7 +5,6 @@ from .utils import (docval, get_docval, call_docval_func, getargs, ExtenderMeta,
                     popargs, LabelledDict)
 from .data_utils import DataIO, append_data, extend_data
 from warnings import warn
-import h5py
 import types
 
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from uuid import uuid4
 from .utils import (docval, get_docval, call_docval_func, getargs, ExtenderMeta, get_data_shape, fmt_docval_args,
                     popargs, LabelledDict)
-from .data_utils import DataIO
+from .data_utils import DataIO, append_data, extend_data
 from warnings import warn
 import h5py
 import types
@@ -477,32 +477,10 @@ class Data(AbstractContainer):
         return self.data[args]
 
     def append(self, arg):
-        if isinstance(self.data, list):
-            self.data.append(arg)
-        elif isinstance(self.data, np.ndarray):
-            self.__data = np.append(self.__data, [arg])
-        elif isinstance(self.data, h5py.Dataset):
-            shape = list(self.__data.shape)
-            shape[0] += 1
-            self.__data.resize(shape)
-            self.__data[-1] = arg
-        else:
-            msg = "Data cannot append to object of type '%s'" % type(self.__data)
-            raise ValueError(msg)
+        self.__data = append_data(self.__data, arg)
 
     def extend(self, arg):
-        if isinstance(self.data, list):
-            self.data.extend(arg)
-        elif isinstance(self.data, np.ndarray):
-            self.__data = np.append(self.__data, [arg])
-        elif isinstance(self.data, h5py.Dataset):
-            shape = list(self.__data.shape)
-            shape[0] += len(arg)
-            self.__data.resize(shape)
-            self.__data[-len(arg):] = arg
-        else:
-            msg = "Data cannot extend object of type '%s'" % type(self.__data)
-            raise ValueError(msg)
+        self.__data = extend_data(self.__data, arg)
 
 
 class DataRegion(Data):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -3,8 +3,43 @@ from collections.abc import Iterable
 import numpy as np
 from warnings import warn
 import copy
+import h5py
 
 from .utils import docval, getargs, popargs, docval_macro, get_data_shape
+
+
+def append_data(data, arg):
+    if isinstance(data, (list, DataIO)):
+        data.append(arg)
+        return data
+    elif isinstance(data, np.ndarray):
+        return np.append(data, [arg])
+    elif isinstance(data, h5py.Dataset):
+        shape = list(data.shape)
+        shape[0] += 1
+        data.resize(shape)
+        data[-1] = arg
+        return data
+    else:
+        msg = "Data cannot append to object of type '%s'" % type(data)
+        raise ValueError(msg)
+
+
+def extend_data(data, arg):
+    if isinstance(data, (list, DataIO)):
+        data.extend(arg)
+        return data
+    elif isinstance(data, np.ndarray):
+        return np.append(data, [arg])
+    elif isinstance(data, h5py.Dataset):
+        shape = list(data.shape)
+        shape[0] += len(arg)
+        data.resize(shape)
+        data[-len(arg):] = arg
+        return data
+    else:
+        msg = "Data cannot extend object of type '%s'" % type(data)
+        raise ValueError(msg)
 
 
 @docval_macro('array_data')
@@ -601,6 +636,12 @@ class DataIO:
         """
         newobj = DataIO(data=self.data)
         return newobj
+
+    def append(self, arg):
+        self.__data = append_data(self.__data, arg)
+
+    def extend(self, arg):
+        self.__data = extend_data(self.__data, arg)
 
     def __deepcopy__(self, memo):
         """

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -30,7 +30,7 @@ def extend_data(data, arg):
         data.extend(arg)
         return data
     elif isinstance(data, np.ndarray):
-        return np.append(data, [arg])
+        return np.vstack((data, arg))
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += len(arg)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1214,13 +1214,17 @@ class TestDataIOIndexedColumns(H5RoundTripMixin, TestCase):
             allow_plugin_filters=True,
         )
         foo = VectorData(name='foo', description='chunked column', data=self.chunked_data)
-        foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3, 4])
+        foo_ind = VectorIndex(name='foo_index', target=foo, data=H5DataIO([2, 3, 4], chunks=True))
         bar = VectorData(name='bar', description='chunked column', data=self.compressed_data)
-        bar_ind = VectorIndex(name='bar_index', target=bar, data=[2, 3, 4])
+        bar_ind = VectorIndex(name='bar_index', target=bar, data=H5DataIO([2, 3, 4], chunks=True))
 
         # NOTE: on construct, columns are ordered such that indices go before data, so create the table that way
         # for proper comparison of the columns list
         table = DynamicTable('table0', 'an example table', columns=[foo_ind, foo, bar_ind, bar])
+
+        # check for add_row
+        table.add_row(foo=np.arange(30).reshape(5, 2, 3), bar=np.arange(30).reshape(5, 2, 3))
+
         return table
 
     def test_roundtrip(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,5 +1,6 @@
 import unittest
-from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, DynamicTableRegion, VocabData, get_manager
+from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, \
+    DynamicTableRegion, VocabData, get_manager
 from hdmf.testing import TestCase, H5RoundTripMixin
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 
@@ -1299,7 +1300,6 @@ class TestDataIOIndex(H5RoundTripMixin, TestCase):
         bar = VectorData(name='bar', description='chunked column', data=self.compressed_data)
         bar_ind = VectorIndex(name='bar_index', target=bar, data=self.compressed_index_data)
 
-
         # NOTE: on construct, columns are ordered such that indices go before data, so create the table that way
         # for proper comparison of the columns list
         table = DynamicTable('table0', 'an example table', columns=[foo_ind, foo, bar_ind, bar],
@@ -1323,4 +1323,3 @@ class TestDataIOIndex(H5RoundTripMixin, TestCase):
         read_table.add_row(foo=data, bar=data)
 
         np.testing.assert_array_equal(read_table['foo'][-1], data)
-

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1214,9 +1214,9 @@ class TestDataIOIndexedColumns(H5RoundTripMixin, TestCase):
             allow_plugin_filters=True,
         )
         foo = VectorData(name='foo', description='chunked column', data=self.chunked_data)
-        foo_ind = VectorIndex(name='foo_index', target=foo, data=H5DataIO([2, 3, 4], chunks=True))
+        foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3, 4])
         bar = VectorData(name='bar', description='chunked column', data=self.compressed_data)
-        bar_ind = VectorIndex(name='bar_index', target=bar, data=H5DataIO([2, 3, 4], chunks=True))
+        bar_ind = VectorIndex(name='bar_index', target=bar, data=[2, 3, 4])
 
         # NOTE: on construct, columns are ordered such that indices go before data, so create the table that way
         # for proper comparison of the columns list
@@ -1278,6 +1278,10 @@ class TestDataIOIndex(H5RoundTripMixin, TestCase):
         # NOTE: on construct, columns are ordered such that indices go before data, so create the table that way
         # for proper comparison of the columns list
         table = DynamicTable('table0', 'an example table', columns=[foo_ind, foo, bar_ind, bar])
+
+        # check for add_row
+        table.add_row(foo=np.arange(30).reshape(5, 2, 3), bar=np.arange(30).reshape(5, 2, 3))
+
         return table
 
     def test_roundtrip(self):


### PR DESCRIPTION
## Motivation

Tables that have columns that use DataIO should now be able to be built using the standard `.add_row` syntax.

tested:
* 1-D `list`
* `DataIO` is used for an n-d `np.ndarray`
* `DataIO` is used for a column index
* chunked `h5py.Dataset` (after read)

I moved the addend and extend logic to data_utils because I needed to use the same logic there.