### PR TITLE
Add get_docval_macro method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add ability to specify a custom class for new columns to a `DynamicTable` that are not `VectorData`,
   `DynamicTableRegion`, or `VocabData` using `DynamicTable.__columns__` or `DynamicTable.add_column(...)`. @rly (#436)  
 - Add capability to add a row to a column after IO. @bendichter (#426)
+- Add method `hdmf.utils.get_docval_macro` to get a tuple of the current values for a docval_macro, e.g., 'array_data'  
+  and 'scalar_data'. @rly (#456)
 
 ### Bug fixes
 - Fix handling of empty lists against a spec with text/bytes dtype. @rly (#434)

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -41,6 +41,10 @@ def docval_macro(macro):
     return _dec
 
 
+def get_docval_macro(macro):
+    return tuple(__macros[macro])
+
+
 def __type_okay(value, argtype, allow_none=False):
     """Check a value against a type
 

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -10,6 +10,7 @@ from enum import Enum
 __macros = {
     'array_data': [np.ndarray, list, tuple, h5py.Dataset],
     'scalar_data': [str, int, float, bytes],
+    'data': []
 }
 
 # code to signify how to handle positional arguments in docval
@@ -41,8 +42,17 @@ def docval_macro(macro):
     return _dec
 
 
-def get_docval_macro(macro):
-    return tuple(__macros[macro])
+def get_docval_macro(key=None):
+    """
+    Return a deepcopy of the docval macros, i.e., strings that represent a customizable list of types for use in docval.
+
+    :param key: Name of the macro. If key=None, then a dictionary of all macros is returned. Otherwise, a tuple of
+                the types associated with the key is returned.
+    """
+    if key is None:
+        return _copy.deepcopy(__macros)
+    else:
+        return tuple(__macros[key])
 
 
 def __type_okay(value, argtype, allow_none=False):

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -974,6 +974,8 @@ class TestPopargs(TestCase):
 class TestMacro(TestCase):
 
     def test_macro(self):
+        self.assertSetEqual(set(get_docval_macro().keys()), {'array_data', 'scalar_data', 'data'})
+
         self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes))
 
         @docval_macro('scalar_data')

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from hdmf.utils import docval, fmt_docval_args, get_docval, getargs, popargs, AllowPositional
+from hdmf.utils import (docval, fmt_docval_args, get_docval, getargs, popargs, AllowPositional, get_docval_macro,
+                        docval_macro)
 from hdmf.testing import TestCase
 
 
@@ -968,3 +969,21 @@ class TestPopargs(TestCase):
         msg = "Argument not found in dict: 'c'"
         with self.assertRaisesWith(ValueError, msg):
             popargs('a', 'c', kwargs)
+
+
+class TestMacro(TestCase):
+
+    def test_macro(self):
+        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes))
+
+        @docval_macro('scalar_data')
+        class Dummy1:
+            pass
+
+        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes, Dummy1))
+
+        @docval_macro('dummy')
+        class Dummy2:
+            pass
+
+        self.assertTupleEqual(get_docval_macro('dummy'), (Dummy2, ))

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -974,6 +974,7 @@ class TestPopargs(TestCase):
 class TestMacro(TestCase):
 
     def test_macro(self):
+        self.assertTrue(isinstance(get_docval_macro(), dict))
         self.assertSetEqual(set(get_docval_macro().keys()), {'array_data', 'scalar_data', 'data'})
 
         self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes))


### PR DESCRIPTION
## Motivation

Add a method to get a tuple of the current values for a docval_macro, e.g., 'array_data' and 'scalar_data'. This is generally useful and specifically useful for working with the allowed types where a docval macro is used to restrict the argument types.

## How to test the behavior?
```python
from hdmf.utils import get_docval_macro
get_docval_macro('array_data')
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
