### PR TITLE
Drop 3.5 and start testing for 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,19 +126,9 @@ jobs:
       - run:
           <<: *run-style-check
 
-  python35:
-    docker:
-      - image: circleci/python:3.5.9-stretch
-    environment:
-     - TEST_TOX_ENV: "py35"
-     - COVERAGE_TOX_ENV: ""
-     - BUILD_TOX_ENV: "build-py35"
-     - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
-    <<: *ci-steps
-
   python36:
     docker:
-      - image: circleci/python:3.6.10-stretch
+      - image: circleci/python:3.6.12-stretch
     environment:
      - TEST_TOX_ENV: "py36"
      - COVERAGE_TOX_ENV: ""
@@ -148,7 +138,7 @@ jobs:
 
   python37:
     docker:
-      - image: circleci/python:3.7.6-stretch
+      - image: circleci/python:3.7.9-stretch
     environment:
      - TEST_TOX_ENV: "py37"
      - COVERAGE_TOX_ENV: ""
@@ -158,7 +148,7 @@ jobs:
 
   python38:
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: circleci/python:3.8.6-slim-buster
     environment:
      - TEST_TOX_ENV: "py38"
      - COVERAGE_TOX_ENV: "coverage"
@@ -167,29 +157,30 @@ jobs:
      - UPLOAD_WHEELS: "true"
     <<: *ci-steps
 
-  python35-min-req:
+  python39:
     docker:
-      - image: circleci/python:3.5.9-stretch
+      - image: circleci/python:3.9.0-buster
     environment:
-     - TEST_TOX_ENV: "py35-min-req"
+     - TEST_TOX_ENV: "py39"
      - COVERAGE_TOX_ENV: ""
-     - BUILD_TOX_ENV: "build-py35-min-req"
-     - TEST_WHEELINSTALL_ENV: "wheelinstall-py35-min-req"
+     - BUILD_TOX_ENV: "build-py39"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py39"
     <<: *ci-steps
 
-  miniconda35:
+
+  python36-min-req:
     docker:
-      - image: continuumio/miniconda3:4.3.27p0
+      - image: circleci/python:3.6.12-stretch
     environment:
-      - CONDA_PYTHON_VER: "3.5"
-      - TEST_TOX_ENV: "py35"
-      - BUILD_TOX_ENV: "build-py35"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
-    <<: *conda-steps
+     - TEST_TOX_ENV: "py36-min-req"
+     - COVERAGE_TOX_ENV: ""
+     - BUILD_TOX_ENV: "build-py36-min-req"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py36-min-req"
+    <<: *ci-steps
 
   miniconda36:
     docker:
-      - image: continuumio/miniconda3:4.7.12
+      - image: continuumio/miniconda3:4.8.2
     environment:
       - CONDA_PYTHON_VER: "3.6"
       - TEST_TOX_ENV: "py36"
@@ -199,7 +190,7 @@ jobs:
 
   miniconda37:
     docker:
-      - image: continuumio/miniconda3:4.7.12
+      - image: continuumio/miniconda3:4.8.2
     environment:
       - CONDA_PYTHON_VER: "3.7"
       - TEST_TOX_ENV: "py37"
@@ -209,7 +200,7 @@ jobs:
 
   miniconda38:
     docker:
-      - image: continuumio/miniconda3:4.7.12
+      - image: continuumio/miniconda3:4.8.2
     environment:
       - CONDA_PYTHON_VER: "3.8"
       - TEST_TOX_ENV: "py38"
@@ -217,12 +208,15 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py38"
     <<: *conda-steps
 
-  gallery35:
+  miniconda39:
     docker:
-      - image: circleci/python:3.5.9-stretch
+      - image: continuumio/miniconda3:4.8.2
     environment:
-     - TEST_TOX_ENV: "gallery-py35"
-    <<: *gallery-steps
+      - CONDA_PYTHON_VER: "3.9"
+      - TEST_TOX_ENV: "py39"
+      - BUILD_TOX_ENV: "build-py39"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall-py39"
+    <<: *conda-steps
 
   gallery36:
     docker:
@@ -245,11 +239,18 @@ jobs:
      - TEST_TOX_ENV: "gallery-py38"
     <<: *gallery-steps
 
-  gallery35-min-req:
+  gallery39:
     docker:
-      - image: circleci/python:3.5.9-stretch
+      - image: circleci/python:3.9.0-buster
     environment:
-     - TEST_TOX_ENV: "gallery-py35-min-req"
+     - TEST_TOX_ENV: "gallery-py39"
+    <<: *gallery-steps
+
+  gallery36-min-req:
+    docker:
+      - image: circleci/python:3.6.10-stretch
+    environment:
+     - TEST_TOX_ENV: "gallery-py36-min-req"
     <<: *gallery-steps
 
   deploy-dev:
@@ -339,17 +340,15 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
-      - python35:
-          <<: *no_filters
       - python36:
           <<: *no_filters
       - python37:
           <<: *no_filters
       - python38:
           <<: *no_filters
-      - python35-min-req:
+      - python39:
           <<: *no_filters
-      - miniconda35:
+      - python36-min-req:
           <<: *no_filters
       - miniconda36:
           <<: *no_filters
@@ -357,7 +356,7 @@ workflows:
           <<: *no_filters
       - miniconda38:
           <<: *no_filters
-      - gallery35:
+      - miniconda39:
           <<: *no_filters
       - gallery36:
           <<: *no_filters
@@ -365,25 +364,27 @@ workflows:
           <<: *no_filters
       - gallery38:
           <<: *no_filters
-      - gallery35-min-req:
+      - gallery39:
+          <<: *no_filters
+      - gallery36-min-req:
           <<: *no_filters
       - deploy-dev:
           requires:
             - flake8
