### PR TITLE
Update requirements, changelog for 2.3 release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,9 +2,9 @@ name: Run coverage
 on:
   push:
     branches:
-    - *
+    - '**'
     tags:
-    - *
+    - '**'
     - '!latest'
     - '!latest-tmp'
 jobs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,9 +1,12 @@
 name: Run coverage
 on:
   push:
-    tags-ignore:
-    - latest
-    - latest-tmp
+    branches:
+    - *
+    tags:
+    - *
+    - '!latest'
+    - '!latest-tmp'
 jobs:
   run:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,9 @@
 name: Run coverage
-on: [push]
+on:
+  push:
+    tags-ignore:
+    - latest
+    - latest-tmp
 jobs:
   run:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.0.0 (December 8, 2020)
-
-### Breaking changes
-- Drop support for Python 3.5. @ajtritt (#459)
-- Remove `hdmf.get_region_slicer` function. @ajtritt (#442)
-- Remove unused or refactored internal builder functions `GroupBuilder.add_group`, `GroupBuilder.add_dataset`,
-  `GroupBuilder.add_link`, `GroupBuilder.set_builder`, `BaseBuilder.deep_update`, `GroupBuilder.deep_update`,
-  `DatasetBuilder.deep_update`. Make `BaseBuilder` not instantiable and refactor builder code. @rly (#452)
-- Remove `hdmf.build.map.py`. Classes formerly in this file should be imported from `hdmf.build` instead. @rly (#463)
-- Replace `MissingRequiredWarning` with `MissingRequiredBuildWarning`. @rly (#463)
+## HDMF 2.3.0 (December 8, 2020)
 
 ### New features
 - Add methods for automatic creation of `MultiContainerInterface` classes. @bendichter (#420, #425)
@@ -40,6 +31,7 @@
     - Add SimpleMultiContainer, a Container for storing other Container and Data objects together.
 
 ### Internal improvements
+- Drop support for Python 3.5. @ajtritt (#459)
 - Improve warning about cached namespace when loading namespaces from file. @rly (#422)
 - Refactor `HDF5IO.write_dataset` to be more readable. @rly (#428)
 - Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
@@ -50,6 +42,9 @@
 - Add type checking and conversion in `CSRMatrix`. @rly (#485)
 - Clean up unreachable validator code. @rly (#483)
 - Reformat imports. @bendichter (#469)
+- Remove unused or refactored internal builder functions `GroupBuilder.add_group`, `GroupBuilder.add_dataset`,
+  `GroupBuilder.add_link`, `GroupBuilder.set_builder`, `BaseBuilder.deep_update`, `GroupBuilder.deep_update`,
+  `DatasetBuilder.deep_update`. Make `BaseBuilder` not instantiable and refactor builder code. @rly (#452)
 
 ### Bug fixes
 - Fix development package dependency issues. @rly (#431)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.0.0 (Upcoming)
+## HDMF 3.0.0 (December 4, 2020)
 
 ### Breaking changes
 - Drop support for Python 3.5. @ajtritt (#459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,18 @@
 - Add support for creating and specifying multi-index columns in a `DynamicTable` using `add_column(...)`.
   @bendichter, @rly (#430)
 - Add capability to add a row to a column after IO. @bendichter (#426)
+- Add method `AbstractContainer.get_fields_conf`. @rly (#441)
 - Add functionality for storing external resource references. @ajtritt (#442)
 - Add method `hdmf.utils.get_docval_macro` to get a tuple of the current values for a docval_macro, e.g., 'array_data'  
   and 'scalar_data'. @rly (#446)
 - Add `SimpleMultiContainer`, a data_type for storing a `Container` and `Data` objects together. @ajtritt (#449)
-- Support `pathlib.Path` paths in `HDMFIO.__init__`, `HDF5IO.__init__`, and `HDF5IO.load_namespaces`. @dsleiter (#439)
+- Support `pathlib.Path` paths in `HDMFIO.__init__`, `HDF5IO.__init__`, and `HDF5IO.load_namespaces`. @dsleiter (#450)
 - Use hdmf-common-schema 1.2.1. See https://hdmf-common-schema.readthedocs.io/en/latest/format_release_notes.html for details.
 - Block usage of h5py 3+. h5py>=2.9, <3 is supported. @rly (#461)
 - Block usage of numpy>=1.19.4 due to a known issue with numpy on some Windows 10 systems. numpy>1.16, <1.19.4 is supported.
   @rly (#461)
 - Allow passing `GroupSpec` and `DatasetSpec` objects for the 'target_type' argument of `LinkSpec.__init__(...)`.
-  @rly (#467)
+  @rly (#468)
 - Use hdmf-common-schema 1.3.0. @rly, @ajtritt (#486)
   - Changes from hdmf-common-schema 1.2.0:
     - Add data type ExternalResources for storing ontology information / external resource references. NOTE:
@@ -43,10 +44,11 @@
 - Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
 - Add testing for Python 3.9 and using pre-release packages. @ajtritt, @rly (#459, #472)
 - Improve contributing guide. @rly (#474)
-- Update CI to be more contributor friendly. @rly (#481)
+- Update CI. @rly, @dsleiter (#481, #484)
 - Add citation information to documentation and support for duecredit tool. @rly (#477, #488)
 - Add type checking and conversion in `CSRMatrix`. @rly (#485)
 - Clean up unreachable validator code. @rly (#483)
+- Reformat imports. @bendichter (#469)
 
 ### Bug fixes
 - Fix development package dependency issues. @rly (#431)
@@ -58,8 +60,11 @@
 - Add missing support for data conversion against spec dtypes "bytes" and "short". @rly (#456)
 - Clarify the validator error message when a named data type is missing. @dsleiter (#478)
 - Update documentation on validation to indicate that the example command is not implemented @dsleiter (#482)
-- Fix generated docval for classes with a LinkSpec. @rly (#478)
+- Fix generated docval for classes with a LinkSpec. @rly (#487)
 - Fix access of `DynamicTableRegion` of a `DynamicTable` with column of references. @rly (#491)
+- Fix handling of `__fields__` for `Data` subclasses. @rly (#441)
+- Fix `DynamicTableRegion` having duplicate fields conf 'table'. @rly (#441)
+- Fix inefficient and sometimes inaccurate build process. @rly (#451)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.0.0 (December 7, 2020)
+## HDMF 3.0.0 (December 8, 2020)
 
 ### Breaking changes
 - Drop support for Python 3.5. @ajtritt (#459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.0.0 (December 4, 2020)
+## HDMF 3.0.0 (December 7, 2020)
 
 ### Breaking changes
 - Drop support for Python 3.5. @ajtritt (#459)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Dependencies
 
 HDMF has the following minimum requirements, which must be installed before you can get started using HDMF.
 
-#. Python 3.5, 3.6, 3.7, or 3.8
+#. Python 3.6, 3.7, or 3.8
 #. pip
 
 ------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF, run HDMF tests, check code style,
 # compute coverage, and create test environments
-codecov==2.1.8
-coverage==5.2
-flake8==3.8.3
-flake8-debugger==3.1.0
-flake8-print==3.1.4
-importlib-metadata<2
+codecov==2.1.10
+coverage==5.3
+flake8==3.8.4
+flake8-debugger==4.0.0
+flake8-print==4.0.0
+importlib-metadata==3.1.1
 python-dateutil==2.8.1
-tox==3.17.1
+tox==3.20.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ coverage==5.3
 flake8==3.8.4
 flake8-debugger==4.0.0
 flake8-print==4.0.0
-importlib-metadata==3.1.1
+importlib-metadata<2
 python-dateutil==2.8.1
 tox==3.20.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,7 +2,7 @@
 # the requirements here specify '==' for testing; setup.py replaces '==' with '>='
 h5py==2.9,<3  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16,<1.19.4
-scipy==1.1
-pandas==0.23
-ruamel.yaml==0.15
-jsonschema==2.6.0
+scipy==1.1,<2
+pandas==0.23,<2
+ruamel.yaml==0.15,<1
+jsonschema==2.6.0,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF
 h5py==2.10.0
-numpy==1.18.5
-scipy==1.4.1
-pandas==0.25.3
-ruamel.yaml==0.16.10
+numpy==1.19.3
+scipy==1.5.4
+pandas==1.1.4
+ruamel.yaml==0.16.12
+jsonschema==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup_args = {
     'package_data': {'hdmf': ["%s/*.yaml" % schema_dir, "%s/*.json" % schema_dir]},
     'classifiers': [
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Prepare for release of HDMF 2.3.0

### Before merging:
- [x] Minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`, `requirements-doc.txt`, `requirements-min.txt` as needed. See https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
- [x] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`, and any other locations as needed
- [x] Update `setup.py` as needed
- [x] Update `README.rst` as needed
- [x] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number manually.
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
- [x] Run PyNWB tests locally including gallery tests and inspect all warnings and outputs (`python test.py -v > out.txt`)
- [x] Test docs locally (`make apidoc`, `make html`)
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/hdmf/builds/

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release 2.3.0` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
3. Check that the readthedocs "latest" and "stable" builds run and succeed
4. Update [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock)
