### PR TITLE
Fix convert dtype when writing numpy array from h5dataset

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -130,7 +130,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         g = np.dtype(given)
         s = np.dtype(specified)
-        if g is s:
+        if g == s:
             return s.type, None
         if g.itemsize <= s.itemsize:  # given type has precision < precision of specified type
             # note: this allows float32 -> int32, bool -> int8, int16 -> uint16 which may involve buffer overflows,


### PR DESCRIPTION
## Motivation

When building an array where the data came from an h5py.Dataset, the dtype of the array is not equivalent (using `is`) to the standard numpy dtypes. The `base` field is different for the two. So we should use `==` instead. 

```python
np.dtype('float64') is np.dtype(value.dtype)  # False
np.dtype('float64') == np.dtype(value.dtype)  # True
np.dtype('float64').base  # dtype('float64')
value.dtype.base  # dtype('<f8')
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
