### PR TITLE
Update documentation on validation to warn that the example does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Fix inheritance when non-`AbstractContainer` is base class. @rly (#444)
 - Fix use of `hdmf.testing.assertContainerEqual(...)` for `Data` objects. @rly (#445)
 - Add missing support for data conversion against spec dtypes "bytes" and "short". @rly (#456)
+- Update documentation on validation to indicate that the example command is not implemented @dsleiter (#482)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -3,6 +3,14 @@
 Validating HDMF data
 ====================
 
+Validation is of NWB files is available through :py:mod:`~pynwb`. See the `PyNWB documentation <https://pynwb.readthedocs.io/en/stable/validation.html>`_ for more information.
+
+--------
+
+.. warning::
+   
+   THE FOLLOWING IS NOT YET IMPLEMENTED. If you would like to validate HDMF structured data directly through :py:mod:`~hdmf`, then please upvote `this issue <https://github.com/hdmf-dev/hdmf/issues/473>`_.
+
 Validating HDMF structured data is is handled by a command-line tool available in :py:mod:`~hdmf`. The validator can be invoked like so:
 
 .. code-block:: bash

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -10,9 +10,9 @@ Validation is of NWB files is available through :py:mod:`~pynwb`. See the `PyNWB
 
 .. note::
    
-   A simple interface for validating HDMF structured data like for PyNWB is not yet implemented. If you would like
-   to validate HDMF structured data directly through :py:mod:`~hdmf`, then please upvote `this issue
-   <https://github.com/hdmf-dev/hdmf/issues/473>`_.
+   A simple interface for validating HDMF structured data through the command line like for PyNWB files is not yet
+   implemented. If you would like this functionality to be available through :py:mod:`~hdmf`, then please upvote
+   `this issue <https://github.com/hdmf-dev/hdmf/issues/473>`_.
 
 ..
     Validating HDMF structured data is is handled by a command-line tool available in :py:mod:`~hdmf`. The validator can be invoked like so:

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -3,19 +3,22 @@
 Validating HDMF data
 ====================
 
-Validation is of NWB files is available through :py:mod:`~pynwb`. See the `PyNWB documentation <https://pynwb.readthedocs.io/en/stable/validation.html>`_ for more information.
+Validation is of NWB files is available through :py:mod:`~pynwb`. See the `PyNWB documentation
+<https://pynwb.readthedocs.io/en/stable/validation.html>`_ for more information.
 
 --------
 
-.. warning::
+.. note::
    
-   THE FOLLOWING IS NOT YET IMPLEMENTED. If you would like to validate HDMF structured data directly through :py:mod:`~hdmf`, then please upvote `this issue <https://github.com/hdmf-dev/hdmf/issues/473>`_.
+   A simple interface for validating HDMF structured data like for PyNWB is not yet implemented. If you would like
+   to validate HDMF structured data directly through :py:mod:`~hdmf`, then please upvote `this issue
+   <https://github.com/hdmf-dev/hdmf/issues/473>`_.
 
-Validating HDMF structured data is is handled by a command-line tool available in :py:mod:`~hdmf`. The validator can be invoked like so:
+..
+    Validating HDMF structured data is is handled by a command-line tool available in :py:mod:`~hdmf`. The validator can be invoked like so:
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    python -m hdmf.validate -p namespace.yaml test.h5
+        python -m hdmf.validate -p namespace.yaml test.h5
 
-This will validate the file ``test.h5`` against the specification in ``namespace.yaml``.
-
+    This will validate the file ``test.h5`` against the specification in ``namespace.yaml``.


### PR DESCRIPTION
Ref #473 - until an implementation is added, here is an update to the documentation as @oruebel suggested.

## Motivation

As described in #473, the example command in validation documentation does not work.

## How to test the behavior?
Check the documentation change to see if you agree.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
