### PR TITLE
add multi-index code and test

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -85,7 +85,11 @@ class VectorIndex(VectorData):
         Add the given data value to the target VectorData and append the corresponding index to this VectorIndex
         :param arg: The data value to be added to self.target
         """
-        self.target.extend(arg)
+        if isinstance(self.target, VectorIndex):
+            for a in arg:
+                self.target.add_vector(a)
+        else:
+            self.target.extend(arg)
         self.append(self.__check_precision(len(self.target)))
 
     def __check_precision(self, idx):
@@ -626,16 +630,20 @@ class DynamicTable(Container):
         if index is not False:
             if isinstance(index, VectorIndex):
                 col_index = index
+                self.__add_column_index_helper(col_index)
             elif isinstance(index, bool):        # make empty VectorIndex
                 if len(col) > 0:
                     raise ValueError("cannot pass empty index with non-empty data to index")
                 col_index = VectorIndex(name + "_index", list(), col)
+                self.__add_column_index_helper(col_index)
             elif isinstance(index, int):
+                assert index > 0, ValueError("integer index value must be greater than 0")
                 assert len(col) == 0, ValueError("cannot pass empty index with non-empty data to index")
                 index_name = name
                 for i in range(index):
                     index_name = index_name + "_index"
                     col_index = VectorIndex(index_name, list(), col)
+                    self.__add_column_index_helper(col_index)
                     if i < index - 1:
                         columns.insert(0, col_index)
                         col = col_index
@@ -643,15 +651,9 @@ class DynamicTable(Container):
                 if len(col) == 0:
                     raise ValueError("cannot pass non-empty index with empty data to index")
                 col_index = VectorIndex(name + "_index", index, col)
+                self.__add_column_index_helper(col_index)
             columns.insert(0, col_index)
-            if not isinstance(col_index.parent, Container):
-                col_index.parent = self
-            # else, the ObjectMapper will create a link from self (parent) to col_index (child with existing parent)
             col = col_index
-            self.__indices[col_index.name] = col_index
-            self.__set_table_attr(col_index)
-            if col_index in self.__uninit_cols:
-                self.__uninit_cols.pop(col_index)
 
         if len(col) != len(self.id):
             raise ValueError("column must have the same number of rows as 'id'")
@@ -659,6 +661,15 @@ class DynamicTable(Container):
         self.fields['colnames'] = tuple(list(self.colnames)+[name])
         self.fields['columns'] = tuple(list(self.columns)+columns)
         self.__df_cols.append(col)
+
+    def __add_column_index_helper(self, col_index):
+        if not isinstance(col_index.parent, Container):
+            col_index.parent = self
+        # else, the ObjectMapper will create a link from self (parent) to col_index (child with existing parent)
+        self.__indices[col_index.name] = col_index
+        self.__set_table_attr(col_index)
+        if col_index in self.__uninit_cols:
+            self.__uninit_cols.pop(col_index)
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of the DynamicTableRegion object'},
             {'name': 'region', 'type': (slice, list, tuple), 'doc': 'the indices of the table'},

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -562,7 +562,12 @@ class DynamicTable(Container):
             {'name': 'table', 'type': (bool, 'DynamicTable'),
              'doc': 'whether or not this is a table region or the table the region applies to', 'default': False},
             {'name': 'index', 'type': (bool, VectorIndex, 'array_data', int),
-             'doc': 'whether or not this column should be indexed', 'default': False},
+             'doc': 'False (default): do not generate a VectorIndex \n'
+                    'True: generate one empty VectorIndex \n'
+                    'VectorIndex: Use the supplied VectorIndex \n'
+                    'array-like of ints: Create a VectorIndex and use these values as the data \n'
+                    'int: Recursively create `n` VectorIndex objects for a multi-ragged array \n',
+             'default': False},
             {'name': 'vocab', 'type': (bool, 'array_data'), 'default': False,
              'doc': ('whether or not this column contains data from a '
                      'controlled vocabulary or the controlled vocabulary')},

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -553,7 +553,7 @@ class DynamicTable(Container):
              'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()},
             {'name': 'table', 'type': (bool, 'DynamicTable'),
              'doc': 'whether or not this is a table region or the table the region applies to', 'default': False},
-            {'name': 'index', 'type': (bool, VectorIndex, 'array_data'),
+            {'name': 'index', 'type': (bool, VectorIndex, 'array_data', int),
              'doc': 'whether or not this column should be indexed', 'default': False},
             {'name': 'vocab', 'type': (bool, 'array_data'), 'default': False,
              'doc': ('whether or not this column contains data from a '
@@ -630,6 +630,15 @@ class DynamicTable(Container):
                 if len(col) > 0:
                     raise ValueError("cannot pass empty index with non-empty data to index")
                 col_index = VectorIndex(name + "_index", list(), col)
+            elif isinstance(index, int):
+                assert len(col) == 0, ValueError("cannot pass empty index with non-empty data to index")
+                index_name = name
+                for i in range(index):
+                    index_name = index_name + "_index"
+                    col_index = VectorIndex(index_name, list(), col)
+                    if i < index - 1:
+                        columns.insert(0, col_index)
+                        col = col_index
             else:                                # make VectorIndex with supplied data
                 if len(col) == 0:
                     raise ValueError("cannot pass non-empty index with empty data to index")

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -205,6 +205,24 @@ class TestDynamicTable(TestCase):
         with self.assertWarnsWith(FutureWarning, msg):
             table.add_column(name='bad', description='bad column', index=ind)
 
+    def test_add_column_multi_index(self):
+        table = self.with_spec()
+        table.add_column(name='qux', description='qux column', index=2)
+        table.add_row(foo=5, bar=50.0, baz='lizard',
+                      qux=[
+                            [1, 2, 3],
+                            [1, 2, 3, 4]
+                      ])
+        table.add_row(foo=5, bar=50.0, baz='lizard',
+                      qux=[
+                            [1, 2]
+                      ]
+                      )
+        table[0, 'qux']
+        table[:, 'qux']
+        table['qux'][0]
+        table['qux'][:]
+
     def test_getitem_row_num(self):
         table = self.with_spec()
         self.add_rows(table)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1079,6 +1079,24 @@ class TestDoubleIndex(TestCase):
         self.assertListEqual(foo_ind_ind[0], [['a11', 'a12'], ['a21']])
         self.assertListEqual(foo_ind_ind[1], [['b11']])
 
+    def test_add_vector(self):
+        # row 1 has three entries
+        # the first entry has two sub-entries
+        # the first sub-entry has two values, the second sub-entry has one value
+        # the second entry has one sub-entry, which has one value
+        foo = VectorData(name='foo', description='foo column', data=['a11', 'a12', 'a21', 'b11'])
+        foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3, 4])
+        foo_ind_ind = VectorIndex(name='foo_index_index', target=foo_ind, data=[2, 3])
+
+        foo_ind_ind.add_vector([['c11', 'c12', 'c13'], ['c21', 'c22']])
+
+        self.assertListEqual(foo.data, ['a11', 'a12', 'a21', 'b11', 'c11', 'c12', 'c13', 'c21', 'c22'])
+        self.assertListEqual(foo_ind.data, [2, 3, 4, 7, 9])
+        self.assertListEqual(foo_ind[3], ['c11', 'c12', 'c13'])
+        self.assertListEqual(foo_ind[4], ['c21', 'c22'])
+        self.assertListEqual(foo_ind_ind.data, [2, 3, 5])
+        self.assertListEqual(foo_ind_ind[2], [['c11', 'c12', 'c13'], ['c21', 'c22']])
+
 
 class TestDTDoubleIndex(TestCase):
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -218,10 +218,6 @@ class TestDynamicTable(TestCase):
                             [1, 2]
                       ]
                       )
-        table[0, 'qux']
-        table[:, 'qux']
-        table['qux'][0]
-        table['qux'][:]
 
     def test_getitem_row_num(self):
         table = self.with_spec()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -220,6 +220,32 @@ class TestDynamicTable(TestCase):
                       ]
                       )
 
+    def test_auto_multi_index(self):
+
+        class TestTable(DynamicTable):
+            __columns__ = (dict(name='qux', description='qux column', index=2),)
+
+        table = TestTable('table_name', 'table_description')
+        table.add_row(qux=[
+                          [1, 2, 3],
+                          [1, 2, 3, 4]
+                      ])
+        table.add_row(qux=[
+                          [1, 2]
+                      ]
+                      )
+
+        np.testing.assert_array_equal(table['qux'][:],
+                                      [
+                                          [
+                                              [1, 2, 3],
+                                              [1, 2, 3, 4]
+                                          ],
+                                          [
+                                              [1, 2]
+                                          ]
+                                      ])
+
     def test_getitem_row_num(self):
         table = self.with_spec()
         self.add_rows(table)


### PR DESCRIPTION
## Motivation

fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1296

Allows for the index arg of add_column to take an `int` type, in which case the column will be indexed `int` times
