### PR TITLE
Fix access of DynamicTableRegion of table with col of refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Clarify the validator error message when a named data type is missing. @dsleiter (#478)
 - Update documentation on validation to indicate that the example command is not implemented @dsleiter (#482)
 - Fix generated docval for classes with a LinkSpec. @rly (#478)
+- Fix access of `DynamicTableRegion` of a `DynamicTable` with column of references. @rly (#491)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/query.py
+++ b/src/hdmf/query.py
@@ -125,7 +125,7 @@ class HDMFDataset(metaclass=ExtenderMeta):
             setattr(cls, op, cls.__build_operation(op))
 
     def __evaluate_key(self, key):
-        if key == tuple():
+        if isinstance(key, tuple) and len(key) == 0:
             return key
         if isinstance(key, (tuple, list, np.ndarray)):
             return list(map(self.__evaluate_key, key))

--- a/src/hdmf/query.py
+++ b/src/hdmf/query.py
@@ -125,8 +125,10 @@ class HDMFDataset(metaclass=ExtenderMeta):
             setattr(cls, op, cls.__build_operation(op))
 
     def __evaluate_key(self, key):
+        if key == tuple():
+            return key
         if isinstance(key, (tuple, list, np.ndarray)):
-            return tuple(map(self.__evaluate_key, key))
+            return list(map(self.__evaluate_key, key))
         else:
             if isinstance(key, Query):
                 return key.evaluate()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -8,7 +8,7 @@ from hdmf import Container
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 from hdmf.common import (DynamicTable, VectorData, VectorIndex, ElementIdentifiers,
                          DynamicTableRegion, VocabData, get_manager, SimpleMultiContainer)
-from hdmf.testing import TestCase, H5RoundTripMixin
+from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 
 
 class TestDynamicTable(TestCase):
@@ -1529,6 +1529,12 @@ class TestDataIOIndex(H5RoundTripMixin, TestCase):
 
 class TestDTRReferences(TestCase):
 
+    def setUp(self):
+        self.filename = 'test_dtr_references.h5'
+
+    def tearDown(self):
+        remove_test_file(self.filename)
+
     def test_dtr_references(self):
         """Test roundtrip of a table with a ragged DTR to another table containing a column of references."""
         group1 = Container('group1')
@@ -1572,12 +1578,10 @@ class TestDTRReferences(TestCase):
         multi_container.add_container(table1)
         multi_container.add_container(table2)
 
-        filename = 'test.h5'
-
-        with HDF5IO(filename, manager=get_manager(), mode='w') as io:
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
             io.write(multi_container)
 
-        with HDF5IO(filename, manager=get_manager(), mode='r') as io:
+        with HDF5IO(self.filename, manager=get_manager(), mode='r') as io:
             read_multi_container = io.read()
             self.assertContainerEqual(read_multi_container, multi_container, ignore_name=True)
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1590,7 +1590,7 @@ class TestDTRReferences(TestCase):
             read_group2 = read_multi_container['group2']
             read_table = read_multi_container['table2']
             ret = read_table[0, 'electrodes']
-            expected = pd.DataFrame({'x': np.array([2, 3], dtype='int32'),
+            expected = pd.DataFrame({'x': np.array([2, 3]),
                                      'y': [read_group1, read_group2]},
                                     index=pd.Index(data=[102, 103], name='id'))
             pd.testing.assert_frame_equal(ret, expected)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1,9 +1,10 @@
-import unittest
 from collections import OrderedDict
-
 import h5py
 import numpy as np
 import pandas as pd
+import unittest
+
+from hdmf import Container
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 from hdmf.common import (DynamicTable, VectorData, VectorIndex, ElementIdentifiers,
                          DynamicTableRegion, VocabData, get_manager, SimpleMultiContainer)
@@ -1524,3 +1525,68 @@ class TestDataIOIndex(H5RoundTripMixin, TestCase):
         read_table.add_row(foo=data, bar=data)
 
         np.testing.assert_array_equal(read_table['foo'][-1], data)
+
+
+class TestDTRReferences(TestCase):
+
+    def test_dtr_references(self):
+        """Test roundtrip of a table with a ragged DTR to another table containing a column of references."""
+        group1 = Container('group1')
+        group2 = Container('group2')
+
+        table1 = DynamicTable(
+            name='table1',
+            description='test table 1'
+        )
+        table1.add_column(
+            name='x',
+            description='test column of ints'
+        )
+        table1.add_column(
+            name='y',
+            description='test column of reference'
+        )
+        table1.add_row(id=101, x=1, y=group1)
+        table1.add_row(id=102, x=2, y=group1)
+        table1.add_row(id=103, x=3, y=group2)
+
+        table2 = DynamicTable(
+            name='table2',
+            description='test table 2'
+        )
+
+        # create a ragged column that references table1
+        # each row of table2 corresponds to one or more rows of table 1
+        table2.add_column(
+            name='electrodes',
+            description='column description',
+            index=True,
+            table=table1
+        )
+
+        table2.add_row(id=10, electrodes=[1, 2])
+
+        multi_container = SimpleMultiContainer('multi')
+        multi_container.add_container(group1)
+        multi_container.add_container(group2)
+        multi_container.add_container(table1)
+        multi_container.add_container(table2)
+
+        filename = 'test.h5'
+
+        with HDF5IO(filename, manager=get_manager(), mode='w') as io:
+            io.write(multi_container)
+
+        with HDF5IO(filename, manager=get_manager(), mode='r') as io:
+            read_multi_container = io.read()
+            self.assertContainerEqual(read_multi_container, multi_container, ignore_name=True)
+
+            # test DTR access
+            read_group1 = read_multi_container['group1']
+            read_group2 = read_multi_container['group2']
+            read_table = read_multi_container['table2']
+            ret = read_table[0, 'electrodes']
+            expected = pd.DataFrame({'x': np.array([2, 3], dtype='int32'),
+                                     'y': [read_group1, read_group2]},
+                                    index=pd.Index(data=[102, 103], name='id'))
+            pd.testing.assert_frame_equal(ret, expected)


### PR DESCRIPTION
## Motivation

Fix part of #460. Relevance in PyNWB to error when accessing rows of the Units table where electrodes are set. Odd that this has not come up yet, but perhaps users are not setting the electrodes column, or not reading the rows of the Units table...

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
