### PR TITLE
Fix improperly set new vs overridden attributes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Fix convert dtype when writing numpy array from `h5py.Dataset`. @rly (#427)
 - Fix inheritance when non-`AbstractContainer` is base class. @rly (#444)
 - Fix use of `hdmf.testing.assertContainerEqual(...)` for `Data` objects. @rly (#445)
+- Fix bug in BaseStorageSpec.resolve_spec where attributes are not correctly removed from the set of new attributes.
+  @rly (#448)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -129,8 +129,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
                 # check whether new fields spec already exists in base class
                 for field_name in fields_dict:
                     if field_name in base_fields:
-                        raise ValueError("Field '%s' cannot be defined in %s. It already exists on base class %s."
-                                         % (field_name, cls.__name__, base_cls.__name__))
+                        warn("Field '%s' should not be defined in %s. It already exists on base class %s."
+                             % (field_name, cls.__name__, base_cls.__name__))
                 # prepend field specs from base class to fields list of this class
                 all_fields_conf[0:0] = base_cls.get_fields_conf()
 

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -374,7 +374,7 @@ class BaseStorageSpec(Spec):
     def resolve_spec(self, **kwargs):
         inc_spec = getargs('inc_spec', kwargs)
         for attribute in inc_spec.attributes:
-            self.__new_attributes.discard(attribute)
+            self.__new_attributes.discard(attribute.name)
             if attribute.name in self.__attributes:
                 self.__overridden_attributes.add(attribute.name)
                 continue

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -372,9 +372,9 @@ class TestAbstractContainerFieldsConf(TestCase):
         class NamedFields(AbstractContainer):
             __fields__ = ({'name': 'field1'}, )
 
-        msg = ("Field 'field1' cannot be defined in NamedFieldsChild. It already exists on base class "
+        msg = ("Field 'field1' should not be defined in NamedFieldsChild. It already exists on base class "
                "NamedFields.")
-        with self.assertRaisesWith(ValueError, msg):
+        with self.assertWarnsWith(UserWarning, msg):
             class NamedFieldsChild(NamedFields):
                 __fields__ = ({'name': 'field1', 'settable': True}, )
 


### PR DESCRIPTION
## Motivation

Fix #447 .

Fix bug in `BaseStorageSpec.resolve_spec` where attributes are not correctly removed from the set of new attributes. `__new_attributes` contains just the field names but `attribute` is a field dictionary, so nothing was being removed.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
