### PR TITLE
Fix convert_dtype for empty list and text/ascii spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 2.3.0 (Upcoming)
+
+### Bug fixes
+- Fix handling of empty lists against a spec with text/bytes dtype. @rly (#434)
+
 ## HDMF 2.2.0 (August 14, 2020)
 
 ### New features

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ exclude =
   versioneer.py
   src/hdmf/_version.py
 per-file-ignores =
-  docs/gallery/*:E402,
+  docs/gallery/*:E402,T001
   docs/source/tutorials/*:E402
   src/hdmf/__init__.py:F401
   src/hdmf/backends/__init__.py:F401

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -209,7 +209,13 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret_dtype = ret.dtype.type
         elif isinstance(value, (tuple, list)):
             if len(value) == 0:
-                return value, spec_dtype_type
+                if spec_dtype_type == _ascii:
+                    ret_dtype = 'ascii'
+                elif spec_dtype_type == _unicode:
+                    ret_dtype = 'utf8'
+                else:
+                    ret_dtype = spec_dtype_type
+                return value, ret_dtype
             ret = list()
             for elem in value:
                 tmp, tmp_dtype = cls.convert_dtype(spec, elem, spec_dtype)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -1163,6 +1163,11 @@ class TestConvertDtype(TestCase):
         np.testing.assert_array_equal(ret, np.array(['a', 'b'], dtype='U1'))
         self.assertEqual(ret_dtype, 'utf8')
 
+        value = []
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertListEqual(ret, value)
+        self.assertEqual(ret_dtype, 'utf8')
+
     def test_ascii_spec(self):
         spec_type = 'ascii'
         spec = DatasetSpec('an example dataset', spec_type, name='data')
@@ -1193,6 +1198,11 @@ class TestConvertDtype(TestCase):
         value = np.array(['a', 'b'], dtype='S1')
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         np.testing.assert_array_equal(ret, value)
+        self.assertEqual(ret_dtype, 'ascii')
+
+        value = []
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertListEqual(ret, value)
         self.assertEqual(ret_dtype, 'ascii')
 
     def test_no_spec(self):


### PR DESCRIPTION
## Motivation

Fix #433.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
