### PR TITLE
Fix TypeError when validating illegally-linked children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Bug fixes
 - Allow `np.bool_` as a valid `bool` dtype when validating. @dsleiter (#505)
+- Fix TypeError when validating a group with an illegally-linked child.
+  @dsleiter (#515)
 
 ### New features
 - `GroupValidator` now checks if child groups, datasets, and links have the correct quantity of elements and returns

--- a/src/hdmf/validate/errors.py
+++ b/src/hdmf/validate/errors.py
@@ -155,7 +155,7 @@ class IllegalLinkError(Error):
             {'name': 'location', 'type': str, 'doc': 'the location of the error', 'default': None})
     def __init__(self, **kwargs):
         name = getargs('name', kwargs)
-        reason = "illegal use of link"
+        reason = "illegal use of link (linked object will not be validated)"
         loc = getargs('location', kwargs)
         super().__init__(name, reason, location=loc)
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -470,6 +470,7 @@ class GroupValidator(BaseStorageValidator):
                     if self.__cannot_be_link(child_spec):
                         errors.append(IllegalLinkError(self.get_spec_loc(child_spec),
                                                        location=self.get_builder_loc(child_builder)))
+                        continue  # do not validate illegally linked objects
                     child_builder = child_builder.builder
                 errors.extend(sub_val.validate(child_builder))
                 n_matching_builders += 1
@@ -493,6 +494,7 @@ class GroupValidator(BaseStorageValidator):
         if isinstance(child_builder, LinkBuilder):
             if not child_spec.linkable:
                 errors.append(IllegalLinkError(self.get_spec_loc(child_spec), location=self.get_builder_loc(builder)))
+                return errors  # do not validate illegally linked objects
             child_builder = child_builder.builder
         if child_builder is None:
             if child_spec.required:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -467,11 +467,10 @@ class GroupValidator(BaseStorageValidator):
             dt_builders = self.__filter_by_name_if_required(builders_matching_type, child_spec.name)
             for child_builder in dt_builders:
                 if isinstance(child_builder, LinkBuilder):
-                    if isinstance(child_spec, LinkSpec) or child_spec.linkable:
-                        child_builder = child_builder.builder
-                    else:
+                    if self.__cannot_be_link(child_spec):
                         errors.append(IllegalLinkError(self.get_spec_loc(child_spec),
                                                        location=self.get_builder_loc(child_builder)))
+                    child_builder = child_builder.builder
                 errors.extend(sub_val.validate(child_builder))
                 n_matching_builders += 1
         if n_matching_builders == 0 and child_spec.required:
@@ -482,17 +481,20 @@ class GroupValidator(BaseStorageValidator):
                                                  n_matching_builders, location=self.get_builder_loc(builder)))
         return errors
 
+    @staticmethod
+    def __cannot_be_link(spec):
+        return not isinstance(spec, LinkSpec) and not spec.linkable
+
     def __validate_untyped_child(self, builder, child_name, child_validator):
         """Validate the named children of parent_builder which have no defined data type"""
         errors = []
         child_builder = builder.get(child_name)
         child_spec = child_validator.spec
         if isinstance(child_builder, LinkBuilder):
-            if child_spec.linkable:
-                child_builder = child_builder.builder
-            else:
+            if not child_spec.linkable:
                 errors.append(IllegalLinkError(self.get_spec_loc(child_spec), location=self.get_builder_loc(builder)))
-        elif child_builder is None:
+            child_builder = child_builder.builder
+        if child_builder is None:
             if child_spec.required:
                 errors.append(MissingError(self.get_spec_loc(child_spec), location=self.get_builder_loc(builder)))
         else:

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -8,7 +8,7 @@ from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder
 from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, LinkSpec
 from hdmf.spec.spec import ONE_OR_MANY, ZERO_OR_MANY, ZERO_OR_ONE
 from hdmf.testing import TestCase
-from hdmf.validate import ValidatorMap, GroupValidator
+from hdmf.validate import ValidatorMap
 from hdmf.validate.errors import (DtypeError, MissingError, ExpectedArrayError, MissingDataType,
                                   IncorrectQuantityError, IllegalLinkError)
 


### PR DESCRIPTION
Fix #514. A TypeError is no longer raised when a group with an illegally-linked child is validated.

In addition:
* the illegally-linked object will NOT be validated
* IllegalLinkError message now indicates that the object will not be validated

## Motivation

A TypeError is raised during validation under certain circumstances, as described in #514. This fixes that problem.

## How to test the behavior?

Verify that all the new unit tests pass.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
