### PR TITLE
Fix generated docval for classes with a LinkSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Add missing support for data conversion against spec dtypes "bytes" and "short". @rly (#456)
 - Clarify the validator error message when a named data type is missing. @dsleiter (#478)
 - Update documentation on validation to indicate that the example command is not implemented @dsleiter (#482)
+- Fix generated docval for classes with a LinkSpec. @rly (#478)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -533,7 +533,7 @@ class TypeMap:
             else:
                 return 'array_data', 'data'
         if isinstance(spec, LinkSpec):
-            return AbstractContainer
+            return self.__get_container_type(spec.target_type)
         if spec.data_type_def is not None:
             return self.__get_container_type(spec.data_type_def)
         if spec.data_type_inc is not None:

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -1,5 +1,5 @@
 from hdmf.spec import (GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, RefSpec,
-                       DtypeSpec)
+                       DtypeSpec, LinkSpec)
 from hdmf.build import (GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager, TypeMap, LinkBuilder,
                         ReferenceBuilder, MissingRequiredBuildWarning, OrphanContainerBuildError,
                         ContainerConfigurationError)
@@ -507,6 +507,17 @@ class TestDynamicContainer(TestCase):
         for arg in docval:
             if arg['name'] == 'name':
                 self.assertEqual(arg['default'], 'MyBaz')
+
+    def test_build_docval_link(self):
+        Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
+        addl_fields = dict(
+            attr3=LinkSpec(name='attr3', target_type='Bar', doc='an example link'),
+        )
+        docval = self.type_map._build_docval(Bar, addl_fields)
+
+        for arg in docval:
+            if arg['name'] == 'attr3':
+                self.assertIs(arg['type'], Bar)
 
 
 class ObjectMapperMixin(metaclass=ABCMeta):


### PR DESCRIPTION
## Motivation

Fix #475. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
