### PR TITLE
Update CircleCI docker images, fix python 3.9 typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
-      printenv
+      echo "a$DOCKERHUB_PASSWORDa"
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
+      echo $DOCKERHUB_PASSWORD
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,35 +19,35 @@ references:
 
   py39: &py39
     docker:
-    - image: circleci/python:3.9/0-buster
+    - image: circleci/python:3.9.2-buster
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
-      
+
   py38: &py38
     docker:
-    - image: circleci/python:3.8.6-buster
+    - image: circleci/python:3.8.8-buster
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   py37: &py37
     docker:
-    - image: circleci/python:3.7.9-stretch
+    - image: circleci/python:3.7.10-buster
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   py36: &py36
     docker:
-    - image: circleci/python:3.6.12-stretch
+    - image: circleci/python:3.6.13-buster
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   conda-image: &conda-image
     docker:
-    - image: continuumio/miniconda3:4.8.2
+    - image: continuumio/miniconda3:4.9.2
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
-      echo $DOCKERHUB_PASSWORD
+      printenv
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
-      echo "a$DOCKERHUB_PASSWORDa"
+      python -c "for i in '$PATH': print(i)"
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
-      python -c "for i in '$PATH': print(i)"
+      python -c "for i in '$DOCKERHUB_PASSWORD': print(i)"
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ references:
       flake8 src/hdmf
       flake8 tests
       flake8 --ignore E402,E501,W504 docs/gallery
-      python -c "for i in '$DOCKERHUB_PASSWORD': print(i)"
 
   initialize-venv: &initialize-venv
     name: Initialize Virtual Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 2.4.1 (Upcoming)
+
+### Bug fixes
+- Fix CI testing on Python 3.9. @rly (#523)
+
 ## HDMF 2.4.0 (February 23, 2021)
 
 ### New features


### PR DESCRIPTION
## Motivation

A typo in the CircleCI config prevented nightly CI jobs from being run on Python 3.9. This PR fixes the typo and updates the docker images to the latest for Python 3.6-3.9 and miniconda3.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
