### PR TITLE
Support pathlib paths in HDMFIO/HDF5IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add capability to add a row to a column after IO. @bendichter (#426)
 - Add method `hdmf.utils.get_docval_macro` to get a tuple of the current values for a docval_macro, e.g., 'array_data'  
   and 'scalar_data'. @rly (#456)
+- Support `pathlib.Path` paths in `HDMFIO.__init__`, `HDF5IO.__init__`, and `HDF5IO.load_namespaces`. @dsleiter (#439)
 
 ### Internal improvements
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1,6 +1,7 @@
 from collections import deque
 import numpy as np
 import os.path
+from pathlib import Path
 from functools import partial
 from h5py import File, Group, Dataset, special_dtype, SoftLink, ExternalLink, Reference, RegionReference, check_dtype
 import logging
@@ -29,7 +30,7 @@ H5_REGREF = special_dtype(ref=RegionReference)
 
 class HDF5IO(HDMFIO):
 
-    @docval({'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
+    @docval({'name': 'path', 'type': (str, Path), 'doc': 'the path to the HDF5 file'},
             {'name': 'manager', 'type': (TypeMap, BuildManager),
              'doc': 'the BuildManager or a TypeMap to construct a BuildManager to use for I/O', 'default': None},
             {'name': 'mode', 'type': str,
@@ -44,6 +45,9 @@ class HDF5IO(HDMFIO):
         """
         self.logger = logging.getLogger('%s.%s' % (self.__class__.__module__, self.__class__.__qualname__))
         path, manager, mode, comm, file_obj = popargs('path', 'manager', 'mode', 'comm', 'file', kwargs)
+
+        if isinstance(path, Path):
+            path = str(path)
 
         if file_obj is not None and os.path.abspath(file_obj.filename) != os.path.abspath(path):
             msg = 'You argued %s as this object\'s path, ' % path
@@ -86,7 +90,7 @@ class HDF5IO(HDMFIO):
     @classmethod
     @docval({'name': 'namespace_catalog', 'type': (NamespaceCatalog, TypeMap),
              'doc': 'the NamespaceCatalog or TypeMap to load namespaces into'},
-            {'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file', 'default': None},
+            {'name': 'path', 'type': (str, Path), 'doc': 'the path to the HDF5 file', 'default': None},
             {'name': 'namespaces', 'type': list, 'doc': 'the namespaces to load', 'default': None},
             {'name': 'file', 'type': File, 'doc': 'a pre-existing h5py.File object', 'default': None},
             returns="dict with the loaded namespaces", rtype=dict)
@@ -99,6 +103,9 @@ class HDF5IO(HDMFIO):
         """
         namespace_catalog, path, namespaces, file_obj = popargs('namespace_catalog', 'path', 'namespaces', 'file',
                                                                 kwargs)
+
+        if isinstance(path, Path):
+            path = str(path)
 
         if path is None and file_obj is None:
             raise ValueError("Either the 'path' or 'file' argument must be supplied to load_namespaces.")

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from pathlib import Path
 
 from ..build import BuildManager, GroupBuilder
 from ..utils import docval, getargs, popargs
@@ -8,12 +9,16 @@ from ..container import Container
 class HDMFIO(metaclass=ABCMeta):
     @docval({'name': 'manager', 'type': BuildManager,
              'doc': 'the BuildManager to use for I/O', 'default': None},
-            {"name": "source", "type": str,
+            {"name": "source", "type": (str, Path),
              "doc": "the source of container being built i.e. file path", 'default': None})
     def __init__(self, **kwargs):
-        self.__manager = getargs('manager', kwargs)
+        manager, source = getargs('manager', 'source', kwargs)
+        if isinstance(source, Path):
+            source = str(source)
+
+        self.__manager = manager
         self.__built = dict()
-        self.__source = getargs('source', kwargs)
+        self.__source = source
         self.open()
 
     @property


### PR DESCRIPTION
## Motivation

Fix #439: support `pathlib.Path` paths when creating `HDMFIO` and `HDF5IO` objects.

This will unblock the development of this issue to use pathlib paths in `pynwb.NWBHDF5IO`: https://github.com/NeurodataWithoutBorders/pynwb/issues/1303

This is my first contribution to `hdmf`, and I'm very open to any suggestions or comments on my PR. I'm excited to be contributing!

The solution provided here is intended to be a minimal change while still fulfilling the requirements of the issue. I initially wanted to support pathlib paths throughout all of the inner workings of `HDF5IO` and `HDMFIO`, but decided against that for a number of reasons:
* it would require a large number of changes across many modules to support pathlib paths alongside path strings in all use cases
* while `h5py.File` accepts pathlib paths, `h5py.File.filename` (which is used in many locations) is always of type `str`, we can't easily use pathlib paths consistently within backend objects
* allowing `HDMFIO.source` to be a `pathlib.Path` is potentially a breaking change
* while python 3.6+ allows usage of `os.path` functions with `pathlib.Path` objects, python 3.5 does not. So to support python 3.5+ we would need to have two sets of logic: with `os.path` for path strings, and with `pathlib.Path` functions for pathlib strings (unless we were to only use pathlib internally and convert path string parameters to `Path` objects inside functions).
* it is not clear that all of these changes would bring significant value

However, if the intention of this issue was to support pathlib paths broadly within `HDMFIO` and `HDF5IO` (as opposed to the simplest use cases when reading and writing files), then let's discuss in the comments the best way to approach that goal and I can take another shot at it.

## How to test the behavior?
```
from pathlib import Path
from hdmf.backends.hdf5 import HDF5IO

filepath = Path('foo.hdf5')
with HDF5IO(filepath, mode='w') as io:
    pass
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
