### PR TITLE
Fix building of Data with no dtype spec and value DataIO wrapping DCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `GroupValidator` now checks if child groups, datasets, and links have the correct quantity of elements and returns
   an `IncorrectQuantityError` for each mismatch. @dsleiter (#500)
 
+### Bug fixes
+- Fix building of Data objects where the spec has no dtype and the Data object value is a DataIO wrapping an
+  AbstractDataChunkIterator. @rly (#512)
+
 ## HDMF 2.3.0 (December 8, 2020)
 
 ### New features

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -767,6 +767,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
         return dtype, shape, spec
 
     def __is_reftype(self, data):
+        if (isinstance(data, AbstractDataChunkIterator) or
+                (isinstance(data, DataIO) and isinstance(data.data, AbstractDataChunkIterator))):
+            return False
+
         tmp = data
         while hasattr(tmp, '__len__') and not isinstance(tmp, (AbstractContainer, str, bytes)):
             tmptmp = None

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -50,6 +50,8 @@ class AbstractDataChunkIterator(metaclass=ABCMeta):
 
     Derived classes must ensure that all abstract methods and abstract properties are implemented, in
     particular, dtype, maxshape, __iter__, ___next__, recommended_chunk_shape, and recommended_data_shape.
+
+    Iterating over AbstractContainer objects is not yet supported.
     """
 
     @abstractmethod

--- a/tests/unit/build_tests/test_io_map_data.py
+++ b/tests/unit/build_tests/test_io_map_data.py
@@ -3,8 +3,10 @@ import os
 import h5py
 import numpy as np
 from hdmf import Container, Data
+from hdmf.backends.hdf5 import H5DataIO
 from hdmf.build import (GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager, TypeMap, ReferenceBuilder,
                         ReferenceTargetNotBuiltError)
+from hdmf.data_utils import DataChunkIterator
 from hdmf.spec import (AttributeSpec, DatasetSpec, DtypeSpec, GroupSpec, SpecCatalog, SpecNamespace, NamespaceCatalog,
                        RefSpec)
 from hdmf.spec.spec import ZERO_OR_MANY
@@ -17,7 +19,7 @@ from tests.unit.utils import Foo, CORE_NAMESPACE
 class Baz(Data):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this Baz'},
-            {'name': 'data', 'type': (list, h5py.Dataset), 'doc': 'some data'},
+            {'name': 'data', 'type': (list, h5py.Dataset, 'data', 'array_data'), 'doc': 'some data'},
             {'name': 'baz_attr', 'type': str, 'doc': 'an attribute'})
     def __init__(self, **kwargs):
         name, data, baz_attr = getargs('name', 'data', 'baz_attr', kwargs)
@@ -407,3 +409,50 @@ class TestBuildDatasetOfReferencesUnbuiltTarget(BuildDatasetOfReferencesMixin, T
         msg = "MyBaz (MyBaz): Could not find already-built Builder for Foo 'my_foo1' in BuildManager"
         with self.assertRaisesWith(ReferenceTargetNotBuiltError, msg):
             self.manager.build(baz, root=True)
+
+
+class TestDataIOEdgeCases(TestCase):
+
+    def setUp(self):
+        self.setUpBazSpec()
+        self.spec_catalog = SpecCatalog()
+        self.spec_catalog.register_spec(self.baz_spec, 'test.yaml')
+        self.namespace = SpecNamespace('a test namespace', CORE_NAMESPACE, [{'source': 'test.yaml'}],
+                                       version='0.1.0',
+                                       catalog=self.spec_catalog)
+        self.namespace_catalog = NamespaceCatalog()
+        self.namespace_catalog.add_namespace(CORE_NAMESPACE, self.namespace)
+        self.type_map = TypeMap(self.namespace_catalog)
+        self.type_map.register_container_type(CORE_NAMESPACE, 'Baz', Baz)
+        self.type_map.register_map(Baz, ObjectMapper)
+        self.manager = BuildManager(self.type_map)
+        self.mapper = ObjectMapper(self.baz_spec)
+
+    def setUpBazSpec(self):
+        self.baz_spec = DatasetSpec(
+            doc='an Baz type',
+            dtype=None,
+            name='MyBaz',
+            data_type_def='Baz',
+            shape=[None],
+            attributes=[AttributeSpec('baz_attr', 'an example string attribute', 'text')]
+        )
+
+    def test_build_dataio(self):
+        """Test building of a dataset with data_type and no dtype with value DataIO."""
+        container = Baz('my_baz', H5DataIO(['a', 'b', 'c', 'd'], chunks=True), 'value1')
+        builder = self.type_map.build(container)
+        self.assertIsInstance(builder.get('data'), H5DataIO)
+
+    def test_build_datachunkiterator(self):
+        """Test building of a dataset with data_type and no dtype with value DataChunkIterator."""
+        container = Baz('my_baz', DataChunkIterator(['a', 'b', 'c', 'd']), 'value1')
+        builder = self.type_map.build(container)
+        self.assertIsInstance(builder.get('data'), DataChunkIterator)
+
+    def test_build_dataio_datachunkiterator(self):  # hdmf#512
+        """Test building of a dataset with no dtype and no data_type with value DataIO wrapping a DCI."""
+        container = Baz('my_baz', H5DataIO(DataChunkIterator(['a', 'b', 'c', 'd']), chunks=True), 'value1')
+        builder = self.type_map.build(container)
+        self.assertIsInstance(builder.get('data'), H5DataIO)
+        self.assertIsInstance(builder.get('data').data, DataChunkIterator)


### PR DESCRIPTION
## Motivation

Fix #512.

When the `ObjectMapper` builds a Data object, and the spec for the `Data` object has no dtype (e.g., `VectorData`), then that `Data` object may be an array of references to other datasets. When checking whether the `Data` object's `data` attribute is an array of references in `ObjectMapper.__is_reftype`, an error is raised if the `data` attribute is a `DataIO` object that wraps an `AbstractDataChunkIterator`. The error results from trying to subscript the data chunk iterator.

This PR short circuits `__is_reftype` so it returns False if data is an `AbstractDataChunkIterator` or is a `DataIO` that wraps an `AbstractDataChunkIterator`.

This means an `AbstractDataChunkIterator` cannot contain references. I think this is a reasonable restriction, but perhaps there are use cases I am not considering. Note that prior to this PR, HDMF assumed that an `AbstractDataChunkIterator` does not contain references (i.e., `__is_reftype` returned False).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
