### PR TITLE
Move some mostly redundant CI from on push to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,11 +358,57 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
+      - python38-upgrade-dev:
+          <<: *no_filters
+      - python36-min-req:
+          <<: *no_filters
+      - miniconda36:
+          <<: *no_filters
+      - miniconda38:
+          <<: *no_filters
+      - gallery38-upgrade-dev:
+          <<: *no_filters
+      - gallery36-min-req:
+          <<: *no_filters
+      - deploy-dev:
+          requires:
+            - flake8
+            - python38-upgrade-dev
+            - python36-min-req
+            - miniconda36
+            - miniconda38
+            - gallery38-upgrade-dev
+            - gallery36-min-req
+          filters:
+            tags:
+              ignore:
+                # exclude tags created by "ci_addons publish_github_release"
+                - /^latest$/
+                - /^latest-tmp$/
+            branches:
+              only: dev
+      - pynwb-dev-python38:
+          filters:
+            branches:
+              ignore: dev
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only: dev
+    jobs:
+      - flake8:
+          <<: *no_filters
       - python36:
           <<: *no_filters
       - python37:
           <<: *no_filters
       - python38:
+          <<: *no_filters
+      - python39:
           <<: *no_filters
       - python38-upgrade-dev:
           <<: *no_filters
@@ -374,40 +420,24 @@ workflows:
           <<: *no_filters
       - miniconda38:
           <<: *no_filters
+      - miniconda39:
+          <<: *no_filters
       - gallery36:
           <<: *no_filters
       - gallery37:
           <<: *no_filters
       - gallery38:
           <<: *no_filters
+      - gallery39:
+          <<: *no_filters
       - gallery38-upgrade-dev:
           <<: *no_filters
       - gallery36-min-req:
           <<: *no_filters
-      - deploy-dev:
-          requires:
-            - flake8
-            - python36
-            - python37
-            - python38
-            - python38-upgrade-dev
-            - python36-min-req
-            - miniconda36
-            - miniconda37
-            - miniconda38
-            - gallery36
-            - gallery37
-            - gallery38
-            - gallery38-upgrade-dev
-            - gallery36-min-req
-          filters:
-            tags:
-              ignore:
-                # exclude tags created by "ci_addons publish_github_release"
-                - /^latest$/
-                - /^latest-tmp$/
-            branches:
-              only: dev
+      - python38-upgrade-dev-pre:
+          <<: *no_filters
+      - gallery38-upgrade-dev-pre:
+          <<: *no_filters
       - deploy-release:
           requires:
             - flake8
@@ -429,26 +459,3 @@ workflows:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
             branches:
               ignore: /.*/
-      - pynwb-dev-python38:
-          filters:
-            branches:
-              ignore: dev
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only: dev
-    jobs:
-      - python39:
-          <<: *no_filters
-      - miniconda39:
-          <<: *no_filters
-      - gallery39:
-          <<: *no_filters
-      - python38-upgrade-dev-pre:
-          <<: *no_filters
-      - gallery38-upgrade-dev-pre:
-          <<: *no_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,20 @@ workflows:
                 - /^latest-tmp$/
             branches:
               only: dev
+      - deploy-release:
+          requires:
+            - flake8
+            - python38
+            - python36-min-req
+            - miniconda36
+            - miniconda38
+            - gallery38
+            - gallery36-min-req
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
+            branches:
+              ignore: /.*/
       - pynwb-dev-python38:
           filters:
             branches:
@@ -438,24 +452,3 @@ workflows:
           <<: *no_filters
       - gallery38-upgrade-dev-pre:
           <<: *no_filters
-      - deploy-release:
-          requires:
-            - flake8
-            - python36
-            - python37
-            - python38
-            - python38-upgrade-dev
-            - python36-min-req
-            - miniconda36
-            - miniconda37
-            - miniconda38
-            - gallery36
-            - gallery37
-            - gallery38
-            - gallery38-upgrade-dev
-            - gallery36-min-req
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
-      - python38-upgrade-dev:
+      - python38:
           <<: *no_filters
       - python36-min-req:
           <<: *no_filters
@@ -366,18 +366,18 @@ workflows:
           <<: *no_filters
       - miniconda38:
           <<: *no_filters
-      - gallery38-upgrade-dev:
+      - gallery38:
           <<: *no_filters
       - gallery36-min-req:
           <<: *no_filters
       - deploy-dev:
           requires:
             - flake8
-            - python38-upgrade-dev
+            - python38
             - python36-min-req
             - miniconda36
             - miniconda38
