### PR TITLE
Cache builders in HDF5IO.written map so it doesn't get gc'd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Update documentation on validation to indicate that the example command is not implemented @dsleiter (#482)
 - Fix generated docval for classes with a LinkSpec. @rly (#478)
 - Fix access of `DynamicTableRegion` of a `DynamicTable` with column of references. @rly (#491)
+- Fix garbage collection issue in Python 3.9. @rly (#496)
 
 ## HDMF 2.2.0 (August 14, 2020)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -457,7 +457,7 @@ class HDF5IO(HDMFIO):
         :return: True if the builder is found in self._written_builders using the builder ID, False otherwise
         """
         builder_id = self.__builderhash(builder)
-        return self._written_builders.get(builder_id, False)
+        return builder_id in self._written_builders
 
     def __builderhash(self, obj):
         """Return the ID of a builder for use as a unique hash."""

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -445,8 +445,6 @@ class HDF5IO(HDMFIO):
         :param builder: Builder object to be marked as written
         :type builder: Builder
         """
-        # currently all values in self._written_builders are True, so this could be a set but is a dict for
-        # future flexibility
         builder_id = self.__builderhash(builder)
         self._written_builders[builder_id] = builder
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -894,8 +894,10 @@ class HDF5IO(HDMFIO):
         parent, builder = popargs('parent', 'builder', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
+            self.logger.debug("    GroupBuilder '%s' is already written" % builder.name)
             group = parent[builder.name]
         else:
+            self.logger.debug("    Creating group '%s'" % builder.name)
             group = parent.create_group(builder.name)
         # write all groups
         subgroups = builder.groups
@@ -939,6 +941,7 @@ class HDF5IO(HDMFIO):
         parent, builder = getargs('parent', 'builder', kwargs)
         self.logger.debug("Writing LinkBuilder '%s' to parent group '%s'" % (builder.name, parent.name))
         if self.get_written(builder):
+            self.logger.debug("    LinkBuilder '%s' is already written" % builder.name)
             return None
         name = builder.name
         target_builder = builder.builder

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -448,7 +448,7 @@ class HDF5IO(HDMFIO):
         # currently all values in self._written_builders are True, so this could be a set but is a dict for
         # future flexibility
         builder_id = self.__builderhash(builder)
-        self._written_builders[builder_id] = True
+        self._written_builders[builder_id] = builder
 
     def get_written(self, builder):
         """Return True if this builder has been written to (or read from) disk by this IO object, False otherwise.


### PR DESCRIPTION
## Motivation

Fix #494 

The bug reported in #494 is due to what I think is a change in garbage collector behavior in Python 3.9.
Consider the test code:
```python
self.io.write_dataset(self.f, DatasetBuilder('ds1', np.arange(10)))
self.io.write_dataset(self.f, DatasetBuilder('ds2', np.arange(10)))
```

`HDF5IO.write_dataset` checks whether the builder being passed to it has been written. It does this by checking the `HDF5IO._written_builders` dictionary to see if the ID of the builder is present and has value True. Only if the builder has not been written, will `write_dataset` continue to write the dataset.

I *think* Python 3.9 looks at the above code and garbage collects the first DatasetBuilder after the first line completes because nothing later in the code or in memory maintains a reference to the DatasetBuilder. So when the second DatasetBuilder is instantiated, it is *sometimes* given the same ID as the first. In those cases, `HDF5IO.write_dataset` will think that this new builder has already been written.

I see a few main ways to get around this. 1) update the test to create local variables for the first and second DatasetBuilder so that the ID is not reused by the second. Realistically, the BuildManager should be maintaining references to all builders anyway, so the error #494 is a quirk of the unit test. But maybe there are cases where the BuildManager does not have a reference to the builder. A better way might be: 2) update how `HDF5IO._written_builders` works so that it maintains a reference to the builder.

Interestingly and frustratingly, adding a `breakpoint` between the first and second lines above changes the flow so that the bug cannot be reproduced...

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
