### PR TITLE
Update circleci to fail job when publish token not available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,8 +305,7 @@ jobs:
                 --prerelease-sha $CIRCLE_SHA1 \
                 --prerelease-packages-clear-pattern "*" \
                 --prerelease-packages-keep-pattern "*dev<COMMIT_DISTANCE>*" \
-                --re-upload \
-                --exit-success-if-missing-token
+                --re-upload
 
   deploy-release:
     docker:


### PR DESCRIPTION
Ref #478

## Motivation

The CircleCI `deploy-dev` job fails silently when the publish token is not available.

## How to test the behavior?
```
* remove the publish token from circleCI and see if it fails
* alternatively, test a build on a fork without the token and see if it fails (this is what I did)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