-            - python35
             - python36
             - python37
             - python38
-            - python35-min-req
-            - miniconda35
+            - python39
+            - python36-min-req
             - miniconda36
             - miniconda37
             - miniconda38
-            - gallery35
+            - miniconda39
             - gallery36
             - gallery37
             - gallery38
-            - gallery35-min-req
+            - gallery39
+            - gallery36-min-req
           filters:
             tags:
               ignore:
@@ -395,20 +396,20 @@ workflows:
       - deploy-release:
           requires:
             - flake8
-            - python35
             - python36
             - python37
             - python38
-            - python35-min-req
-            - miniconda35
+            - python39
+            - python36-min-req
             - miniconda36
             - miniconda37
             - miniconda38
-            - gallery35
+            - miniconda39
             - gallery36
             - gallery37
             - gallery38
-            - gallery35-min-req
+            - gallery39
+            - gallery36-min-req
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
 
   python38:
     docker:
-      - image: circleci/python:3.8.6-slim-buster
+      - image: circleci/python:3.8.6-buster
     environment:
      - TEST_TOX_ENV: "py38"
      - COVERAGE_TOX_ENV: "coverage"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,14 @@ jobs:
 
   strategy:
     matrix:
+      macOS-py3.9:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.9'
+        testToxEnv: 'py39'
+        coverageToxEnv: ''
+        buildToxEnv: 'build-py39'
+        testWheelInstallEnv: 'wheelinstall-py39'
+
       macOS-py3.8:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
@@ -32,21 +40,21 @@ jobs:
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
-      macOS-py3.5:
+      macOS-py3.6-min-req:
         imageName: 'macos-10.15'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
         coverageToxEnv: ''
-        buildToxEnv: 'build-py35'
-        testWheelInstallEnv: 'wheelinstall-py35'
+        buildToxEnv: 'build-py36-min-req'
+        testWheelInstallEnv: 'wheelinstall-py36-min-req'
 
-      macOS-py3.5-min-req:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35-min-req'
+      Windows-py3.9:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.9'
+        testToxEnv: 'py39'
         coverageToxEnv: ''
-        buildToxEnv: 'build-py35-min-req'
-        testWheelInstallEnv: 'wheelinstall-py35-min-req'
+        buildToxEnv: 'build-py39'
+        testWheelInstallEnv: 'wheelinstall-py39'
 
       Windows-py3.8:
         imageName: 'vs2017-win2016'
@@ -72,21 +80,13 @@ jobs:
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
-      Windows-py3.5:
+      Windows-py3.6-min-req:
         imageName: 'vs2017-win2016'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
         coverageToxEnv: ''
-        buildToxEnv: 'build-py35'
-        testWheelInstallEnv: 'wheelinstall-py35'
-
-      Windows-py3.5-min-req:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35-min-req'
-        coverageToxEnv: ''
-        buildToxEnv: 'build-py35-min-req'
-        testWheelInstallEnv: 'wheelinstall-py35-min-req'
+        buildToxEnv: 'build-py36-min-req'
+        testWheelInstallEnv: 'wheelinstall-py36-min-req'
 
   pool:
     vmImage: $(imageName)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 
 [testenv]
 usedevelop = True
@@ -27,9 +27,9 @@ commands =
     python -m coverage run test.py -u
     coverage html -d tests/coverage/htmlcov
 
-# Test with python 3.5, pinned dev reqs, and minimum run requirements
-[testenv:py35-min-req]
-basepython = python3.5
+# Test with python 3.6, pinned dev reqs, and minimum run requirements
+[testenv:py36-min-req]
+basepython = python3.6
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -40,10 +40,6 @@ commands = {[testenv]commands}
 commands =
     python setup.py sdist
     python setup.py bdist_wheel
-
-[testenv:build-py35]
-basepython = python3.5
-commands = {[testenv:build]commands}
 
 [testenv:build-py36]
 basepython = python3.6
@@ -57,8 +53,12 @@ commands = {[testenv:build]commands}
 basepython = python3.8
 commands = {[testenv:build]commands}
 
-[testenv:build-py35-min-req]
-basepython = python3.5
+[testenv:build-py39]
+basepython = python3.9
+commands = {[testenv:build]commands}
+
+[testenv:build-py36-min-req]
+basepython = python3.6
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -74,10 +74,6 @@ commands =
     codecov
 
 # Envs that will test installation from a wheel
-[testenv:wheelinstall-py35]
-deps = null
-commands = python -c "import hdmf"
-
 [testenv:wheelinstall-py36]
 deps = null
 commands = python -c "import hdmf"
@@ -90,7 +86,11 @@ commands = python -c "import hdmf"
 deps = null
 commands = python -c "import hdmf"
 
-[testenv:wheelinstall-py35-min-req]
+[testenv:wheelinstall-py39]
+deps = null
+commands = python -c "import hdmf"
+
+[testenv:wheelinstall-py36-min-req]
 deps = null
 commands = python -c "import hdmf"
 
@@ -107,11 +107,6 @@ deps =
 commands =
     python test.py --example
 
-[testenv:gallery-py35]
-basepython = python3.5
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
 [testenv:gallery-py36]
 basepython = python3.6
 deps = {[testenv:gallery]deps}
@@ -127,8 +122,13 @@ basepython = python3.8
 deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
-[testenv:gallery-py35-min-req]
-basepython = python3.5
+[testenv:gallery-py39]
+basepython = python3.9
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+[testenv:gallery-py36-min-req]
+basepython = python3.6
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt


### PR DESCRIPTION
## Motivation

Python 3.5 is at end-of-life. 3.9 was released a month ago.

Given that 3.9 is so young, it might be impossible at this moment to get 3.9 tests to pass. 