### PR TITLE
Move Codecov CI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,6 @@ references:
           # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.
           no_output_timeout: 30m
       - run:
-          name: Run coverage and submit to codecov-io if COVERAGE_TOX_ENV != ""
-          command: |
-            . ../venv/bin/activate
-            if [[ "${COVERAGE_TOX_ENV}" != "" ]]; then
-              tox -e $COVERAGE_TOX_ENV
-            fi
-      - run:
           name: Build wheel and source distribution
           command: |
             . ../venv/bin/activate
@@ -131,7 +124,6 @@ jobs:
       - image: circleci/python:3.6.12-stretch
     environment:
      - TEST_TOX_ENV: "py36"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py36"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
@@ -141,7 +133,6 @@ jobs:
       - image: circleci/python:3.7.9-stretch
     environment:
      - TEST_TOX_ENV: "py37"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py37"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
@@ -151,7 +142,6 @@ jobs:
       - image: circleci/python:3.8.6-buster
     environment:
      - TEST_TOX_ENV: "py38"
-     - COVERAGE_TOX_ENV: "coverage"
      - BUILD_TOX_ENV: "build-py38"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
      - UPLOAD_WHEELS: "true"
@@ -162,7 +152,6 @@ jobs:
       - image: circleci/python:3.9.0-buster
     environment:
      - TEST_TOX_ENV: "py39"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py39"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
@@ -172,7 +161,6 @@ jobs:
       - image: circleci/python:3.8.6-buster
     environment:
      - TEST_TOX_ENV: "py38-upgrade-dev"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py38-upgrade-dev"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
@@ -182,7 +170,6 @@ jobs:
       - image: circleci/python:3.8.6-buster
     environment:
      - TEST_TOX_ENV: "py38-upgrade-dev-pre"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py38-upgrade-dev-pre"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
@@ -192,7 +179,6 @@ jobs:
       - image: circleci/python:3.6.12-stretch
     environment:
      - TEST_TOX_ENV: "py36-min-req"
-     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py36-min-req"
      - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Cancel Workflow Action
       uses: styfle/cancel-workflow-action@0.6.0
       with:
-        access_token: ${{ secrets.GITHUB_TOKEN }}
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m coverage run test.py -u
     - name: Upload coverage to Codecov
-    - uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,29 @@
+name: Codecov
+on: [push]
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: '3.8'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U -r requirements-dev.txt -r requirements.txt
+    - name: Run tests and generate coverage report
+      run: |
+        python -m coverage run test.py -u
+    - name: Upload coverage to Codecov
+    - uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Codecov
+name: Run coverage
 on: [push]
 jobs:
   run:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U -r requirements-dev.txt -r requirements.txt
+        python setup.py install
     - name: Run tests and generate coverage report
       run: |
         python -m coverage run test.py -u

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Cancel Workflow Action
       uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,4 +30,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
-        verbose: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Cancel Workflow Action
       uses: styfle/cancel-workflow-action@0.6.0
       with:
-        access_token: ${{ github.token }}
+        access_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,6 +11,8 @@ jobs:
       PYTHON: '3.8'
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -23,6 +25,7 @@ jobs:
     - name: Run tests and generate coverage report
       run: |
         python -m coverage run test.py -u
+        coverage report -m
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,8 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: '3.8'
     steps:
