### PR TITLE
Improve validation error message for missing data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fix inheritance when non-`AbstractContainer` is base class. @rly (#444)
 - Fix use of `hdmf.testing.assertContainerEqual(...)` for `Data` objects. @rly (#445)
 - Add missing support for data conversion against spec dtypes "bytes" and "short". @rly (#456)
+- Clarify the validator error message when a named data type is missing. @dsleiter (#478)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/validate/errors.py
+++ b/src/hdmf/validate/errors.py
@@ -83,11 +83,15 @@ class MissingError(Error):
 class MissingDataType(Error):
     @docval({'name': 'name', 'type': str, 'doc': 'the name of the component that is erroneous'},
             {'name': 'data_type', 'type': str, 'doc': 'the missing data type'},
-            {'name': 'location', 'type': str, 'doc': 'the location of the error', 'default': None})
+            {'name': 'location', 'type': str, 'doc': 'the location of the error', 'default': None},
+            {'name': 'missing_dt_name', 'type': str, 'doc': 'the name of the missing data type', 'default': None})
     def __init__(self, **kwargs):
-        name, data_type = getargs('name', 'data_type', kwargs)
+        name, data_type, missing_dt_name = getargs('name', 'data_type', 'missing_dt_name', kwargs)
         self.__data_type = data_type
-        reason = "missing data type %s" % self.__data_type
+        if missing_dt_name is not None:
+            reason = "missing data type %s (%s)" % (self.__data_type, missing_dt_name)
+        else:
+            reason = "missing data type %s" % self.__data_type
         loc = getargs('location', kwargs)
         super().__init__(name, reason, location=loc)
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -460,7 +460,7 @@ class GroupValidator(BaseStorageValidator):
                         found = True
             if not found and self.__include_dts[dt].required:
                 ret.append(MissingDataType(self.get_spec_loc(self.spec), dt,
-                                           location=self.get_builder_loc(builder)))
+                                           location=self.get_builder_loc(builder), missing_dt_name=inc_name))
         it = chain(self.__dataset_validators.items(),
                    self.__group_validators.items())
         for name, validator in it:
@@ -472,7 +472,7 @@ class GroupValidator(BaseStorageValidator):
                 if sub_builder is None:
                     if inc_spec.required:
                         ret.append(MissingDataType(self.get_spec_loc(def_spec), def_spec.data_type_def,
-                                                   location=self.get_builder_loc(builder)))
+                                                   location=self.get_builder_loc(builder), missing_dt_name=name))
                 else:
                     ret.extend(validator.validate(sub_builder))
 

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -26,6 +26,14 @@ class ValidatorTestBase(TestCase, metaclass=ABCMeta):
     def getSpecs(self):
         pass
 
+    def assertValidationError(self, error, type_, name=None, reason=None):
+        """Assert that a validation Error matches expectations"""
+        self.assertIsInstance(error, type_)
+        if name is not None:
+            self.assertEqual(error.name, name)
+        if reason is not None:
+            self.assertEqual(error.reason, reason)
+
 
 class TestEmptySpec(ValidatorTestBase):
 
@@ -61,29 +69,23 @@ class TestBasicSpec(ValidatorTestBase):
         validator = self.vmap.get_validator('Bar')
         result = validator.validate(builder)
         self.assertEqual(len(result), 2)
-        self.assertIsInstance(result[0], MissingError)  # noqa: F405
-        self.assertEqual(result[0].name, 'Bar/attr1')
-        self.assertIsInstance(result[1], MissingError)  # noqa: F405
-        self.assertEqual(result[1].name, 'Bar/data')
+        self.assertValidationError(result[0], MissingError, name='Bar/attr1')  # noqa: F405
+        self.assertValidationError(result[1], MissingError, name='Bar/data')  # noqa: F405
 
     def test_invalid_incorrect_type_get_validator(self):
         builder = GroupBuilder('my_bar', attributes={'data_type': 'Bar', 'attr1': 10})
         validator = self.vmap.get_validator('Bar')
         result = validator.validate(builder)
         self.assertEqual(len(result), 2)
