### PR TITLE
Compare `Data` fields, clarify use of `assertContainerEqual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,22 @@
 ## HDMF 2.3.0 (Upcoming)
 
 ### New features
+- Add methods for automatic creation of `MultiContainerInterface` classes. @bendichter (#420, #425)
 - Add ability to specify a custom class for new columns to a `DynamicTable` that are not `VectorData`,
   `DynamicTableRegion`, or `VocabData` using `DynamicTable.__columns__` or `DynamicTable.add_column(...)`. @rly (#436)  
+- Add support for creating and specifying multi-index columns in a `DynamicTable` using `add_column(...)`.
+  @bendichter, @rly (#430)
 - Add capability to add a row to a column after IO. @bendichter (#426)
 
+### Internal improvements
+- Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)
+
 ### Bug fixes
+- Fix development package dependency issues. @rly (#431)
 - Fix handling of empty lists against a spec with text/bytes dtype. @rly (#434)
 - Fix handling of 1-element datasets with compound dtype against a scalar spec with text/bytes dtype. @rly (#438)
+- Fix convert dtype when writing numpy array from `h5py.Dataset`. @rly (#427)
+- Fix inheritance when non-`AbstractContainer` is base class. @rly (#444)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix handling of 1-element datasets with compound dtype against a scalar spec with text/bytes dtype. @rly (#438)
 - Fix convert dtype when writing numpy array from `h5py.Dataset`. @rly (#427)
 - Fix inheritance when non-`AbstractContainer` is base class. @rly (#444)
+- Fix use of `hdmf.testing.assertContainerEqual(...)` for `Data` objects. @rly (#445)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -5,7 +5,7 @@ import numpy as np
 import os
 from abc import ABCMeta, abstractmethod
 
-from ..container import Container, Data
+from ..container import AbstractContainer, Container, Data
 from ..query import HDMFDataset
 
 from ..common import validate as common_validate, get_manager
@@ -35,12 +35,14 @@ class TestCase(unittest.TestCase):
 
     def assertContainerEqual(self, container1, container2, ignore_name=False, ignore_hdmf_attrs=False):
         """
-        Asserts that the two containers have equal contents.
+        Asserts that the two AbstractContainers have equal contents. This applies to both Container and Data types.
 
-        ignore_name - whether to ignore testing equality of name
+        ignore_name - whether to ignore testing equality of name of the top-level container
         ignore_hdmf_attrs - whether to ignore testing equality of HDMF container attributes, such as
         container_source and object_id
         """
+        self.assertTrue(isinstance(container1, AbstractContainer))
+        self.assertTrue(isinstance(container2, AbstractContainer))
         type1 = type(container1)
         type2 = type(container2)
         self.assertEqual(type1, type2)
@@ -50,7 +52,8 @@ class TestCase(unittest.TestCase):
             self.assertEqual(container1.container_source, container2.container_source)
             self.assertEqual(container1.object_id, container2.object_id)
         # NOTE: parent is not tested because it can lead to infinite loops
-        self.assertEqual(len(container1.children), len(container2.children))
+        if isinstance(container1, Container):
+            self.assertEqual(len(container1.children), len(container2.children))
         # do not actually check the children values here. all children *should* also be fields, which is checked below.
         # this is in case non-field children are added to one and not the other
 
@@ -82,9 +85,11 @@ class TestCase(unittest.TestCase):
             self.assertEqual(f1, f2)
 
     def _assert_data_equal(self, data1, data2, ignore_hdmf_attrs=False):
-        self.assertEqual(type(data1), type(data2))
+        self.assertTrue(isinstance(data1, Data))
+        self.assertTrue(isinstance(data2, Data))
         self.assertEqual(len(data1), len(data2))
         self._assert_array_equal(data1.data, data2.data, ignore_hdmf_attrs=ignore_hdmf_attrs)
+        self.assertContainerEqual(data1, data2, ignore_hdmf_attrs=ignore_hdmf_attrs)
 
     def _assert_array_equal(self, arr1, arr2, ignore_hdmf_attrs=False):
         if isinstance(arr1, (h5py.Dataset, HDMFDataset)):


### PR DESCRIPTION
## Motivation

`Data` objects can have `fields` but these are not currently compared in `hdmf.testing.TestCase.assertContainerEqual(...)`. This PR adds comparison of those fields and also clarifies that `assertContainerEqual(...)` works on both `Container` and `Data` types. It really should be named `assertAbstractContainerEqual(...)` but that is a long name and changing the name would break backward compatibility.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
