### PR TITLE
automatically create dynamic tables

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -679,7 +679,7 @@ class TypeMap:
                 dtype = self.__get_type(field_spec)
                 fields_conf = {'name': f,
                                'doc': field_spec['doc']}
-                if self.__ischild(dtype) and issubclass(base, Container):
+                if self.__ischild(dtype) and issubclass(base, Container) and not isinstance(field_spec, LinkSpec):
                     fields_conf['child'] = True
                 # if getattr(field_spec, 'value', None) is not None:  # TODO set the fixed value on the class?
                 #     fields_conf['settable'] = False

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -608,6 +608,16 @@ class TypeMap:
 
         return docval_args
 
+    @staticmethod
+    def __make_dynamic_table_column(f, field_spec):
+        col_spec = dict(name=f, description=field_spec['doc'])
+        if getattr(field_spec, 'quantity', None) == '?':
+            col_spec.update(required=False)
+        if field_spec[field_spec.inc_key()] == 'DynamicTableRegion':
+            col_spec.update(table=True)
+
+        return col_spec
+
     def __get_cls_dict(self, base, addl_fields, name=None, default_name=None):
         """
         Get __init__ and fields of new class.
@@ -646,12 +656,7 @@ class TypeMap:
             elif base.__name__ == 'DynamicTable' \
                     and getattr(field_spec, field_spec.inc_key(), None) in ('VectorData', 'DynamicTableRegion'):
                 # column of a DynamicTable
-                col_spec = dict(name=f, description=field_spec['doc'])
-                if getattr(field_spec, 'quantity', None) == '?':
-                    col_spec.update(required=False)
-                if field_spec[field_spec.inc_key()] == 'DynamicTableRegion':
-                    col_spec.update(table=True)
-                cols.append(col_spec)
+                cols.append(self.make_dynamic_table_column(f, field_spec))
             else:
                 # if not, add arguments to fields for getter/setter generation
                 dtype = self.__get_type(field_spec)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -574,6 +574,10 @@ class TypeMap:
         """
         docval_args = list(deepcopy(get_docval(base.__init__)))
         for f, field_spec in addl_fields.items():
+            if base.__name__ == 'DynamicTable' \
+                    and getattr(field_spec, 'neurodata_type_inc', None) in (
+                    'VectorData', 'DynamicTableRegion'):
+                continue  # do not add DynamicTable columns to init docval
             docval_arg = dict(name=f, doc=field_spec.doc)
             if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):
                 docval_arg.update(type=(list, tuple, dict, self.__get_type(field_spec)))
@@ -645,6 +649,8 @@ class TypeMap:
                 col_spec = dict(name=f, doc=field_spec['doc'])
                 if getattr(field_spec, 'quantity', None) == '?':
                     col_spec.update(required=False)
+                if field_spec['neurodata_type_inc'] == 'DynamicTableRegion':
+                    col_spec.update(table=True)
                 cols.append(col_spec)
             else:
                 # if not, add arguments to fields for getter/setter generation

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -575,7 +575,7 @@ class TypeMap:
         docval_args = list(deepcopy(get_docval(base.__init__)))
         for f, field_spec in addl_fields.items():
             if base.__name__ == 'DynamicTable' \
-                    and getattr(field_spec, 'neurodata_type_inc', None) in (
+                    and getattr(field_spec, field_spec.inc_key(), None) in (
                     'VectorData', 'DynamicTableRegion'):
                 continue  # do not add DynamicTable columns to init docval
             docval_arg = dict(name=f, doc=field_spec.doc)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -644,12 +644,12 @@ class TypeMap:
                     create='create_{}'.format(f)
                 ))
             elif base.__name__ == 'DynamicTable' \
-                    and getattr(field_spec, 'neurodata_type_inc', None) in ('VectorData', 'DynamicTableRegion'):
+                    and getattr(field_spec, field_spec.inc_key(), None) in ('VectorData', 'DynamicTableRegion'):
                 # column of a DynamicTable
                 col_spec = dict(name=f, description=field_spec['doc'])
                 if getattr(field_spec, 'quantity', None) == '?':
                     col_spec.update(required=False)
-                if field_spec['neurodata_type_inc'] == 'DynamicTableRegion':
+                if field_spec[field_spec.inc_key()] == 'DynamicTableRegion':
                     col_spec.update(table=True)
                 cols.append(col_spec)
             else:

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -646,7 +646,7 @@ class TypeMap:
             elif base.__name__ == 'DynamicTable' \
                     and getattr(field_spec, 'neurodata_type_inc', None) in ('VectorData', 'DynamicTableRegion'):
                 # column of a DynamicTable
-                col_spec = dict(name=f, doc=field_spec['doc'])
+                col_spec = dict(name=f, description=field_spec['doc'])
                 if getattr(field_spec, 'quantity', None) == '?':
                     col_spec.update(required=False)
                 if field_spec['neurodata_type_inc'] == 'DynamicTableRegion':