-        self.assertIsInstance(result[0], DtypeError)  # noqa: F405
-        self.assertEqual(result[0].name, 'Bar/attr1')
-        self.assertIsInstance(result[1], MissingError)  # noqa: F405
-        self.assertEqual(result[1].name, 'Bar/data')
+        self.assertValidationError(result[0], DtypeError, name='Bar/attr1')  # noqa: F405
+        self.assertValidationError(result[1], MissingError, name='Bar/data')  # noqa: F405
 
     def test_invalid_incorrect_type_validate(self):
         builder = GroupBuilder('my_bar', attributes={'data_type': 'Bar', 'attr1': 10})
         result = self.vmap.validate(builder)
         self.assertEqual(len(result), 2)
-        self.assertIsInstance(result[0], DtypeError)  # noqa: F405
-        self.assertEqual(result[0].name, 'Bar/attr1')
-        self.assertIsInstance(result[1], MissingError)  # noqa: F405
-        self.assertEqual(result[1].name, 'Bar/data')
+        self.assertValidationError(result[0], DtypeError, name='Bar/attr1')  # noqa: F405
+        self.assertValidationError(result[1], MissingError, name='Bar/data')  # noqa: F405
 
     def test_valid(self):
         builder = GroupBuilder('my_bar',
@@ -130,8 +132,7 @@ class TestDateTimeInSpec(ValidatorTestBase):
         validator = self.vmap.get_validator('Bar')
         result = validator.validate(builder)
         self.assertEqual(len(result), 1)
-        self.assertIsInstance(result[0], DtypeError)  # noqa: F405
-        self.assertEqual(result[0].name, 'Bar/time')
+        self.assertValidationError(result[0], DtypeError, name='Bar/time')  # noqa: F405
 
     def test_invalid_isodatetime_array(self):
         builder = GroupBuilder('my_bar',
@@ -144,18 +145,17 @@ class TestDateTimeInSpec(ValidatorTestBase):
         validator = self.vmap.get_validator('Bar')
         result = validator.validate(builder)
         self.assertEqual(len(result), 1)
-        self.assertIsInstance(result[0], ExpectedArrayError)  # noqa: F405
-        self.assertEqual(result[0].name, 'Bar/time_array')
+        self.assertValidationError(result[0], ExpectedArrayError, name='Bar/time_array')  # noqa: F405
 
 
 class TestNestedTypes(ValidatorTestBase):
 
     def getSpecs(self):
+        baz = DatasetSpec('A dataset with a data type', 'int', data_type_def='Baz',
+                          attributes=[AttributeSpec('attr2', 'an example integer attribute', 'int')])
         bar = GroupSpec('A test group specification with a data type',
                         data_type_def='Bar',
-                        datasets=[DatasetSpec('an example dataset', 'int', name='data',
-                                              attributes=[AttributeSpec('attr2', 'an example integer attribute',
-                                                                        'int')])],
+                        datasets=[DatasetSpec('an example dataset', data_type_inc='Baz')],
                         attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
         foo = GroupSpec('A test group that contains a data type',
                         data_type_def='Foo',
@@ -163,17 +163,19 @@ class TestNestedTypes(ValidatorTestBase):
                         attributes=[AttributeSpec('foo_attr', 'a string attribute specified as text', 'text',
                                                   required=False)])
 
-        return (bar, foo)
+        return (bar, foo, baz)
 
-    def test_invalid_missing_req_group(self):
+    def test_invalid_missing_named_req_group(self):
+        """Test that a MissingDataType is returned when a required named nested data type is missing."""
         foo_builder = GroupBuilder('my_foo', attributes={'data_type': 'Foo',
                                                          'foo_attr': 'example Foo object'})
         results = self.vmap.validate(foo_builder)
-        self.assertIsInstance(results[0], MissingDataType)  # noqa: F405
-        self.assertEqual(results[0].name, 'Foo')
-        self.assertEqual(results[0].reason, 'missing data type Bar')
+        self.assertEqual(len(results), 1)
+        self.assertValidationError(results[0], MissingDataType, name='Foo',  # noqa: F405
+                                   reason='missing data type Bar (my_bar)')
 
     def test_invalid_wrong_name_req_type(self):
+        """Test that a MissingDataType is returned when a required nested data type is given the wrong name."""
         bar_builder = GroupBuilder('bad_bar_name',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
                                    datasets=[DatasetBuilder('data', 100, attributes={'attr2': 10})])
@@ -184,13 +186,28 @@ class TestNestedTypes(ValidatorTestBase):
 
         results = self.vmap.validate(foo_builder)
         self.assertEqual(len(results), 1)
-        self.assertIsInstance(results[0], MissingDataType)  # noqa: F405
+        self.assertValidationError(results[0], MissingDataType, name='Foo')   # noqa: F405
         self.assertEqual(results[0].data_type, 'Bar')
 
+    def test_invalid_missing_unnamed_req_group(self):
+        """Test that a MissingDataType is returned when a required unnamed nested data type is missing."""
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': 'a string attribute'})
+
+        foo_builder = GroupBuilder('my_foo',
+                                   attributes={'data_type': 'Foo', 'foo_attr': 'example Foo object'},
+                                   groups=[bar_builder])
+
+        results = self.vmap.validate(foo_builder)
+        self.assertEqual(len(results), 1)
+        self.assertValidationError(results[0], MissingDataType, name='Bar',  # noqa: F405
+                                   reason='missing data type Baz')
+
     def test_valid(self):
+        """Test that no errors are returned when nested data types are correctly built."""
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
-                                   datasets=[DatasetBuilder('data', 100, attributes={'attr2': 10})])
+                                   datasets=[DatasetBuilder('data', 100, attributes={'data_type': 'Baz', 'attr2': 10})])
 
         foo_builder = GroupBuilder('my_foo',
                                    attributes={'data_type': 'Foo', 'foo_attr': 'example Foo object'},
@@ -200,9 +217,10 @@ class TestNestedTypes(ValidatorTestBase):
         self.assertEqual(len(results), 0)
 
     def test_valid_wo_opt_attr(self):
+        """"Test that no errors are returned when an optional attribute is omitted from a group."""
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
-                                   datasets=[DatasetBuilder('data', 100, attributes={'attr2': 10})])
+                                   datasets=[DatasetBuilder('data', 100, attributes={'data_type': 'Baz', 'attr2': 10})])
         foo_builder = GroupBuilder('my_foo',
                                    attributes={'data_type': 'Foo'},
                                    groups=[bar_builder])


### PR DESCRIPTION
* Fix #284
* Add optional parameter `missing_dt_name` to validation error `MissingDataType`
* Add tests for bug fix
* Refactor `TestNestedTypes` slightly to reduce duplication and facilitate the new test

## Motivation

Fix #284 by improving the validation error message shown when a missing data type has a name.

## How to test the behavior?
```python
from hdmf.spec import GroupSpec, SpecCatalog, SpecNamespace
from hdmf.build import GroupBuilder
from hdmf.validate import ValidatorMap

def get_vmap(specs):
    spec_catalog = SpecCatalog()
    for spec in specs:
        spec_catalog.register_spec(spec, 'test.yaml')
    namespace = SpecNamespace(
        'a test namespace', 'test_namespace', [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
    return ValidatorMap(namespace)

def build_specs():
    bar = GroupSpec('A test group specification with a data type', data_type_def='Bar')
    foo = GroupSpec('A test group that contains a data type', data_type_def='Foo',
                groups=[GroupSpec('A Bar group for Foos', name='my_bar', data_type_inc='Bar')])
    return (bar, foo)

foo_builder = GroupBuilder('my_foo', attributes={'data_type': 'Foo'})
vmap = get_vmap(build_specs())
vmap.validate(foo_builder)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
