### PR TITLE
Refactor `HDF5IO.write_dataset` to be more readable

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1050,32 +1050,6 @@ class HDF5IO(HDMFIO):
                             without_attrs=True)
                 dset = parent[name]
 
-                # if link_data and (data_filename != export_source or parent.name != data.parent.name):
-                #     parent_filename = os.path.abspath(parent.file.filename)
-                #     if data_filename != parent_filename and data_filename != export_source:
-                #         relative_path = os.path.relpath(data_filename, os.path.dirname(parent_filename))
-                #         link = ExternalLink(relative_path, data.name)
-                #         self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
-                #                           % (parent.name, name, link.filename, link.path))
-                #     else:
-                #         link = SoftLink(data.name)
-                #         self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
-                #                           % (parent.name, name, link.path))
-                #     parent[name] = link
-                # # Copy the dataset
-                # # TODO add option for case where there are multiple links to the same dataset within a file:
-                # # instead of copying the dset N times, copy it once and create soft links to it within the file
-                # else:
-                #     self.logger.debug("    Copying data from '%s://%s' to '%s/%s'"
-                #                       % (data.file.filename, data.name, parent.name, name))
-                #     parent.copy(source=data,
-                #                 dest=parent,
-                #                 name=name,
-                #                 expand_soft=False,
-                #                 expand_external=False,
-                #                 expand_refs=False,
-                #                 without_attrs=True)
-                #     dset = parent[name]
         #  Write a compound dataset, i.e, a dataset with compound data type
         elif isinstance(options['dtype'], list):
             # do some stuff to figure out what data is a reference

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -994,27 +994,51 @@ class HDF5IO(HDMFIO):
         # The user provided an existing h5py dataset as input and asked to create a link to the dataset
         if isinstance(data, Dataset):
             data_filename = os.path.abspath(data.file.filename)
-            if export_source is not None:
-                export_source = os.path.abspath(export_source)
-            # if exporting and dset is in same file as export source, then the current dset could be linked or the
-            # actual dset in the right location
-            if link_data and (data_filename != export_source or parent.name != data.parent.name):
-                # Create a Soft/External link to the dataset
-                parent_filename = os.path.abspath(parent.file.filename)
-                if data_filename != parent_filename and data_filename != export_source:
-                    relative_path = os.path.relpath(data_filename, os.path.dirname(parent_filename))
-                    link = ExternalLink(relative_path, data.name)
-                    self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
-                                      % (parent.name, name, link.filename, link.path))
-                else:
-                    link = SoftLink(data.name)
-                    self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
-                                      % (parent.name, name, link.path))
-                parent[name] = link
-            # Copy the dataset
-            # TODO add option for case where there are multiple links to the same dataset within a file:
-            # instead of copying the dset N times, copy it once and create soft links to it within the file
+            if link_data:
+                if export_source is None:  # not exporting
+                    parent_filename = os.path.abspath(parent.file.filename)
+                    if data_filename != parent_filename:  # create external link to data
+                        relative_path = os.path.relpath(data_filename, os.path.dirname(parent_filename))
+                        link = ExternalLink(relative_path, data.name)
+                        self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
+                                          % (parent.name, name, link.filename, link.path))
+                    else:  # create soft link to dataset already in this file -- possible if mode == 'r+'
+                        link = SoftLink(data.name)
+                        self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
+                                          % (parent.name, name, link.path))
+                    parent[name] = link
+                else:  # exporting
+                    export_source = os.path.abspath(export_source)
+                    parent_filename = os.path.abspath(parent.file.filename)
+                    if data_filename != export_source:  # dataset is in different file than export source
+                        # possible if user adds a link to a dataset in a different file after reading export source
+                        # to memory
+                        relative_path = os.path.relpath(data_filename, os.path.dirname(parent_filename))
+                        link = ExternalLink(relative_path, data.name)
+                        self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
+                                          % (parent.name, name, link.filename, link.path))
+                        parent[name] = link
+                    elif parent.name != data.parent.name:  # dataset is in export source and has different path
+                        # so create a soft link to the dataset in this file
+                        # possible if user adds a link to a dataset in export source after reading to memory
+                        link = SoftLink(data.name)
+                        self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
+                                          % (parent.name, name, link.path))
+                        parent[name] = link
+                    else:  # dataset is in export source and has same path as the builder, so copy the dataset
+                        self.logger.debug("    Copying data from '%s://%s' to '%s/%s'"
+                                          % (data.file.filename, data.name, parent.name, name))
+                        parent.copy(source=data,
+                                    dest=parent,
+                                    name=name,
+                                    expand_soft=False,
+                                    expand_external=False,
+                                    expand_refs=False,
+                                    without_attrs=True)
+                        dset = parent[name]
             else:
+                # TODO add option for case where there are multiple links to the same dataset within a file:
+                # instead of copying the dset N times, copy it once and create soft links to it within the file
                 self.logger.debug("    Copying data from '%s://%s' to '%s/%s'"
                                   % (data.file.filename, data.name, parent.name, name))
                 parent.copy(source=data,
@@ -1025,6 +1049,33 @@ class HDF5IO(HDMFIO):
                             expand_refs=False,
                             without_attrs=True)
                 dset = parent[name]
+
+                # if link_data and (data_filename != export_source or parent.name != data.parent.name):
+                #     parent_filename = os.path.abspath(parent.file.filename)
+                #     if data_filename != parent_filename and data_filename != export_source:
+                #         relative_path = os.path.relpath(data_filename, os.path.dirname(parent_filename))
+                #         link = ExternalLink(relative_path, data.name)
+                #         self.logger.debug("    Creating ExternalLink '%s/%s' to '%s://%s'"
+                #                           % (parent.name, name, link.filename, link.path))
+                #     else:
+                #         link = SoftLink(data.name)
+                #         self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
+                #                           % (parent.name, name, link.path))
+                #     parent[name] = link
+                # # Copy the dataset
+                # # TODO add option for case where there are multiple links to the same dataset within a file:
+                # # instead of copying the dset N times, copy it once and create soft links to it within the file
+                # else:
+                #     self.logger.debug("    Copying data from '%s://%s' to '%s/%s'"
+                #                       % (data.file.filename, data.name, parent.name, name))
+                #     parent.copy(source=data,
+                #                 dest=parent,
+                #                 name=name,
+                #                 expand_soft=False,
+                #                 expand_external=False,
+                #                 expand_refs=False,
+                #                 without_attrs=True)
+                #     dset = parent[name]
         #  Write a compound dataset, i.e, a dataset with compound data type
         elif isinstance(options['dtype'], list):
             # do some stuff to figure out what data is a reference


### PR DESCRIPTION
## Motivation

Based on feedback from @oruebel while creating the Zarr backend #98, I refactored the part of `HDF5IO.write_dataset(...)` that handles writing an existing `h5py.Dataset` to be more readable and have clearer logic (at the cost of more lines of code). 

I could move some of the duplicated code to separate functions with 1-2 lines and lots of arguments, but I think it is more readable as is. Let me know if not.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
