### PR TITLE
Update schema submodule to 1.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@
   @rly (#461)
 - Allow passing `GroupSpec` and `DatasetSpec` objects for the 'target_type' argument of `LinkSpec.__init__(...)`.
   @rly (#467)
+- Use hdmf-common-schema 1.3.0. @rly, @ajtritt (#486)
+  - Changes from hdmf-common-schema 1.2.0:
+    - Add data type ExternalResources for storing ontology information / external resource references. NOTE:
+      this data type is in beta testing and is subject to change in a later version.
+    - Fix missing data_type_inc and use dtype uint for CSRMatrix. It now has data_type_inc: Container.
+    - Add hdmf-schema-language comment at the top of each yaml file.
+    - Add SimpleMultiContainer, a Container for storing other Container and Data objects together.
 
 ### Internal improvements
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)


### PR DESCRIPTION
## Motivation

This PR updates the hdmf-common-schema submodule to version 1.3.0 which was just released.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