@@ -674,7 +674,7 @@ class TypeMap:
         if len(clsconf):
             classdict.update(__clsconf__=clsconf)
         if len(cols):
-            classdict.update(__cols__=cols)
+            classdict.update(__columns__=tuple(cols))
 
         docval_args = self._build_docval(base, addl_fields, name, default_name)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -576,7 +576,7 @@ class TypeMap:
         for f, field_spec in addl_fields.items():
             if base.__name__ == 'DynamicTable' \
                     and getattr(field_spec, field_spec.inc_key(), None) in (
-                    'VectorData', 'DynamicTableRegion'):
+                    'VectorData', 'DynamicTableRegion', 'VectorIndex'):
                 continue  # do not add DynamicTable columns to init docval
             docval_arg = dict(name=f, doc=field_spec.doc)
             if getattr(field_spec, 'quantity', None) in (ZERO_OR_MANY, ONE_OR_MANY):

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -656,7 +656,7 @@ class TypeMap:
             elif base.__name__ == 'DynamicTable' \
                     and getattr(field_spec, field_spec.inc_key(), None) in ('VectorData', 'DynamicTableRegion'):
                 # column of a DynamicTable
-                cols.append(self.make_dynamic_table_column(f, field_spec))
+                cols.append(self.__make_dynamic_table_column(f, field_spec))
             else:
                 # if not, add arguments to fields for getter/setter generation
                 dtype = self.__get_type(field_spec)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -537,7 +537,19 @@ class TestDynamicDynamicTable(TestCase):
                     name='my_col',
                     doc='a test column',
                     dtype='float'
-                )
+                ),
+                DatasetSpec(
+                    data_type_inc='VectorData',
+                    name='indexed_col',
+                    doc='a test column',
+                    dtype='float'
+                ),
+                DatasetSpec(
+                    data_type_inc='VectorData',
+                    name='indexed_col_index',
+                    doc='a test column',
+                    dtype='float'
+                ),
             ]
         )
 
@@ -601,7 +613,10 @@ class TestDynamicDynamicTable(TestCase):
 
         test_table = TestTable(name='test_table', description='my test table')
 
-        test_table.add_row(my_col=3.0)
+        test_table.add_row(my_col=3.0, indexed_col=[1.0, 3.0])
+        test_table.add_row(my_col=4.0, indexed_col=[2.0, 4.0])
+
+        np.testing.assert_array_equal(test_table['indexed_col'].target.data, [1., 3., 2., 4.])
 
         test_dtr_table = TestDTRTable(name='test_dtr_table', description='my table')
         test_dtr_table.add_row(

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -564,7 +564,6 @@ class TestDynamicDynamicTable(TestCase):
         writer.write_spec(dict(groups=[self.dt_spec]), spec_fpath)
         writer.write_namespace(self.namespace, namespace_fpath)
         self.namespace_catalog = NamespaceCatalog()
-        #self.namespace_catalog.add_namespace(CORE_NAMESPACE, self.namespace)
         hdmf_typemap = hdmf.common.get_type_map()
         self.namespace_catalog.merge(hdmf_typemap.namespace_catalog)
         self.type_map = TypeMap(self.namespace_catalog)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -16,6 +16,7 @@ from hdmf.spec import (GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecN
                        DtypeSpec, LinkSpec)
 from hdmf.testing import TestCase
 from hdmf.utils import docval, getargs, get_docval
+from hdmf.common import DynamicTable
 
 from tests.unit.utils import CORE_NAMESPACE
 
@@ -428,6 +429,32 @@ class TestDynamicContainer(TestCase):
                       attr3=5.)
         assert multi.bars['my_bar'] == Bar('my_bar', list(range(10)), 'value1', 10)
         assert multi.attr3 == 5.
+
+    def test_dynamic_table(self):
+        dt_spec = GroupSpec(
+            'A test extension that contains a multi',
+            data_type_def='TestTable',
+            data_type_inc='DynamicTable',
+            datasets=[
+                DatasetSpec(
+                    data_type_inc='VectorData',
+                    name='my_col',
+                    doc='a test column',
+                    quantity='?'
+                )
+            ]
+        )
+
+        self.spec_catalog.register_spec(dt_spec, 'extension.yaml')
+        TestTable = self.type_map.get_container_cls(CORE_NAMESPACE, 'TestTable')
+
+        assert issubclass(TestTable, DynamicTable)
+
+        assert TestTable.__cols__[0] == dict(
+            name='my_col',
+            required=False,
+            doc='a test column'
+        )
 
     def test_build_docval(self):
         Bar = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')


### PR DESCRIPTION
## Motivation

fix #234

be able to use `get_class` on dynamic tables.

Works and tested for:
* regular columns
* DynamicTableRegion columns
* indexed columns