### PR TITLE
Fix check quantity for non-data-type datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Block usage of h5py 3+. h5py>=2.9, <3 is supported. @rly (#461)
 - Block usage of numpy>=1.19.4 due to a known issue with numpy on some Windows 10 systems. numpy>1.16, <1.19.4 is supported.
   @rly (#461)
+- Add check for correct quantity during the build process in `ObjectMapper`. @rly (#463, #492)
 - Allow passing `GroupSpec` and `DatasetSpec` objects for the 'target_type' argument of `LinkSpec.__init__(...)`.
   @rly (#467)
 - Use hdmf-common-schema 1.3.0. @rly, @ajtritt (#486)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -648,14 +648,14 @@ class ObjectMapper(metaclass=ExtenderMeta):
         return ret
 
     def __check_quantity(self, attr_value, spec, container):
-        # attr_value is None, AbstractContainer, or list of AbstractContainers
         if attr_value is None and spec.required:
             attr_name = self.get_attribute(spec)
             msg = ("%s '%s' is missing required value for attribute '%s'."
                    % (container.__class__.__name__, container.name, attr_name))
             warnings.warn(msg, MissingRequiredBuildWarning)
             self.logger.debug('MissingRequiredBuildWarning: ' + msg)
-        elif attr_value is not None and not isinstance(spec, AttributeSpec):
+        elif attr_value is not None and self.__get_data_type(spec) is not None:
+            # quantity is valid only for specs with a data type or target type
             if isinstance(attr_value, AbstractContainer):
                 attr_value = [attr_value]
             n = len(attr_value)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -1594,3 +1594,5 @@ class TestObjectMapperBadValue(TestCase):
         msg = "Qux 'my_qux' attribute 'foo' has unexpected type."
         with self.assertRaisesWith(ContainerConfigurationError, msg):
             self.mapper.build(container, self.manager)
+
+    # TODO test passing a Container/Data/other object for a non-container/data array spec


### PR DESCRIPTION
## Motivation

When datasets without a `data_type_def` or `data_type_inc` (and therefore must have a name) are encountered, the `ObjectMapper` raises an error when checking quantity. This PR should fix that error.

This is blocking the release of HDMF 3.0.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