-            - gallery38-upgrade-dev
+            - gallery38
             - gallery36-min-req
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Fix bug in slicing tables with DynamicTableRegions. @ajtritt (#449)
 - Add testing for Python 3.9 and using pre-release packages. @ajtritt, @rly (#459, #472)
 - Improve contributing guide. @rly (#474)
-- Update CI to be more contributor friendly. @rly (#481, #493)
+- Update CI to be more contributor friendly. @rly (#481, #493, #497)
 - Add citation information to documentation and support for duecredit tool. @rly (#477, #488)
 - Add type checking and conversion in `CSRMatrix`. @rly (#485)
 - Clean up unreachable validator code. @rly (#483)

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -23,14 +23,6 @@ jobs:
         buildToxEnv: 'build-py39'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.9:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.9'
-        testToxEnv: 'py39'
-        coverageToxEnv: ''
-        buildToxEnv: 'build-py39'
-        testWheelInstallEnv: 'wheelinstall'
-
       macOS-py3.8-upgrade-dev-pre:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
@@ -39,12 +31,90 @@ jobs:
         buildToxEnv: 'build-py38-upgrade-dev-pre'
         testWheelInstallEnv: 'wheelinstall'
 
+      macOS-py3.8-upgrade-dev:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.8'
+        testToxEnv: 'py38-upgrade-dev'
+        buildToxEnv: 'build-py38-upgrade-dev'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.8:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.8'
+        testToxEnv: 'py38'
+        buildToxEnv: 'build-py38'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.7:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37'
+        buildToxEnv: 'build-py37'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.6:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36'
+        buildToxEnv: 'build-py36'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.6-min-req:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
+        buildToxEnv: 'build-py36-min-req'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.9:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.9'
+        testToxEnv: 'py39'
+        coverageToxEnv: ''
+        buildToxEnv: 'build-py39'
+        testWheelInstallEnv: 'wheelinstall'
+
       Windows-py3.8-upgrade-dev-pre:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
         testToxEnv: 'py38-upgrade-dev-pre'
         coverageToxEnv: ''
         buildToxEnv: 'build-py38-upgrade-dev-pre'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.8-upgrade-dev:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.8'
+        testToxEnv: 'py38-upgrade-dev'
+        buildToxEnv: 'build-py38-upgrade-dev'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.8:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.8'
+        testToxEnv: 'py38'
+        buildToxEnv: 'build-py38'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.7:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37'
+        buildToxEnv: 'build-py37'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.6:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36'
+        buildToxEnv: 'build-py36'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.6-min-req:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
+        buildToxEnv: 'build-py36-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
   pool:
@@ -69,12 +139,6 @@ jobs:
   - bash: |
       tox -e $(testToxEnv)
     displayName: 'Run tox tests'
-
-  - bash: |
-      if [[ "$(coverageToxEnv)" != "" ]]; then
-        tox -e $(coverageToxEnv)
-      fi
-    displayName: 'Run coverage tests if coverageToxEnv != ""'
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,27 +8,6 @@ jobs:
 
   strategy:
     matrix:
-      macOS-py3.8:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38'
-        buildToxEnv: 'build-py38'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.7:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.7'
-        testToxEnv: 'py37'
-        buildToxEnv: 'build-py37'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.6:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36'
-        buildToxEnv: 'build-py36'
-        testWheelInstallEnv: 'wheelinstall'
-
       macOS-py3.8-upgrade-dev:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
@@ -41,27 +20,6 @@ jobs:
         pythonVersion: '3.6'
         testToxEnv: 'py36-min-req'
         buildToxEnv: 'build-py36-min-req'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.8:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38'
-        buildToxEnv: 'build-py38'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.7:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.7'
-        testToxEnv: 'py37'
-        buildToxEnv: 'build-py37'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.6:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36'
-        buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall'
 
       Windows-py3.8-upgrade-dev:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,11 @@ jobs:
 
   strategy:
     matrix:
-      macOS-py3.8-upgrade-dev:
+      macOS-py3.8:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev'
-        buildToxEnv: 'build-py38-upgrade-dev'
+        testToxEnv: 'py38'
+        buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall'
 
       macOS-py3.6-min-req:
@@ -22,11 +22,11 @@ jobs:
         buildToxEnv: 'build-py36-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.8-upgrade-dev:
+      Windows-py3.8:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev'
-        buildToxEnv: 'build-py38-upgrade-dev'
+        testToxEnv: 'py38'
+        buildToxEnv: 'build-py38'
         testWheelInstallEnv: 'wheelinstall'
 
       Windows-py3.6-min-req:


### PR DESCRIPTION
## Motivation

Our CI involves too many jobs -- it takes a long time for all the jobs to complete, especially when trying to merge successive PRs. Some of these jobs can be moved to a nightly build rather than an on-every-push build.

With this PR, CI will consist of:
CircleCI:
- flake8
- python38 (3.8 with pip install pinned requirements)
- python36-min-req (3.6 with pip install minimal requirements)
- miniconda38 (3.8 on conda with pinned requirements)
- miniconda36 (3.6 on conda with pinned requirements)
- gallery38 (gallery/example tests...) 
- gallery36-min-req
- pynwb-dev-python38 (git pull dev branch of pynwb and run tests)

Azure Pipelines:
- macOS-py3.8
- Windows-py3.8
- macOS-py3.6-min-req
- Windows-py3.6-min-req

I changed the required CI for a PR merge to be just:
- circleci/flake8
- circleci/python36-min-req
- circleci/python38
- azure/windows-py3.8

~~The 'deploy-release' job that creates the pre-releases will move from every time a commit is made to dev to a nightly build.~~

Nightly build includes testing on every configuration including Python 3.9.

This will cut on-push CI down to 12 jobs + 3 for code coverage, down from 25 + 3 and reduce the CI time on a commit to dev.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
