### PR TITLE
Remove outdated info about labels/milestones from contributing.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ assignees: ''
 
 ## Checklist
 
-- [ ] Have you ensured the feature or change was not already [reported](https://github.com/hdmf-dev/hdmf/issues) ?
+- [ ] Have you ensured the bug was not already [reported](https://github.com/hdmf-dev/hdmf/issues) ?
 - [ ] Have you included a brief and descriptive title?
 - [ ] Have you included a clear description of the problem you are trying to solve?
 - [ ] Have you included a minimal code snippet that reproduces the issue you are encountering?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)
 - Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
 - Add testing for Python 3.9 and using pre-release packages. @ajtritt, @rly (#459, #472)
+- Improve contributing guide. @rly (#474)
 
 ### Bug fixes
 - Fix development package dependency issues. @rly (#431)

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ Did you find a bug? or Do you intend to add a new feature or change an existing 
     * **clear description of the problem you are trying to solve**. Describing the use case is often more important than proposing a specific solution. By describing the use case and problem you are trying to solve gives the development team community a better understanding for the reasons of changes and enables others to suggest solutions.
     * **context** providing as much relevant information as possible and if available a **code sample** or an **executable test case** demonstrating the expected behavior and/or problem.
 
-* Be sure to select the appropriate labels (see :ref:`sec-issue-labels`) for your tickets so that they can be processed accordingly.
+* Be sure to select the appropriate label (bug report or feature request) for your tickets so that they can be processed accordingly.
 
 * HDMF is currently being developed primarily by staff at scientific research institutions and industry, most of which work on many different research projects. Please be patient, if our development team is not able to respond immediately to your issues. In particular issues that belong to later project milestones may not be reviewed or processed until work on that milestone begins.
 
@@ -77,33 +77,10 @@ From your local copy directory, use the following commands.
 
     * Ensure the PR description clearly describes the problem and solution.
     * Include the relevant issue number if applicable.
-    * Before submitting, please ensure that the code follows the standard coding style of the respective repository.
+    * Before submitting, please ensure that:
+      * The proposed changes include an addition to ``CHANGELOG.md`` describing your changes. To label the change with the PR number, you will have to first create the PR, then edit the ``CHANGELOG.md`` with the PR number, and push that change.
+      * The code follows our coding style. This can be checked running ``flake8`` from the source directory.
     * **NOTE:** Contributed branches will be removed by the development team after the merge is complete and should, hence, not be used after the pull request is complete.
-
-
-.. _sec-issue-labels:
-
-Issue Labels, Projects, and Milestones
---------------------------------------
-
-Labels
-^^^^^^
-
-Labels are used to describe the general scope of an issue, e.g., whether it describes a bug or feature request etc. Please review and select the appropriate labels for the respective Git repository:
-
-    * `HDMF issue labels  <https://github.com/hdmf-dev/hdmf/labels>`_
-
-Milestones
-^^^^^^^^^^
-
-Milestones are used to define the scope and general timeline for issues. Please review and select the appropriate milestones for the respective Git repository:
-
-    * `HDMF milestones <https://github.com/hdmf-dev/hdmf/milestones>`_
-
-Projects
-^^^^^^^^
-
-Projects are currently used mainly on the HDMF organization level and are only accessible to members of the organization. Projects are used to plan and organize developments across repositories. We currently do not use projects on the individual repository level, although that might change in the future.
 
 .. _sec-styleguides:
 
@@ -132,7 +109,7 @@ Python coding style is checked via ``flake8`` for automatic checking of PEP8 sty
 Endorsement
 -----------
 
-Please don’t take the fact that working with an organization (e.g., during a hackathon or via GitHub) as an endorsement of your work or your organization. It’s okay to say e.g., “We worked with XXXXX to advance science” but not e.g., “XXXXX supports our work on HDMF”.”
+Please do not take working with an organization (e.g., during a hackathon or via GitHub) as an endorsement of your work or your organization. It's okay to say e.g., “We worked with XXXXX to advance science” but not e.g., “XXXXX supports our work on HDMF”.”
 
 License and Copyright
 =======================
@@ -143,4 +120,4 @@ As indicated in the HDMF license: *“You are under no obligation whatsoever to 
 
 Contributors to the HDMF code base are expected to use a permissive, non-copyleft open source license. Typically 3-clause BSD is used, but any compatible license is allowed, the MIT and Apache 2.0 licenses being good alternative choices. The GPL and other copyleft licenses are not allowed due to the consternation it generates across many organizations.
 
-Also, make sure that you are permitted to contribute code. Some organizations, even academic organizations, have agreements in place that discuss IP ownership in detail (i.e., address IP rights and ownership that you create while under the employ of the organization). These are typically signed documents that you looked at on your first day of work and then promptly forgot. We don’t want contributed code to be yanked later due to IP issues.
+Also, make sure that you are permitted to contribute code. Some organizations, even academic organizations, have agreements in place that discuss IP ownership in detail (i.e., address IP rights and ownership that you create while under the employ of the organization). These are typically signed documents that you looked at on your first day of work and then promptly forgot. We don't want contributed code to be yanked later due to IP issues.


### PR DESCRIPTION
Non-admin contributors (those who would consult the contributing guide) 
cannot set labels or milestones on projects, so this information is not 
relevant to them.

Suggested by @dsleiter 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