+    - name: Cancel Workflow Action
+      uses: styfle/cancel-workflow-action@0.6.0
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
 - Add testing for Python 3.9 and using pre-release packages. @ajtritt, @rly (#459, #472)
 - Improve contributing guide. @rly (#474)
+- Update CI to be more contributor friendly. @rly (#481)
 
 ### Bug fixes
 - Fix development package dependency issues. @rly (#431)

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ Build Status
 Overall Health
 ==============
 
+.. image:: https://github.com/hdmf-dev/hdmf/workflows/Codecov/badge.svg
+    :target: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ACodecov
+
 .. image:: https://codecov.io/gh/hdmf-dev/hdmf/branch/dev/graph/badge.svg
     :target: https://codecov.io/gh/hdmf-dev/hdmf
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Overall Health
 ==============
 
 .. image:: https://github.com/hdmf-dev/hdmf/workflows/Run%20coverage/badge.svg
-    :target: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ACodecov
+    :target: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3A%22Run+coverage%22
 
 .. image:: https://codecov.io/gh/hdmf-dev/hdmf/branch/dev/graph/badge.svg
     :target: https://codecov.io/gh/hdmf-dev/hdmf

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Build Status
 Overall Health
 ==============
 
-.. image:: https://github.com/hdmf-dev/hdmf/workflows/Codecov/badge.svg
+.. image:: https://github.com/hdmf-dev/hdmf/workflows/Run%20coverage/badge.svg
     :target: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ACodecov
 
 .. image:: https://codecov.io/gh/hdmf-dev/hdmf/branch/dev/graph/badge.svg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ jobs:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
         testToxEnv: 'py38'
-        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -20,7 +19,6 @@ jobs:
         imageName: 'macos-10.15'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -28,7 +26,6 @@ jobs:
         imageName: 'macos-10.15'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -36,7 +33,6 @@ jobs:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
         testToxEnv: 'py38-upgrade-dev'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py38-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -44,7 +40,6 @@ jobs:
         imageName: 'macos-10.15'
         pythonVersion: '3.6'
         testToxEnv: 'py36-min-req'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py36-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -52,7 +47,6 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
         testToxEnv: 'py38'
-        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -60,7 +54,6 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -68,7 +61,6 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -76,7 +68,6 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
         testToxEnv: 'py38-upgrade-dev'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py38-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -84,7 +75,6 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.6'
         testToxEnv: 'py36-min-req'
-        coverageToxEnv: ''
         buildToxEnv: 'build-py36-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
@@ -110,12 +100,6 @@ jobs:
   - bash: |
       tox -e $(testToxEnv)
     displayName: 'Run tox tests'
-
-  - bash: |
-      if [[ "$(coverageToxEnv)" != "" ]]; then
-        tox -e $(coverageToxEnv)
-      fi
-    displayName: 'Run coverage tests if coverageToxEnv != ""'
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -29,12 +29,13 @@ There are badges in the README_ file which shows the current condition of the de
 Coverage
 --------
 
-Code coverage is computed and reported using the coverage_ tool. There is a badge in the README_ file which
-shows the status of the `Codecov GitHub Action`_ and the percentage coverage. A detailed report can be found on
-codecov_ which shows line by line which lines are covered by the tests.
+Code coverage is computed and reported using the coverage_ tool. There are two coverage-related badges in the README_
+file. One shows the status of the `GitHub Action`_ which runs the coverage_ tool and uploads the report to codecov_,
+and the other badge shows the percentage coverage reported from codecov_. A detailed report can be found on
+codecov_, which shows line by line which lines are covered by the tests.
 
 .. _coverage: https://coverage.readthedocs.io
-.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ACodecov
+.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ARun%20coverage
 .. _codecov: https://codecov.io/gh/hdmf-dev/hdmf/tree/dev/src/hdmf
 
 ..  _software_process_requirement_specifications:

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -35,7 +35,7 @@ and the other badge shows the percentage coverage reported from codecov_. A deta
 codecov_, which shows line by line which lines are covered by the tests.
 
 .. _coverage: https://coverage.readthedocs.io
-.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ARun%20coverage
+.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3A%22Run+coverage%22
 .. _codecov: https://codecov.io/gh/hdmf-dev/hdmf/tree/dev/src/hdmf
 
 ..  _software_process_requirement_specifications:

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -11,8 +11,8 @@ Continuous Integration
 HDMF is tested against Ubuntu, macOS, and Windows operating systems.
 The project has both unit and integration tests.
 
-* CircleCI_ runs all HDMF tests on Ubuntu
 * `Azure Pipelines`_ runs all HDMF tests on Windows and macOS
+* CircleCI_ runs all HDMF tests on Ubuntu
 
 Each time a PR is published or updated, the project is built, packaged, and tested on all supported operating systems
 and python distributions. That way, as a contributor, you know if you introduced regressions or coding style
@@ -29,11 +29,12 @@ There are badges in the README_ file which shows the current condition of the de
 Coverage
 --------
 
-Coverage is computed and reported using the coverage_ tool. There is a badge in the README_ file which
-shows percentage coverage. A detailed report can be found on codecov_ which shows line by line which
-lines are covered by the tests.
+Code coverage is computed and reported using the coverage_ tool. There is a badge in the README_ file which
+shows the status of the `Codecov GitHub Action`_ and the percentage coverage. A detailed report can be found on
+codecov_ which shows line by line which lines are covered by the tests.
 
 .. _coverage: https://coverage.readthedocs.io
+.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3ACodecov
 .. _codecov: https://codecov.io/gh/hdmf-dev/hdmf/tree/dev/src/hdmf
 
 ..  _software_process_requirement_specifications:

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -30,12 +30,12 @@ Coverage
 --------
 
 Code coverage is computed and reported using the coverage_ tool. There are two coverage-related badges in the README_
-file. One shows the status of the `GitHub Action`_ which runs the coverage_ tool and uploads the report to codecov_,
-and the other badge shows the percentage coverage reported from codecov_. A detailed report can be found on
+file. One shows the status of the `GitHub Action workflow`_ which runs the coverage_ tool and uploads the report to
+codecov_, and the other badge shows the percentage coverage reported from codecov_. A detailed report can be found on
 codecov_, which shows line by line which lines are covered by the tests.
 
 .. _coverage: https://coverage.readthedocs.io
-.. _codecov GitHub Action: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3A%22Run+coverage%22
+.. _GitHub Action workflow: https://github.com/hdmf-dev/hdmf/actions?query=workflow%3A%22Run+coverage%22
 .. _codecov: https://codecov.io/gh/hdmf-dev/hdmf/tree/dev/src/hdmf
 
 ..  _software_process_requirement_specifications:

--- a/tox.ini
+++ b/tox.ini
@@ -98,15 +98,6 @@ deps =
     -rrequirements-min.txt
 commands = {[testenv:build]commands}
 
-# Envs that will only be executed on CI that does coverage reporting
-[testenv:coverage]
-passenv = CI CIRCLECI CIRCLE_*
-basepython = python3.8
-commands =
-    python -m coverage run test.py -u
-    coverage report -m
-    codecov
-
 # Envs that will test installation from a wheel
 [testenv:wheelinstall]
 deps = null


### PR DESCRIPTION
## Motivation

Codecov requires passing a private token when called from tox (our current method), but not when called directly from supported CI services such as CircleCI, Azure Pipelines, and GitHub Actions. This prevents coverage from being run when contributors create PRs. I moved coverage testing and uploading of coverage data to codecov to GitHub Actions. I had tried doing this in CircleCI but it was too complicated to integrate with the way we were currently matrixing the jobs. I could have created a new workflow just for coverage in both Circle and Azure, but I figured it would be easier to have coverage runs for all OS's in one place, and this would be a good opportunity to test out GitHub Actions. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
