### PR TITLE
Fix DynamicTable slicing and add SimpleMultiContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   and 'scalar_data'. @rly (#446)
 - Add SimpleMultiContainer, a data_type for storing a Container and Data objects together. @ajtritt (#449)
 - Support `pathlib.Path` paths in `HDMFIO.__init__`, `HDF5IO.__init__`, and `HDF5IO.load_namespaces`. @dsleiter (#439)
-
+- Use hdmf-common-schema 1.2.1. See https://hdmf-common-schema.readthedocs.io/en/latest/format_release_notes.html for details.
 
 ### Internal improvements
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add ability to specify a custom class for new columns to a `DynamicTable` that are not `VectorData`,
   `DynamicTableRegion`, or `VocabData` using `DynamicTable.__columns__` or `DynamicTable.add_column(...)`. @rly (#436)  
 - Add capability to add a row to a column after IO. @bendichter (#426)
+- Add SimpleMultiContainer, a data_type for storing a Container and Data objects together. @ajtritt (#449)
+- Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
 
 ### Bug fixes
 - Fix handling of empty lists against a spec with text/bytes dtype. @rly (#434)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -306,10 +306,11 @@ class BuildManager:
 
     @docval({'name': 'builder', 'type': (GroupBuilder, DatasetBuilder), 'doc': 'the builder to check'},
             {'name': 'parent_data_type', 'type': (str, type), 'doc': 'the potential parent data_type'},
-            returns="a tuple with the type hierarchy", rtype=tuple)
+            returns="True if data_type of *builder* is a sub-data_type of *parent_data_type*, False otherwise",
+            rtype=bool)
     def is_sub_data_type(self, **kwargs):
         '''
-        Return True if data_type of *builder* is a sub-data_type of *parent_data_type*, False otherwise
+        Return whether or not data_type of *builder* is a sub-data_type of *parent_data_type*
         '''
         builder, parent_dt = getargs('builder', 'parent_data_type', kwargs)
         dt = self.get_builder_dt(builder)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -304,6 +304,18 @@ class BuildManager:
         builder = getargs('builder', kwargs)
         return self.__type_map.get_builder_dt(builder)
 
+    @docval({'name': 'builder', 'type': (GroupBuilder, DatasetBuilder), 'doc': 'the builder to check'},
+            {'name': 'parent_data_type', 'type': (str, type), 'doc': 'the potential parent data_type'},
+            returns="a tuple with the type hierarchy", rtype=tuple)
+    def is_sub_data_type(self, **kwargs):
+        '''
+        Return True if data_type of *builder* is a sub-data_type of *parent_data_type*, False otherwise
+        '''
+        builder, parent_dt = getargs('builder', 'parent_data_type', kwargs)
+        dt = self.get_builder_dt(builder)
+        ns = self.get_builder_ns(builder)
+        return self.namespace_catalog.is_sub_data_type(ns, dt, parent_dt)
+
 
 class TypeSource:
     '''A class to indicate the source of a data_type in a namespace.

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -172,8 +172,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """
         cls.__no_convert.add(obj_type)
 
-    @classmethod
-    def convert_dtype(cls, spec, value, spec_dtype=None):
+    @classmethod  # noqa: C901
+    def convert_dtype(cls, spec, value, spec_dtype=None):  # noqa: C901
         """
         Convert values to the specified dtype. For example, if a literal int
         is passed in to a field that is specified as a unsigned integer, this function
@@ -920,7 +920,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
                                       % (repr(spec.name),
                                          spec.def_key(), repr(spec.data_type_def),
                                          spec.inc_key(), repr(spec.data_type_inc)))
-                    attr_name = self.get_attribute(spec)
                     attr_value = self.get_attr_value(spec, container, build_manager)
                     if attr_value is not None:
                         self.__add_containers(builder, spec, attr_value, build_manager, source, container, export)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -205,7 +205,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret_dtype = "ascii"
             else:
                 dtype_func, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
-                ret = np.asarray(value).astype(dtype_func)
+                if value.dtype == dtype_func:
+                    ret = value
+                else:
+                    ret = value.astype(dtype_func)
                 ret_dtype = ret.dtype.type
         elif isinstance(value, (tuple, list)):
             if len(value) == 0:

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -104,6 +104,7 @@ if os.path.exists(__resources['namespace_path']):
 
     from . import table  # noqa: F401,E402
     from . import sparse  # noqa: F401,E402
+    from . import multi  # noqa: F401,E402
 
     from .. import Data, Container
     __TYPE_MAP.register_container_type(CORE_NAMESPACE, 'Container', Container)
@@ -120,6 +121,7 @@ ElementIdentifiers = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'ElementIdenti
 DynamicTableRegion = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'DynamicTableRegion')
 VocabData = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'VocabData')
 CSRMatrix = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'CSRMatrix')
+SimpleMultiContainer = __TYPE_MAP.get_container_cls(CORE_NAMESPACE, 'SimpleMultiContainer')
 
 
 @docval({'name': 'extensions', 'type': (str, TypeMap, list),

--- a/src/hdmf/common/io/__init__.py
+++ b/src/hdmf/common/io/__init__.py
@@ -1,1 +1,2 @@
 from . import table  # noqa: F401
+from . import multi  # noqa: F401

--- a/src/hdmf/common/io/multi.py
+++ b/src/hdmf/common/io/multi.py
@@ -1,0 +1,21 @@
+from ...build import ObjectMapper
+from ..multi import SimpleMultiContainer
+from .. import register_map
+from ...container import Container, Data
+
+
+@register_map(SimpleMultiContainer)
+class SimpleMultiContainerMap(ObjectMapper):
+
+    @ObjectMapper.object_attr('containers')
+    def containers_attr(self, container, manager):
+        return [c for c in container.containers.values() if isinstance(c, Container)]
+
+    @ObjectMapper.constructor_arg('containers')
+    def containers_carg(self, builder, manager):
+        return [manager.construct(sub) for sub in builder.datasets.values() if manager.is_sub_data_type(sub, 'Data')] +\
+            [manager.construct(sub) for sub in builder.groups.values() if manager.is_sub_data_type(sub, 'Container')]
+
+    @ObjectMapper.object_attr('datas')
+    def datas_attr(self, container, manager):
+        return [c for c in container.containers.values() if isinstance(c, Data)]

--- a/src/hdmf/common/multi.py
+++ b/src/hdmf/common/multi.py
@@ -1,0 +1,23 @@
+from ..container import Container, Data, MultiContainerInterface
+from ..utils import docval, call_docval_func, popargs
+
+from . import register_class
+
+
+@register_class('SimpleMultiContainer')
+class SimpleMultiContainer(MultiContainerInterface):
+
+    __clsconf__ = {
+        'attr': 'containers',
+        'type': (Container, Data),
+        'add': 'add_container',
+        'get': 'get_container',
+    }
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
+            {'name': 'containers', 'type': (list, tuple), 'default': None,
+             'doc': 'the Container or Data objects in this file'})
+    def __init__(self, **kwargs):
+        containers = popargs('containers', kwargs)
+        call_docval_func(super().__init__, kwargs)
+        self.containers = containers

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -783,9 +783,7 @@ class DynamicTable(Container):
                         if len(arg.shape) != 1:
                             raise ValueError("cannot index DynamicTable with multiple dimensions")
                     ret = OrderedDict()
-                    ret['id'] = (self.id.data[arg]
-                                 if isinstance(self.id.data, (np.ndarray, Dataset))
-                                 else [self.id.data[i] for i in arg])
+                    ret['id'] = self.id[arg]
                     for name in self.colnames:
                         col = self.__df_cols[self.__colids[name]]
                         ret[name] = col.get(arg, df=df, **kwargs)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -776,11 +776,7 @@ class DynamicTable(Container):
                     ret['id'] = self.id.data[arg]
                     for name in self.colnames:
                         col = self.__df_cols[self.__colids[name]]
-                        if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
-                            ret[name] = col.get(arg, df=df, **kwargs)
-                        else:
-                            currdata = col.get(arg, df=df, **kwargs)
-                            ret[name] = currdata
+                        ret[name] = col.get(arg, df=df, **kwargs)
                 # index by a list of ints, return multiple rows
                 elif isinstance(arg, (list, np.ndarray)):
                     if isinstance(arg, np.ndarray):
@@ -792,12 +788,7 @@ class DynamicTable(Container):
                                  else [self.id.data[i] for i in arg])
                     for name in self.colnames:
                         col = self.__df_cols[self.__colids[name]]
-                        if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
-                            ret[name] = [x for x in col.get(arg, df=df, **kwargs)]
-                        elif isinstance(col.data, (list, np.ndarray, Dataset)):
-                            ret[name] = col.get(arg, df=df, **kwargs)
-                        else:
-                            ret[name] = [col.get(arg, df=df, **kwargs) for i in arg]
+                        ret[name] = col.get(arg, df=df, **kwargs)
                 else:
                     raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
             except ValueError as ve:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1099,7 +1099,7 @@ class DynamicTableRegion(VectorData):
             elif isinstance(col, np.ndarray):
                 ret.append(np.array([col[lut[i]] for i in index], dtype=col.dtype))
             else:
-                raise ValueError(f'unrecognized column type: {type(col)}. Expected list or np.ndarray')
+                raise ValueError('unrecognized column type: %s. Expected list or np.ndarray' % type(col))
         return ret
 
     def to_dataframe(self, **kwargs):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -782,7 +782,7 @@ class DynamicTable(Container):
                             currdata = col.get(arg, df=df, **kwargs)
                             ret[name] = currdata
                 # index by a list of ints, return multiple rows
-                elif isinstance(arg, (tuple, list, np.ndarray)):
+                elif isinstance(arg, (list, np.ndarray)):
                     if isinstance(arg, np.ndarray):
                         if len(arg.shape) != 1:
                             raise ValueError("cannot index DynamicTable with multiple dimensions")

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1055,7 +1055,7 @@ class DynamicTableRegion(VectorData):
             idx = arg
 
             # get the data at the specified indices
-            if isinstance(self.data, list) and isinstance(idx, list):
+            if isinstance(self.data, (tuple, list)) and isinstance(idx, list):
                 ret = [self.data[i] for i in idx]
             else:
                 ret = self.data[idx]

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1051,7 +1051,7 @@ class DynamicTableRegion(VectorData):
             if not index:
                 ret = self.table.get(ret, df=df, **kwargs)
             return ret
-        elif isinstance(arg, slice) or isinstance(arg, (list, np.ndarray)):
+        elif isinstance(arg, (list, slice, np.ndarray)):
             idx = arg
 
             # get the data at the specified indices

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -120,18 +120,19 @@ class AbstractContainer(metaclass=ExtenderMeta):
         # check whether this class overrides __fields__
         if len(bases):
             # find highest base class that is an AbstractContainer (parent is higher than children)
-            base_container_ind = -1
-            while base_container_ind*-1 <= len(bases) and not issubclass(bases[base_container_ind], AbstractContainer):
-                base_container_ind = base_container_ind - 1
-            base_fields = bases[base_container_ind]._get_fields()  # tuple of field names from base class
+            base_cls = None
+            for base_cls in reversed(bases):
+                if issubclass(base_cls, AbstractContainer):
+                    break
+            base_fields = base_cls._get_fields()  # tuple of field names from base class
             if base_fields is not fields:
                 # check whether new fields spec already exists in base class
                 for field_name in fields_dict:
                     if field_name in base_fields:
                         raise ValueError("Field '%s' cannot be defined in %s. It already exists on base class %s."
-                                         % (field_name, cls.__name__, bases[base_container_ind].__name__))
+                                         % (field_name, cls.__name__, base_cls.__name__))
                 # prepend field specs from base class to fields list of this class
-                all_fields_conf[0:0] = bases[base_container_ind].get_fields_conf()
+                all_fields_conf[0:0] = base_cls.get_fields_conf()
 
         # create getter and setter if attribute does not already exist
         # if 'doc' not specified in __fields__, use doc from docval of __init__

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -119,15 +119,19 @@ class AbstractContainer(metaclass=ExtenderMeta):
 
         # check whether this class overrides __fields__
         if len(bases):
-            base_fields = bases[-1]._get_fields()  # tuple of field names from base class
+            # find highest base class that is an AbstractContainer (parent is higher than children)
+            base_container_ind = -1
+            while base_container_ind*-1 <= len(bases) and not issubclass(bases[base_container_ind], AbstractContainer):
+                base_container_ind = base_container_ind - 1
+            base_fields = bases[base_container_ind]._get_fields()  # tuple of field names from base class
             if base_fields is not fields:
                 # check whether new fields spec already exists in base class
                 for field_name in fields_dict:
                     if field_name in base_fields:
                         raise ValueError("Field '%s' cannot be defined in %s. It already exists on base class %s."
-                                         % (field_name, cls.__name__, bases[-1].__name__))
+                                         % (field_name, cls.__name__, bases[base_container_ind].__name__))
                 # prepend field specs from base class to fields list of this class
-                all_fields_conf[0:0] = bases[-1].get_fields_conf()
+                all_fields_conf[0:0] = bases[base_container_ind].get_fields_conf()
 
         # create getter and setter if attribute does not already exist
         # if 'doc' not specified in __fields__, use doc from docval of __init__

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1,3 +1,4 @@
+import h5py
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from uuid import uuid4
@@ -510,6 +511,9 @@ class Data(AbstractContainer):
     def get(self, args):
         if isinstance(self.data, (tuple, list)) and isinstance(args, (tuple, list, np.ndarray)):
             return [self.data[i] for i in args]
+        if isinstance(self.data, h5py.Dataset) and isinstance(args, np.ndarray):
+            # This is needed for h5py 2.9 compatability
+            args = args.tolist()
         return self.data[args]
 
     def append(self, arg):

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -327,6 +327,21 @@ class NamespaceCatalog:
             raise KeyError("'%s' not a namespace" % namespace)
         return spec_ns.get_hierarchy(data_type)
 
+    @docval({'name': 'namespace', 'type': str, 'doc': 'the name of the namespace containing the data_type'},
+            {'name': 'data_type', 'type': (str, type), 'doc': 'the data_type to check'},
+            {'name': 'parent_data_type', 'type': (str, type), 'doc': 'the potential parent data_type'},
+            returns="a tuple with the type hierarchy", rtype=tuple)
+    def is_sub_data_type(self, **kwargs):
+        '''
+        Return True if *data_type* is a sub `data_type` of *parent_data_type*, False otherwise
+        '''
+        ns, dt, parent_dt = getargs('namespace', 'data_type', 'parent_data_type', kwargs)
+        spec_ns = self.__namespaces.get(ns)
+        if spec_ns is None:
+            raise KeyError("'%s' not a namespace" % ns)
+        hier = spec_ns.get_hierarchy(dt)
+        return parent_dt in hier
+
     @docval(rtype=tuple)
     def get_sources(self, **kwargs):
         '''

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -330,10 +330,10 @@ class NamespaceCatalog:
     @docval({'name': 'namespace', 'type': str, 'doc': 'the name of the namespace containing the data_type'},
             {'name': 'data_type', 'type': (str, type), 'doc': 'the data_type to check'},
             {'name': 'parent_data_type', 'type': (str, type), 'doc': 'the potential parent data_type'},
-            returns="a tuple with the type hierarchy", rtype=tuple)
+            returns="True if *data_type* is a sub `data_type` of *parent_data_type*, False otherwise", rtype=bool)
     def is_sub_data_type(self, **kwargs):
         '''
-        Return True if *data_type* is a sub `data_type` of *parent_data_type*, False otherwise
+        Return whether or not *data_type* is a sub `data_type` of *parent_data_type*
         '''
         ns, dt, parent_dt = getargs('namespace', 'data_type', 'parent_data_type', kwargs)
         spec_ns = self.__namespaces.get(ns)

--- a/tests/unit/common/test_multi.py
+++ b/tests/unit/common/test_multi.py
@@ -3,7 +3,7 @@ from hdmf.common import SimpleMultiContainer
 from hdmf.testing import TestCase, H5RoundTripMixin
 
 
-class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
+class SimpleMultiContainerRoundTrip(H5RoundTripMixin, TestCase):
 
     def setUpContainer(self):
         containers = [

--- a/tests/unit/common/test_multi.py
+++ b/tests/unit/common/test_multi.py
@@ -1,52 +1,16 @@
-from hdmf.common import DynamicTable, VectorData, \
-    DynamicTableRegion, SimpleMultiContainer
+from hdmf.container import Container, Data
+from hdmf.common import SimpleMultiContainer
 from hdmf.testing import TestCase, H5RoundTripMixin
 
 
 class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
 
-    def make_tables(self):
-        self.spec2 = [
-            {'name': 'qux', 'description': 'qux column'},
-            {'name': 'quz', 'description': 'quz column'},
-        ]
-        self.data2 = [
-            ['qux_1', 'qux_2'],
-            ['quz_1', 'quz_2'],
-        ]
-
-        target_columns = [
-            VectorData(name=s['name'], description=s['description'], data=d)
-            for s, d in zip(self.spec2, self.data2)
-        ]
-        target_table = DynamicTable("target_table", 'example table to target with a DynamicTableRegion',
-                                    columns=target_columns)
-
-        self.spec1 = [
-            {'name': 'foo', 'description': 'foo column'},
-            {'name': 'bar', 'description': 'bar column'},
-            {'name': 'baz', 'description': 'baz column'},
-            {'name': 'dtr', 'description': 'DTR'},
-        ]
-        self.data1 = [
-            [1, 2, 3, 4, 5],
-            [10.0, 20.0, 30.0, 40.0, 50.0],
-            ['cat', 'dog', 'bird', 'fish', 'lizard']
-        ]
-        columns = [
-            VectorData(name=s['name'], description=s['description'], data=d)
-            for s, d in zip(self.spec1, self.data1)
-        ]
-        columns.append(DynamicTableRegion(name='dtr', description='example DynamicTableRegion',
-                                          data=[0, 1, 1, 0, 1], table=target_table))
-        table = DynamicTable("table_with_dtr", 'a test table that has a DynamicTableRegion', columns=columns)
-        vdata = VectorData('vector_data', 'a test Data object', data=[-1, -2, -3, -4, -5])
-        return table, target_table, vdata
-
-    def setUp(self):
-        self.table, self.target_table, self.vdata = self.make_tables()
-        super().setUp()
-
     def setUpContainer(self):
-        multi_container = SimpleMultiContainer('multi', [self.table, self.target_table, self.vdata])
+        containers = [
+            Container('container1'),
+            Container('container2'),
+            Data('data1', [0, 1, 2, 3, 4]),
+            Data('data2', [0.0, 1.0, 2.0, 3.0, 4.0]),
+        ]
+        multi_container = SimpleMultiContainer('multi', containers)
         return multi_container

--- a/tests/unit/common/test_multi.py
+++ b/tests/unit/common/test_multi.py
@@ -50,6 +50,3 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
     def setUpContainer(self):
         multi_container = SimpleMultiContainer('multi', [self.table, self.target_table, self.vdata])
         return multi_container
-
-    def setUpExtras(self):
-        return [self.target_table]

--- a/tests/unit/common/test_multi.py
+++ b/tests/unit/common/test_multi.py
@@ -1,0 +1,55 @@
+from hdmf.common import DynamicTable, VectorData, \
+    DynamicTableRegion, SimpleMultiContainer
+from hdmf.testing import TestCase, H5RoundTripMixin
+
+
+class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
+
+    def make_tables(self):
+        self.spec2 = [
+            {'name': 'qux', 'description': 'qux column'},
+            {'name': 'quz', 'description': 'quz column'},
+        ]
+        self.data2 = [
+            ['qux_1', 'qux_2'],
+            ['quz_1', 'quz_2'],
+        ]
+
+        target_columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec2, self.data2)
+        ]
+        target_table = DynamicTable("target_table", 'example table to target with a DynamicTableRegion',
+                                    columns=target_columns)
+
+        self.spec1 = [
+            {'name': 'foo', 'description': 'foo column'},
+            {'name': 'bar', 'description': 'bar column'},
+            {'name': 'baz', 'description': 'baz column'},
+            {'name': 'dtr', 'description': 'DTR'},
+        ]
+        self.data1 = [
+            [1, 2, 3, 4, 5],
+            [10.0, 20.0, 30.0, 40.0, 50.0],
+            ['cat', 'dog', 'bird', 'fish', 'lizard']
+        ]
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec1, self.data1)
+        ]
+        columns.append(DynamicTableRegion(name='dtr', description='example DynamicTableRegion',
+                                          data=[0, 1, 1, 0, 1], table=target_table))
+        table = DynamicTable("table_with_dtr", 'a test table that has a DynamicTableRegion', columns=columns)
+        vdata = VectorData('vector_data', 'a test Data object', data=[-1, -2, -3, -4, -5])
+        return table, target_table, vdata
+
+    def setUp(self):
+        self.table, self.target_table, self.vdata = self.make_tables()
+        super().setUp()
+
+    def setUpContainer(self):
+        multi_container = SimpleMultiContainer('multi', [self.table, self.target_table, self.vdata])
+        return multi_container
+
+    def setUpExtras(self):
+        return [self.target_table]

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -741,15 +741,16 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         data = [[1, 10.0, 'cat', 0, 'qux_1', 'quz_1'],
                 [2, 20.0, 'dog', 1, 'qux_2', 'quz_2']]
         exp = pd.DataFrame(data=data, columns=columns, index=pd.Series(name='id', data=[0, 1]))
-        pd.testing.assert_frame_equal(rec, exp)
+        pd.testing.assert_frame_equal(rec, exp, check_dtype=False)
 
     def _assert_one_elem_df(self, rec):
         columns = ['foo', 'bar', 'baz', 'dtr_id', 'dtr_qux', 'dtr_quz']
         data = [[1, 10.0, 'cat', 0, 'qux_1', 'quz_1']]
         exp = pd.DataFrame(data=data, columns=columns, index=pd.Series(name='id', data=[0]))
-        pd.testing.assert_frame_equal(rec, exp)
+        pd.testing.assert_frame_equal(rec, exp, check_dtype=False)
 
-    ### tests DynamicTableRegion.__getitem__
+    #####################
+    # tests DynamicTableRegion.__getitem__
     def test_getitem_int(self):
         rec = self._getitem(0)
         self._assert_one_elem_df(rec)
@@ -762,7 +763,8 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         rec = self._getitem(slice(0, 2, None))
         self._assert_two_elem_df(rec)
 
-    ### tests DynamicTableRegion.get, return a DataFrame
+    #####################
+    # tests DynamicTableRegion.get, return a DataFrame
     def test_get_int(self):
         rec = self._get(0)
         self._assert_one_elem_df(rec)
@@ -775,7 +777,8 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         rec = self._get(slice(0, 2, None))
         self._assert_two_elem_df(rec)
 
-    ### tests DynamicTableRegion.get, DO NOT return a DataFrame
+    #####################
+    # tests DynamicTableRegion.get, DO NOT return a DataFrame
     def test_get_nodf_int(self):
         rec = self._get_nodf(0)
         exp = [0, 1, 10.0, 'cat', [0, 'qux_1', 'quz_1']]

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -729,11 +729,12 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         return table[arg]
 
     def test_getitem_oor(self):
-        with self.assertRaisesRegex(IndexError, 'Row index 12 out of range'):
+        msg = 'Row index 12 out of range for DynamicTable \'table_with_dtr\' (length 5).'
+        with self.assertRaisesWith(IndexError, msg):
             self._getitem(12)
 
     def test_getitem_badcol(self):
-        with self.assertRaisesRegex(KeyError, 'boo'):
+        with self.assertRaisesWith(KeyError, '\'boo\''):
             self._getitem('boo')
 
     def _assert_two_elem_df(self, rec):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -736,48 +736,46 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         with self.assertRaisesRegex(KeyError, 'boo'):
             self._getitem('boo')
 
+    def _assert_two_elem_df(self, rec):
+        columns = ['foo', 'bar', 'baz', 'dtr_id', 'dtr_qux', 'dtr_quz']
+        data = [[1, 10.0, 'cat', 0, 'qux_1', 'quz_1'],
+                [2, 20.0, 'dog', 1, 'qux_2', 'quz_2']]
+        exp = pd.DataFrame(data=data, columns=columns, index=pd.Series(name='id', data=[0, 1]))
+        pd.testing.assert_frame_equal(rec, exp)
+
+    def _assert_one_elem_df(self, rec):
+        columns = ['foo', 'bar', 'baz', 'dtr_id', 'dtr_qux', 'dtr_quz']
+        data = [[1, 10.0, 'cat', 0, 'qux_1', 'quz_1']]
+        exp = pd.DataFrame(data=data, columns=columns, index=pd.Series(name='id', data=[0]))
+        pd.testing.assert_frame_equal(rec, exp)
+
+    ### tests DynamicTableRegion.__getitem__
     def test_getitem_int(self):
         rec = self._getitem(0)
-        data = {'foo': 1, 'bar': 10.0, 'baz': 'cat',
-                'dtr_id': 0, 'dtr_qux': 'qux_1', 'dtr_quz': 'quz_1'}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_one_elem_df(rec)
 
     def test_getitem_list(self):
         rec = self._getitem([0, 1])
-        data = {'foo': [1, 2], 'bar': [10.0, 20.0], 'baz': ['cat', 'dog'],
-                'dtr_id': [0, 1], 'dtr_qux': ['qux_1', 'qux_2'], 'dtr_quz': ['quz_1', 'quz_2']}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0, 1]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_two_elem_df(rec)
 
     def test_getitem_slice(self):
         rec = self._getitem(slice(0, 2, None))
-        data = {'foo': [1, 2], 'bar': [10.0, 20.0], 'baz': ['cat', 'dog'],
-                'dtr_id': [0, 1], 'dtr_qux': ['qux_1', 'qux_2'], 'dtr_quz': ['quz_1', 'quz_2']}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0, 1]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_two_elem_df(rec)
 
