### PR TITLE
Minor updates to CI and copyright date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,8 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
-            if [[ "${TEST_TOX_ENV}" != "py39" ]]; then
-              sudo apt-get install libhdf5
+            if [[ "${TEST_TOX_ENV}" == "py39" ]]; then
+              sudo apt-get install libhdf5-dev
             fi
             pip install tox
             tox -e $TEST_TOX_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
-            if [[ "${TEST_TOX_ENV}" == "py39" ]]; then
+            if [[ "${TEST_TOX_ENV}" == "py38" ]]; then
               sudo apt-get install libhdf5-dev
             fi
             pip install tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
+            if [[ "${TEST_TOX_ENV}" != "py39" ]]; then
+              sudo apt-get install libhdf5
+            fi
             pip install tox
             tox -e $TEST_TOX_ENV
           # Install is expected to be quick. Increase timeout in case there are some network issues.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
-            if [[ "${TEST_TOX_ENV}" == "py38" ]]; then
+            if [[ "${TEST_TOX_ENV}" == "py39" ]]; then
               sudo apt-get install libhdf5-dev
             fi
             pip install tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 2.4.1 (Upcoming)
 
 ### Bug fixes
-- Fix CI testing on Python 3.9. @rly (#523)
+- Fix CI testing on Python 3.9. @rly (#523, #525)
 
 ## HDMF 2.4.0 (February 23, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 2.4.1 (Upcoming)
 
 ### Bug fixes
-- Fix CI testing on Python 3.9. @rly (#523, #525)
+- Fix CI testing on Python 3.9. @rly (#523, #524)
 
 ## HDMF 2.4.0 (February 23, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## HDMF 2.4.1 (Upcoming)
 
-### Bug fixes
-- Fix CI testing on Python 3.9. @rly (#523, #524)
+### Internal improvements
+- Update CI and copyright year. @rly (#523, #524)
 
 ## HDMF 2.4.0 (February 23, 2021)
 

--- a/Legal.txt
+++ b/Legal.txt
@@ -1,4 +1,4 @@
-“hdmf” Copyright (c) 2017-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf” Copyright (c) 2017-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Citing HDMF
 LICENSE
 =======
 
-"hdmf" Copyright (c) 2017-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+"hdmf" Copyright (c) 2017-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -103,7 +103,7 @@ You are under no obligation whatsoever to provide any bug fixes, patches, or upg
 COPYRIGHT
 =========
 
-"hdmf" Copyright (c) 2017-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+"hdmf" Copyright (c) 2017-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
 
 NOTICE.  This Software was developed under funding from the U.S. Department of Energy and the U.S. Government consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, prepare derivative works, and perform publicly and display publicly, and to permit other to do so.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HDMF'
-copyright = u'2017-2020, Hierarchical Data Modeling Framework'
+copyright = u'2017-2021, Hierarchical Data Modeling Framework'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-“hdmf” Copyright (c) 2017-2020, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“hdmf” Copyright (c) 2017-2021, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/tox.ini
+++ b/tox.ini
@@ -136,22 +136,27 @@ basepython = python3.9
 deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
+# Test with python 3.8, pinned dev and doc reqs, and upgraded run requirements
 [testenv:gallery-py38-upgrade-dev]
 basepython = python3.8
 install_command =
     pip install -U -e . {opts} {packages}
 deps =
     -rrequirements-dev.txt
+    -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
+# Test with python 3.8, pinned dev and doc reqs, and pre-release run requirements
 [testenv:gallery-py38-upgrade-dev-pre]
 basepython = python3.8
 install_command =
     pip install -U --pre -e . {opts} {packages}
 deps =
     -rrequirements-dev.txt
+    -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
+# Test with python 3.6, pinned dev reqs, and minimum run requirements
 [testenv:gallery-py36-min-req]
 basepython = python3.6
 deps =


### PR DESCRIPTION
## Motivation

1. Wheels for h5py on python 3.9 have not yet been released, so CI attempts to build h5py. This fails due to `error: libhdf5.so: cannot open shared object file: No such file or directory`. This can be worked around by adding `sudo apt-get install libhdf5`. We will ultimately want to remove this after h5py is officially supported on python 3.9. 
2. Fix missing requirements for custom gallery test.
3. Update copyright date from 2020 to 2021.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
