### PR TITLE
Fix error when constructing some extension data using get_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,21 @@
 
 ## HDMF 2.4.0 (Upcoming)
 
-### Internal improvements
-- Update CI. @rly (#432)
-
-### Bug fixes
-- Allow `np.bool_` as a valid `bool` dtype when validating. @dsleiter (#505)
-- Fix `DynamicTable.get` for compound type columns. @rly (#518)
-
 ### New features
 - `GroupValidator` now checks if child groups, datasets, and links have the correct quantity of elements and returns
   an `IncorrectQuantityError` for each mismatch. @dsleiter (#500)
 
+### Internal improvements
+- Update CI. @rly (#432)
+- Added  driver option for ros3. @bendichter (#506)
+
 ### Bug fixes
+- Allow `np.bool_` as a valid `bool` dtype when validating. @dsleiter (#505)
 - Fix building of Data objects where the spec has no dtype and the Data object value is a DataIO wrapping an
   AbstractDataChunkIterator. @rly (#512)
+- Fix `DynamicTable.get` for compound type columns. @rly (#518)
+- Fix and removed error "Field 'x' cannot be defined in EllipseSeries." when opening files with some extensions. @rly
+  (#519)
 
 ## HDMF 2.3.0 (December 8, 2020)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -640,10 +640,13 @@ class TypeMap:
             else:
                 # if not, add arguments to fields for getter/setter generation
                 dtype = self.__get_type(field_spec)
+                fields_conf = {'name': f,
+                               'doc': field_spec['doc']}
                 if self.__ischild(dtype) and issubclass(base, Container):
-                    fields.append({'name': f, 'child': True})
-                else:
-                    fields.append(f)
+                    fields_conf['child'] = True
+                # if getattr(field_spec, 'value', None) is not None:  # TODO set the fixed value on the class?
+                #     fields_conf['settable'] = False
+                fields.append(fields_conf)
 
             # auto-initialize arguments not found in superclass
             if f not in existing_args:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -128,15 +128,22 @@ class AbstractContainer(metaclass=ExtenderMeta):
             for base_cls in reversed(bases):
                 if issubclass(base_cls, AbstractContainer):
                     break
+
             base_fields = base_cls._get_fields()  # tuple of field names from base class
             if base_fields is not fields:
                 # check whether new fields spec already exists in base class
+                fields_to_remove_from_base = list()
                 for field_name in fields_dict:
                     if field_name in base_fields:
-                        raise ValueError("Field '%s' cannot be defined in %s. It already exists on base class %s."
-                                         % (field_name, cls.__name__, base_cls.__name__))
+                        fields_to_remove_from_base.append(field_name)
                 # prepend field specs from base class to fields list of this class
-                all_fields_conf[0:0] = base_cls.get_fields_conf()
+                # but only field specs that are not redefined in this class
+                base_fields_conf = base_cls.get_fields_conf()  # tuple of fields configurations from base class
+                base_fields_conf_to_add = list()
+                for pconf in base_fields_conf:
+                    if pconf['name'] not in fields_to_remove_from_base:
+                        base_fields_conf_to_add.append(pconf)
+                all_fields_conf[0:0] = base_fields_conf_to_add
 
         # create getter and setter if attribute does not already exist
         # if 'doc' not specified in __fields__, use doc from docval of __init__

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -371,11 +371,16 @@ class TestAbstractContainerFieldsConf(TestCase):
         class NamedFields(AbstractContainer):
             __fields__ = ({'name': 'field1'}, )
 
-        msg = ("Field 'field1' cannot be defined in NamedFieldsChild. It already exists on base class "
-               "NamedFields.")
-        with self.assertRaisesWith(ValueError, msg):
-            class NamedFieldsChild(NamedFields):
-                __fields__ = ({'name': 'field1', 'settable': True}, )
+        class NamedFieldsChild(NamedFields):
+            __fields__ = ({'name': 'field1', 'doc': 'overridden field', 'settable': False}, )
+
+        self.assertEqual(NamedFieldsChild._get_fields(), ('field1', ))
+        ret = NamedFieldsChild.get_fields_conf()
+        self.assertEqual(ret[0], {'name': 'field1', 'doc': 'overridden field', 'settable': False})
+
+        # obj = NamedFieldsChild('test name')
+        # with self.assertRaisesWith(AttributeError, "can't set attribute"):
+        #     obj.field1 = 'field1 value'
 
     def test_mult_inheritance_base_mixin(self):
         class NamedFields(AbstractContainer):


### PR DESCRIPTION
## Motivation

HDMF 2.3.0 introduced a new error that was raised if an API class redefined a container class field in `__fields__` that a superclass defined in `__fields__`. This error should not have been added because it breaks backwards compatibility with previously created extension API classes where this occurs and previously created extension specs where classes are dynamically generated. 

This PR removes the error and instead, replaces the superclass-defined field spec (e.g., name, doc, settable, child) from the list of `__fields__` with the extension-defined field spec. Note that prior to HDMF 2.3.0, both field specs were present in `__fields__` and the superclass-defined field spec was used to create getters and setters, which is not the intended behavior.

This issue resolves https://github.com/NeurodataWithoutBorders/pynwb/issues/1337 and a related issue with the Allen Institute. It requires an urgent release as these are blocking files from being read and validated.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
