### PR TITLE
Fix DynamicTable.get for compound columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 - Allow `np.bool_` as a valid `bool` dtype when validating. @dsleiter (#505)
+- Fix `DynamicTable.get` for compound type columns. @rly (#518)
 
 ### New features
 - `GroupValidator` now checks if child groups, datasets, and links have the correct quantity of elements and returns

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -281,8 +281,12 @@ table[10::-1]  # get rows 10 to 0 in reverse order
 # the following are equivalent to table[0:10:2]
 table[slice(0, 10, 2)]
 table[np.s_[0:10:2]]
-table[[0, 2, 4, 6, 8]]
-table[np.ndarray([0, 2, 4, 6, 8])]
+
+# you can also index a DynamicTable with a list or 1-dimensional numpy array of
+# integer values. This will raise an IndexError if any of the index values is
+# out of bounds of the table.
+table[[0, 2]]
+table[np.array([0, 2])]
 
 ###############################################################################
 # .. note::
@@ -362,9 +366,18 @@ table['col1'][0]  # get the 0th element from column 'col1'
 table['col1'][:2]  # get a list of the 0th and 1st elements
 table['col1'][0:10:2]  # get a list of the 0th to 10th (exclusive) elements in steps of 2
 table['col1'][10::-1]  # get a list of the 10th to 0th elements in reverse order
-table['col1'][slice(0, 10, 2)]  # equivalent to table['col1'][0:10:2]
-table['col1'][np.s_[0:10:2]]  # equivalent to table['col1'][0:10:2]
 
+# the following are equivalent to table['col1'][0:10:2]
+table['col1'][slice(0, 10, 2)]
+table['col1'][np.s_[0:10:2]]
+
+# you can also index a column with a list or 1-dimensional numpy array of
+# integer values. This will raise an IndexError if any of the index values is
+# out of bounds of the table.
+table['col1'][[0, 2]]
+table['col1'][np.array([0, 2])]
+
+# this slicing and indexing works for ragged array columns as well
 table['col4'][:2]  # get a list of the 0th and 1st list elements
 
 ###############################################################################

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -277,8 +277,12 @@ table[0]  # get the 0th row of the table as a DataFrame
 table[:2]  # get the first two rows
 table[0:10:2]  # get rows 0 to 10 (exclusive) in steps of 2
 table[10::-1]  # get rows 10 to 0 in reverse order
-table[slice(0, 10, 2)]  # equivalent to table[0:10:2, 'col1']
-table[np.s_[0:10:2]]  # equivalent to table[0:10:2, 'col1']
+
+# the following are equivalent to table[0:10:2]
+table[slice(0, 10, 2)]
+table[np.s_[0:10:2]]
+table[[0, 2, 4, 6, 8]]
+table[np.ndarray([0, 2, 4, 6, 8])]
 
 ###############################################################################
 # .. note::

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -763,7 +763,6 @@ class DynamicTable(Container):
                 return default
         else:
             # index by int, list, np.ndarray, or slice --> return pandas Dataframe consisting of one or more rows
-            # determine the key. If the key is an int, then turn it into a slice to reduce the number of cases below
             arg = key
             ret = OrderedDict()
             try:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -738,7 +738,8 @@ class DynamicTable(Container):
 
         :return: 1) If key is a string, then return array with the data of the selected column
                  2) If key is a tuple of (int, str), then return the scalar value of the selected cell
