### PR TITLE
Fix package dependency issues with importlib

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ coverage==5.2
 flake8==3.8.3
 flake8-debugger==3.1.0
 flake8-print==3.1.4
+importlib-metadata<2
 python-dateutil==2.8.1
 tox==3.17.1


### PR DESCRIPTION
Installing flake8 installs dependency importlib-metadata; python_version < "3.8"
The latest importlib-metadata is version 2.0.0, but:
- virtualenv 20.0.31 has requirement importlib-metadata<2,>=0.12; python_version < "3.8".
- tox 3.17.1 has requirement importlib-metadata<2,>=0.12; python_version < "3.8".

This creates a conflict and `pip check` fails.

This PR forces the installation of importlib-metadata<2

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
