### PR TITLE
Allow np.bool_ as a valid type when bool is specified in spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Internal improvements
 - Update CI. @rly (#432)
 
+### Bug fixes
+- Allow `np.bool_` as a valid `bool` dtype when validating. @dsleiter (#505)
+
 ## HDMF 2.3.0 (December 8, 2020)
 
 ### New features

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -497,7 +497,7 @@ class TypeMap:
         'utf-8': str,
         'ascii': bytes,
         'bytes': bytes,
-        'bool': bool,
+        'bool': (bool, np.bool_),
         'isodatetime': datetime,
         'datetime': datetime
     }

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -32,7 +32,7 @@ class DtypeHelper:
         'long': ["int64", "long"],
         'utf': ["text", "utf", "utf8", "utf-8"],
         'ascii': ["ascii", "bytes"],
-        'bool': ["bool", "bool_"],
+        'bool': ["bool"],
         'int8': ["int8"],
         'uint8': ["uint8"],
         'uint16': ["uint16"],

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -32,7 +32,7 @@ class DtypeHelper:
         'long': ["int64", "long"],
         'utf': ["text", "utf", "utf8", "utf-8"],
         'ascii': ["ascii", "bytes"],
-        'bool': ["bool"],
+        'bool': ["bool", "bool_"],
         'int8': ["int8"],
         'uint8': ["uint8"],
         'uint16': ["uint16"],

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -23,7 +23,7 @@ class DtypeHelper:
     # make sure keys are consistent between hdmf.spec.spec.DtypeHelper.primary_dtype_synonyms,
     # hdmf.build.objectmapper.ObjectMapper.__dtypes, hdmf.build.manager.TypeMap._spec_dtype_map,
     # hdmf.validate.validator.__allowable, and backend dtype maps
-    # see https://hdmf-schema-language.readthedocs.io/en/latest/specification_language_description.html#dtype
+    # see https://hdmf-schema-language.readthedocs.io/en/latest/description.html#dtype
     primary_dtype_synonyms = {
         'float': ["float", "float32"],
         'double': ["double", "float64"],

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -10,7 +10,7 @@ import numpy as np
 
 __macros = {
     'array_data': [np.ndarray, list, tuple, h5py.Dataset],
-    'scalar_data': [str, int, float, bytes],
+    'scalar_data': [str, int, float, bytes, bool],
     'data': []
 }
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -111,6 +111,8 @@ def get_type(data):
         if data.size == 0:
             raise EmptyArrayError()
         return get_type(data[0])
+    elif isinstance(data, np.bool_):
+        return 'bool'
     if not hasattr(data, '__len__'):
         return type(data).__name__
     else:

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -976,13 +976,13 @@ class TestMacro(TestCase):
         self.assertTrue(isinstance(get_docval_macro(), dict))
         self.assertSetEqual(set(get_docval_macro().keys()), {'array_data', 'scalar_data', 'data'})
 
-        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes))
+        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes, bool))
 
         @docval_macro('scalar_data')
         class Dummy1:
             pass
 
-        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes, Dummy1))
+        self.assertTupleEqual(get_docval_macro('scalar_data'), (str, int, float, bytes, bool, Dummy1))
 
         @docval_macro('dummy')
         class Dummy2:

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -311,6 +311,16 @@ class TestDtypeValidation(TestCase):
                            "Bar/data (my_bar/data): incorrect type - expected 'numeric', got 'bool'"}
         self.assertEqual(result_strings, expected_errors)
 
+    def test_np_bool_for_bool(self):
+        """Test that validator allows np.bool_ data where bool is specified."""
+        self.set_up_spec('bool')
+        value = np.bool_(True)
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
 
 class Test1DArrayValidation(TestCase):
 


### PR DESCRIPTION
* Allow `np.bool_` as a valid type when `bool` is specified in a spec
* Fix #504
* Ref https://github.com/NeurodataWithoutBorders/pynwb/issues/1298
* Include bool as a scalar type for docval

## Motivation

To fix this pynwb issue: https://github.com/NeurodataWithoutBorders/pynwb/issues/1298

As it is currently possible to create an attribute with a `np.bool_` when the spec lists the dtype as `bool`, the validator should similarly allow `np.bool_` as a valid bool type.

While testing, I discovered that a `DatasetBulder` will not accept an `np.bool_` as valid data when the dtype is `bool` because `bool` is not included as a scalar type. This seemed like an inconsistency to me, so I added it as a scalar type for docval, but please let me know if you disagree and I'll revert the change.

## How to test the behavior?
```python
import numpy as np
from hdmf.spec import GroupSpec, DatasetSpec, AttributeSpec, SpecCatalog, SpecNamespace
from hdmf.build import GroupBuilder, DatasetBuilder
from hdmf.validate import ValidatorMap


def set_up_vmap(dtype):
    spec_catalog = SpecCatalog()
    spec = GroupSpec('A test group specification with a data type',
                     data_type_def='Bar',
                     datasets=[DatasetSpec('an example dataset', dtype, name='data')],
                     attributes=[AttributeSpec('attr1', 'an example attribute', dtype)])
    spec_catalog.register_spec(spec, 'test.yaml')
    namespace = SpecNamespace(
        'a test namespace', 'test_namespace', [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
    return ValidatorMap(namespace)


vmap = set_up_vmap('bool')
value = np.bool_(True)
bar_builder = GroupBuilder('my_bar',
                           attributes={'data_type': 'Bar', 'attr1': value},
                           datasets=[DatasetBuilder('data', value)])
vmap.validate(bar_builder)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