-                 3) If key is an int, list or slice, then return pandas.DataFrame consisting of one or more rows
+                 3) If key is an int, list, np.ndarray, or slice, then return pandas.DataFrame consisting of one or
+                    more rows
 
         :raises: KeyError
         """
@@ -761,35 +762,20 @@ class DynamicTable(Container):
             else:
                 return default
         else:
-            # index by int, list, or slice --> return pandas Dataframe consisting of one or more rows
+            # index by int, list, np.ndarray, or slice --> return pandas Dataframe consisting of one or more rows
             # determine the key. If the key is an int, then turn it into a slice to reduce the number of cases below
             arg = key
+            ret = OrderedDict()
             try:
-                if np.issubdtype(type(arg), np.integer):
-                    ret = OrderedDict()
-                    ret['id'] = self.id.data[arg]
-                    for name in self.colnames:
-                        col = self.__df_cols[self.__colids[name]]
-                        ret[name] = col.get(arg, df=df, **kwargs)
-                # index with a python slice (or single integer) to select one or multiple rows
-                elif isinstance(arg, slice):
-                    ret = OrderedDict()
-                    ret['id'] = self.id.data[arg]
-                    for name in self.colnames:
-                        col = self.__df_cols[self.__colids[name]]
-                        ret[name] = col.get(arg, df=df, **kwargs)
-                # index by a list of ints, return multiple rows
-                elif isinstance(arg, (list, np.ndarray)):
-                    if isinstance(arg, np.ndarray):
-                        if len(arg.shape) != 1:
-                            raise ValueError("cannot index DynamicTable with multiple dimensions")
-                    ret = OrderedDict()
-                    ret['id'] = self.id[arg]
-                    for name in self.colnames:
-                        col = self.__df_cols[self.__colids[name]]
-                        ret[name] = col.get(arg, df=df, **kwargs)
-                else:
+                # index with a python slice or single int to select one or multiple rows
+                if not (np.issubdtype(type(arg), np.integer) or isinstance(arg, (slice, list, np.ndarray))):
                     raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
+                if isinstance(arg, np.ndarray) and len(arg.shape) != 1:
+                    raise ValueError("cannot index DynamicTable with multiple dimensions")
+                ret['id'] = self.id[arg]
+                for name in self.colnames:
+                    col = self.__df_cols[self.__colids[name]]
+                    ret[name] = col.get(arg, df=df, **kwargs)
             except ValueError as ve:
                 x = re.match(r"^Index \((.*)\) out of range \(.*\)$", str(ve))
                 if x:
@@ -811,7 +797,7 @@ class DynamicTable(Container):
                 if np.isscalar(id_index):
                     id_index = [id_index]
                 retdf = OrderedDict()
-                for k in ret:
+                for k in ret:  # for each column
                     if isinstance(ret[k], np.ndarray):
                         if ret[k].ndim == 1:
                             if len(id_index) == 1:
@@ -827,7 +813,7 @@ class DynamicTable(Container):
                                 retdf[k] = list(ret[k])
                             else:
                                 raise ValueError('unable to convert selection to DataFrame')
-                    elif isinstance(ret[k], list):
+                    elif isinstance(ret[k], (list, tuple)):
                         if len(id_index) == 1:
                             # k is a multi-dimension column, and
                             # only one element has been selected

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -506,6 +506,50 @@ Fields:
         with self.assertRaisesWith(IndexError, msg):
             table[5]
 
+    def test_multidim_col(self):
+        multidim_data = [
+            [[1, 2], [3, 4], [5, 6]],
+            ((1, 2), (3, 4), (5, 6)),
+            [(1, 'a', True), (2, 'b', False), (3, 'c', True)],
+        ]
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec, multidim_data)
+        ]
+        table = DynamicTable("with_columns_and_data", 'a test table', columns=columns)
+        df = table.to_dataframe()
+        df2 = pd.DataFrame({'foo': multidim_data[0],
+                            'bar': multidim_data[1],
+                            'baz': multidim_data[2]},
+                           index=pd.Index(name='id', data=[0, 1, 2]))
+        pd.testing.assert_frame_equal(df, df2)
+
+        df3 = pd.DataFrame({'foo': [multidim_data[0][0]],
+                            'bar': [multidim_data[1][0]],
+                            'baz': [multidim_data[2][0]]},
+                           index=pd.Index(name='id', data=[0]))
+        pd.testing.assert_frame_equal(table.get(0), df3)
+
+    def test_multidim_col_one_elt_list(self):
+        data = [[1, 2]]
+        col = VectorData(name='data', description='desc', data=data)
+        table = DynamicTable('test', 'desc', columns=(col, ))
+        df = table.to_dataframe()
+        df2 = pd.DataFrame({'data': [x for x in data]},
+                           index=pd.Index(name='id', data=[0]))
+        pd.testing.assert_frame_equal(df, df2)
+        pd.testing.assert_frame_equal(table.get(0), df2)
+
+    def test_multidim_col_one_elt_tuple(self):
+        data = [(1, 2)]
+        col = VectorData(name='data', description='desc', data=data)
+        table = DynamicTable('test', 'desc', columns=(col, ))
+        df = table.to_dataframe()
+        df2 = pd.DataFrame({'data': [x for x in data]},
+                           index=pd.Index(name='id', data=[0]))
+        pd.testing.assert_frame_equal(df, df2)
+        pd.testing.assert_frame_equal(table.get(0), df2)
+
 
 class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 


### PR DESCRIPTION
@oruebel ran into the error `ValueError: Shape of passed values is (3, 1), indices imply (1, 1)` in `DynamicTable.get` when the table has a compound column and one element. This PR fixes that error.

I also refactored an earlier section of code in `DynamicTable.get` to reduce code duplication and increase readability.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