+    ### tests DynamicTableRegion.get, return a DataFrame
     def test_get_int(self):
         rec = self._get(0)
-        data = {'foo': 1, 'bar': 10.0, 'baz': 'cat',
-                'dtr_id': 0, 'dtr_qux': 'qux_1', 'dtr_quz': 'quz_1'}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_one_elem_df(rec)
 
     def test_get_list(self):
         rec = self._get([0, 1])
-        data = {'foo': [1, 2], 'bar': [10.0, 20.0], 'baz': ['cat', 'dog'],
-                'dtr_id': [0, 1], 'dtr_qux': ['qux_1', 'qux_2'], 'dtr_quz': ['quz_1', 'quz_2']}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0, 1]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_two_elem_df(rec)
 
     def test_get_slice(self):
         rec = self._get(slice(0, 2, None))
-        data = {'foo': [1, 2], 'bar': [10.0, 20.0], 'baz': ['cat', 'dog'],
-                'dtr_id': [0, 1], 'dtr_qux': ['qux_1', 'qux_2'], 'dtr_quz': ['quz_1', 'quz_2']}
-        exp = pd.DataFrame(data=data, index=pd.Series(name='id', data=[0, 1]))
-        pd.testing.assert_frame_equal(rec, exp)
+        self._assert_two_elem_df(rec)
 
