### PR TITLE
Support passing GroupSpec/DatasetSpec for LinkSpec target_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@
 - Support `pathlib.Path` paths in `HDMFIO.__init__`, `HDF5IO.__init__`, and `HDF5IO.load_namespaces`. @dsleiter (#439)
 - Use hdmf-common-schema 1.2.1. See https://hdmf-common-schema.readthedocs.io/en/latest/format_release_notes.html for details.
 - Block usage of h5py 3+. h5py>=2.9, <3 is supported. @rly (#461)
-- Block usage of numpy>=1.19.4 due to a known issue with numpy on some Windows 10 systems. numpy>1.16, <1.19.4 is supported.  @rly (#461)
+- Block usage of numpy>=1.19.4 due to a known issue with numpy on some Windows 10 systems. numpy>1.16, <1.19.4 is supported.
+  @rly (#461)
+- Allow passing `GroupSpec` and `DatasetSpec` objects for the 'target_type' argument of `LinkSpec.__init__(...)`.
+  @rly (#467)
 
 ### Internal improvements
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -764,7 +764,7 @@ class DatasetSpec(BaseStorageSpec):
 
 _link_args = [
     {'name': 'doc', 'type': str, 'doc': 'a description about what this link represents'},
-    {'name': _target_type_key, 'type': str, 'doc': 'the target type GroupSpec or DatasetSpec'},
+    {'name': _target_type_key, 'type': (str, BaseStorageSpec), 'doc': 'the target type GroupSpec or DatasetSpec'},
     {'name': 'quantity', 'type': (str, int), 'doc': 'the required number of allowed instance', 'default': 1},
     {'name': 'name', 'type': str, 'doc': 'the name of this link', 'default': None}
 ]
@@ -776,7 +776,14 @@ class LinkSpec(Spec):
     def __init__(self, **kwargs):
         doc, target_type, name, quantity = popargs('doc', _target_type_key, 'name', 'quantity', kwargs)
         super().__init__(doc, name, **kwargs)
-        self[_target_type_key] = target_type
+        if isinstance(target_type, BaseStorageSpec):
+            if target_type.data_type_def is None:
+                msg = ("'%s' must be a string or a GroupSpec or DatasetSpec with a '%s' key."
+                       % (_target_type_key, target_type.def_key()))
+                raise ValueError(msg)
+            self[_target_type_key] = target_type.data_type_def
+        else:
+            self[_target_type_key] = target_type
         if quantity != 1:
             self['quantity'] = quantity
 

--- a/tests/unit/spec_tests/test_link_spec.py
+++ b/tests/unit/spec_tests/test_link_spec.py
@@ -1,0 +1,69 @@
+import json
+
+from hdmf.spec import GroupSpec, LinkSpec
+from hdmf.testing import TestCase
+
+
+class LinkSpecTests(TestCase):
+
+    def test_constructor(self):
+        spec = LinkSpec(
+            doc='A test link',
+            target_type='Group1',
+            quantity='+',
+            name='Link1',
+        )
+        self.assertEqual(spec.doc, 'A test link')
+        self.assertEqual(spec.target_type, 'Group1')
+        self.assertEqual(spec.data_type_inc, 'Group1')
+        self.assertEqual(spec.quantity, '+')
+        self.assertEqual(spec.name, 'Link1')
+        json.dumps(spec)
+
+    def test_constructor_target_spec_def(self):
+        group_spec_def = GroupSpec(
+            data_type_def='Group1',
+            doc='A test group',
+        )
+        spec = LinkSpec(
+            doc='A test link',
+            target_type=group_spec_def,
+        )
+        self.assertEqual(spec.target_type, 'Group1')
+        json.dumps(spec)
+
+    def test_constructor_target_spec_inc(self):
+        group_spec_inc = GroupSpec(
+            data_type_inc='Group1',
+            doc='A test group',
+        )
+        msg = "'target_type' must be a string or a GroupSpec or DatasetSpec with a 'data_type_def' key."
+        with self.assertRaisesWith(ValueError, msg):
+            LinkSpec(
+                doc='A test link',
+                target_type=group_spec_inc,
+            )
+
+    def test_constructor_defaults(self):
+        spec = LinkSpec(
+            doc='A test link',
+            target_type='Group1',
+        )
+        self.assertEqual(spec.quantity, 1)
+        self.assertIsNone(spec.name)
+        json.dumps(spec)
+
+    def test_required_is_many(self):
+        quantity_opts = ['?', 1, '*', '+']
+        is_required = [False, True, False, True]
+        is_many = [False, False, True, True]
+        for (quantity, req, many) in zip(quantity_opts, is_required, is_many):
+            with self.subTest(quantity=quantity):
+                spec = LinkSpec(
+                    doc='A test link',
+                    target_type='Group1',
+                    quantity=quantity,
+                    name='Link1',
+                )
+                self.assertEqual(spec.required, req)
+                self.assertEqual(spec.is_many(), many)


### PR DESCRIPTION
## Motivation

Fix #464, add missing tests for `LinkSpec`.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
