### PR TITLE
Revert breaking changes prior to 2.3.0

### DIFF
--- a/src/hdmf/__init__.py
+++ b/src/hdmf/__init__.py
@@ -1,6 +1,23 @@
 from . import query  # noqa: F401
 from .container import Container, Data, DataRegion
 from .utils import docval, getargs
+from .region import ListSlicer
+from .backends.hdf5.h5_utils import H5RegionSlicer, H5Dataset
+
+
+@docval({'name': 'dataset', 'type': None, 'doc': 'the HDF5 dataset to slice'},
+        {'name': 'region', 'type': None, 'doc': 'the region reference to use to slice'},
+        is_method=False)
+def get_region_slicer(**kwargs):
+    import warnings  # noqa: E402
+    warnings.warn('get_region_slicer is deprecated and will be removed in HDMF 3.0.', DeprecationWarning)
+
+    dataset, region = getargs('dataset', 'region', kwargs)
+    if isinstance(dataset, (list, tuple, Data)):
+        return ListSlicer(dataset, region)
+    elif isinstance(dataset, H5Dataset):
+        return H5RegionSlicer(dataset, region)
+    return None
 
 
 from ._version import get_versions  # noqa: E402

--- a/src/hdmf/build/__init__.py
+++ b/src/hdmf/build/__init__.py
@@ -3,4 +3,5 @@ from .errors import (BuildError, OrphanContainerBuildError, ReferenceTargetNotBu
                      ConstructError)
 from .manager import BuildManager, TypeMap
 from .objectmapper import ObjectMapper
-from .warnings import BuildWarning, MissingRequiredBuildWarning, DtypeConversionWarning, IncorrectQuantityBuildWarning
+from .warnings import (BuildWarning, MissingRequiredBuildWarning, DtypeConversionWarning, IncorrectQuantityBuildWarning,
+                       MissingRequiredWarning, OrphanContainerWarning)

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1,0 +1,7 @@
+# this prevents breaking of code that imports these classes directly from map.py
+from .manager import Proxy, BuildManager, TypeSource, TypeMap  # noqa: F401
+from .objectmapper import ObjectMapper  # noqa: F401
+
+import warnings
+warnings.warn('Classes in map.py should be imported from hdmf.build. Importing from hdmf.build.map will be removed '
+              'in HDMF 3.0.', DeprecationWarning)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -541,9 +541,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
         spec, container, manager = getargs('spec', 'container', 'manager', kwargs)
         attr_name = self.get_attribute(spec)
         if attr_name is None:
-            msg = ("%s has no container attribute mapped to spec: %s"
-                   % (self.__class__, spec))
-            raise ContainerConfigurationError(msg)
+            return None
         attr_val = self.__get_override_attr(attr_name, container, manager)
         if attr_val is None:
             try:

--- a/src/hdmf/build/warnings.py
+++ b/src/hdmf/build/warnings.py
@@ -19,6 +19,20 @@ class MissingRequiredBuildWarning(BuildWarning):
     pass
 
 
+class MissingRequiredWarning(MissingRequiredBuildWarning):
+    """
+    Raised when a required field is missing.
+    """
+    pass
+
+
+class OrphanContainerWarning(BuildWarning):
+    """
+    Raised when a container is built without a parent.
+    """
+    pass
+
+
 class DtypeConversionWarning(UserWarning):
     """
     Raised when a value is converted to a different data type in order to match the specification.

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -1,4 +1,3 @@
-import re
 from abc import ABCMeta, abstractmethod
 
 from hdmf.build import GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager, TypeMap, ContainerConfigurationError
@@ -278,24 +277,6 @@ class TestNestedContainersSubgroupSubgroup(NestedBaseMixin, TestBase):
     def test_construct(self):
         container = self.manager.construct(self.bucket_builder)
         self.assertEqual(container, self.foo_bucket)
-
-
-class TestNoMappedAttribute(TestBase):
-
-    def test_build(self):
-        """Test that an error is raised when a spec is not mapped to a container attribute."""
-        class Unmapper(ObjectMapper):
-            def __init__(self, spec):
-                super().__init__(spec)
-                self.unmap(self.spec.get_dataset('my_data'))  # remove mapping from this spec to container attribute
-
-        self.type_map.register_map(Foo, Unmapper)  # override
-
-        container_inst = Foo('my_foo', list(range(10)), 'value1', 10)
-        msg = (r"<class '.*Unmapper'> has no container attribute mapped to spec: %s"
-               % re.escape(str(self.foo_spec.get_dataset('my_data'))))
-        with self.assertRaisesRegex(ContainerConfigurationError, msg):
-            self.manager.build(container_inst)
 
 
 class TestNoAttribute(TestBase):


### PR DESCRIPTION
## Motivation

The current dev branch contains minor breaking changes. These are reverted in this PR. After 2.3 is released and before 3.0 is released, this commit to dev should be reverted to reintroduce these changes.

The changelog will be updated in #490.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