+    ### tests DynamicTableRegion.get, DO NOT return a DataFrame
     def test_get_nodf_int(self):
         rec = self._get_nodf(0)
         exp = [0, 1, 10.0, 'cat', [0, 'qux_1', 'quz_1']]

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,6 +1,6 @@
 import unittest
 from hdmf.common import DynamicTable, VectorData, VectorIndex, ElementIdentifiers, \
-    DynamicTableRegion, VocabData, get_manager
+    DynamicTableRegion, VocabData, get_manager, SimpleMultiContainer
 from hdmf.testing import TestCase, H5RoundTripMixin
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 
@@ -664,6 +664,57 @@ class TestDynamicTableRegion(TestCase):
 """
         expected = expected % (id(dynamic_table_region), id(table))
         self.assertEqual(str(dynamic_table_region), expected)
+
+
+class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
+
+    def make_tables(self):
+        self.spec2 = [
+            {'name': 'qux', 'description': 'qux column'},
+            {'name': 'quz', 'description': 'quz column'},
+        ]
+        self.data2 = [
+            ['qux_1', 'qux_2'],
+            ['quz_1', 'quz_2'],
+        ]
+
+        target_columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec2, self.data2)
+        ]
+        target_table = DynamicTable("target_table", 'example table to target with a DynamicTableRegion',
+                                    columns=target_columns)
+
+        self.spec1 = [
+            {'name': 'foo', 'description': 'foo column'},
+            {'name': 'bar', 'description': 'bar column'},
+            {'name': 'baz', 'description': 'baz column'},
+            {'name': 'dtr', 'description': 'DTR'},
+        ]
+        self.data1 = [
+            [1, 2, 3, 4, 5],
+            [10.0, 20.0, 30.0, 40.0, 50.0],
+            ['cat', 'dog', 'bird', 'fish', 'lizard']
+        ]
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec1, self.data1)
+        ]
+        columns.append(DynamicTableRegion(name='dtr', description='example DynamicTableRegion',
+                                          data=[0, 1, 1, 0, 1], table=target_table))
+        table = DynamicTable("table_with_dtr", 'a test table that has a DynamicTableRegion', columns=columns)
+        return table, target_table
+
+    def setUp(self):
+        self.table, self.target_table = self.make_tables()
+        super().setUp()
+
+    def setUpContainer(self):
+        multi_container = SimpleMultiContainer('multi', [self.table, self.target_table])
+        return multi_container
+
+    def setUpExtras(self):
+        return [self.target_table]
 
 
 class TestElementIdentifiers(TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -713,9 +713,6 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         multi_container = SimpleMultiContainer('multi', [self.table, self.target_table])
         return multi_container
 
-    def setUpExtras(self):
-        return [self.target_table]
-
 
 class TestElementIdentifiers(TestCase):
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -378,6 +378,32 @@ class TestAbstractContainerFieldsConf(TestCase):
             class NamedFieldsChild(NamedFields):
                 __fields__ = ({'name': 'field1', 'settable': True}, )
 
+    def test_mult_inheritance_base_mixin(self):
+        class NamedFields(AbstractContainer):
+            __fields__ = ({'name': 'field1', 'doc': 'field1 doc', 'settable': False}, )
+
+        class BlankMixin:
+            pass
+
+        class NamedFieldsChild(NamedFields, BlankMixin):
+            __fields__ = ({'name': 'field2'}, )
+
+        self.assertTupleEqual(NamedFieldsChild.__fields__, ('field1', 'field2'))
+        self.assertIs(NamedFieldsChild._get_fields(), NamedFieldsChild.__fields__)
+
+    def test_mult_inheritance_base_container(self):
+        class NamedFields(AbstractContainer):
+            __fields__ = ({'name': 'field1', 'doc': 'field1 doc', 'settable': False}, )
+
+        class BlankMixin:
+            pass
+
+        class NamedFieldsChild(BlankMixin, NamedFields):
+            __fields__ = ({'name': 'field2'}, )
+
+        self.assertTupleEqual(NamedFieldsChild.__fields__, ('field1', 'field2'))
+        self.assertIs(NamedFieldsChild._get_fields(), NamedFieldsChild.__fields__)
+
 
 class TestContainerFieldsConf(TestCase):
 


### PR DESCRIPTION
## Motivation

Fix DynamicTableRegion and add SimpleMultiContainer 

## How to test the behavior?
```python
from hdmf.common import SimpleMultiContainer
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
