### PR TITLE
Ensure all specs are validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 - Fix CI testing on Python 3.9. @rly (#523)
+- Fix certain edge cases where `GroupValidator` would not validate all of the child groups or datasets
+  attached to a `GroupBuilder`. @dsleiter (#526)
 
 ## HDMF 2.4.0 (February 23, 2021)
 

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -483,13 +483,18 @@ class BaseStorageSpec(Spec):
 
     @property
     def data_type_inc(self):
-        ''' The data type of this specification '''
+        ''' The data type this specification inherits '''
         return self.get(self.inc_key())
 
     @property
     def data_type_def(self):
         ''' The data type this specification defines '''
         return self.get(self.def_key(), None)
+
+    @property
+    def data_type(self):
+        ''' The data type of this specification '''
+        return self.data_type_def or self.data_type_inc
 
     @property
     def quantity(self):

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -488,11 +488,16 @@ class GroupValidator(BaseStorageValidator):
         """Validate a child builder against a child spec considering links"""
         if isinstance(child_builder, LinkBuilder):
             if self.__cannot_be_link(child_spec):
-                yield IllegalLinkError(self.get_spec_loc(child_spec), location=self.get_builder_loc(parent_builder))
+                yield self.__construct_illegal_link_error(child_spec, parent_builder)
                 return  # do not validate illegally linked objects
             child_builder = child_builder.builder
         child_validator = self.__get_child_validator(child_spec)
         yield from child_validator.validate(child_builder)
+
+    def __construct_illegal_link_error(self, child_spec, parent_builder):
+        name_of_erroneous = self.get_spec_loc(child_spec)
+        builder_loc = self.get_builder_loc(parent_builder)
+        return IllegalLinkError(name_of_erroneous, location=builder_loc)
 
     @staticmethod
     def __cannot_be_link(spec):

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -159,9 +159,6 @@ class ValidatorMap:
     def __init__(self, **kwargs):
         ns = getargs('namespace', kwargs)
         self.__ns = ns
-
-        # build tree that isn't really a tree
-        # map(type, list of child types or self)
         tree = defaultdict(list)
         types = ns.get_registered_types()
         self.__type_key = ns.get_spec(types[0]).type_key()
@@ -174,10 +171,7 @@ class ValidatorMap:
                 tree[parent].append(child)
         for t in tree:
             self.__rec(tree, t)
-
-        # map(type, validators of child types or self)
         self.__valid_types = dict()
-        # map(type, validator of self)
         self.__validators = dict()
         for dt, children in tree.items():
             _list = list()
@@ -193,7 +187,6 @@ class ValidatorMap:
             self.__valid_types[dt] = tuple(_list)
 
     def __rec(self, tree, node):
-        # recursively go through subtypes and convert to tuple when complete
         if not isinstance(tree[node], tuple):
             sub_types = {node}
             for child in tree[node]:

--- a/tests/unit/spec_tests/test_dataset_spec.py
+++ b/tests/unit/spec_tests/test_dataset_spec.py
@@ -230,3 +230,18 @@ class DatasetSpecTests(TestCase):
                         [dtype3],
                         data_type_inc=base,
                         data_type_def='ExtendedTable')
+
+    def test_data_type_property_value(self):
+        """Test that the property data_type has the expected value"""
+        test_cases = {
+            ('Foo', 'Bar'): 'Bar',
+            ('Foo', None): 'Foo',
+            (None, 'Bar'): 'Bar',
+            (None, None): None,
+        }
+        for (data_type_inc, data_type_def), data_type in test_cases.items():
+            with self.subTest(data_type_inc=data_type_inc,
+                              data_type_def=data_type_def, data_type=data_type):
+                group = GroupSpec('A group', name='group',
+                                  data_type_inc=data_type_inc, data_type_def=data_type_def)
+                self.assertEqual(group.data_type, data_type)

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -252,3 +252,18 @@ class GroupSpecTests(TestCase):
                       groups=[subgroup])
 
         self.assertEqual(attribute.path, 'root/GroupType/DatasetType/attribute1')
+
+    def test_data_type_property_value(self):
+        """Test that the property data_type has the expected value"""
+        test_cases = {
+            ('Foo', 'Bar'): 'Bar',
+            ('Foo', None): 'Foo',
+            (None, 'Bar'): 'Bar',
+            (None, None): None,
+        }
+        for (data_type_inc, data_type_def), data_type in test_cases.items():
+            with self.subTest(data_type_inc=data_type_inc,
+                              data_type_def=data_type_def, data_type=data_type):
+                dataset = DatasetSpec('A dataset', 'int', name='dataset',
+                                      data_type_inc=data_type_inc, data_type_def=data_type_def)
+                self.assertEqual(dataset.data_type, data_type)

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from unittest import mock
+from unittest import mock, skip
 
 import numpy as np
 from dateutil.tz import tzlocal
@@ -802,6 +802,21 @@ class TestMultipleChildrenAtDifferentLevelsOfInheritance(TestCase):
         datasets = [
             DatasetBuilder('foo', attributes={'data_type': 'Foo'}),
             DatasetBuilder('bar', attributes={'data_type': 'Bar'})
+        ]
+        builder = GroupBuilder('my_baz', attributes={'data_type': 'Baz'}, datasets=datasets)
+        result = self.vmap.validate(builder)
+        self.assertEqual(len(result), 0)
+
+    @skip("Functionality not yet supported")
+    def test_both_levels_of_hierarchy_validated_inverted_order(self):
+        """Test that when both required children at separate levels of
+        inheritance hierarchy are present, both child specs are satisfied.
+        This should work no matter what the order of the builders.
+        """
+        self.set_up_spec()
+        datasets = [
+            DatasetBuilder('bar', attributes={'data_type': 'Bar'}),
+            DatasetBuilder('foo', attributes={'data_type': 'Foo'})
         ]
         builder = GroupBuilder('my_baz', attributes={'data_type': 'Baz'}, datasets=datasets)
         result = self.vmap.validate(builder)


### PR DESCRIPTION
## Motivation

* Fix #507
* Significant refactoring of the GroupValidator was done in an attempt to make it more easily understandable and facilitate future development
* The logic for matching group builder children against group spec children was extracted to a new SpecMatcher class in order to isolate the matching algorithm, which will need to be improved in future iterations
* New unit tests were added for the improvements listed in #507
* Refactoring was done with future validator issues in mind, such as raising a warning for superfluous builders attached to a group (https://github.com/NeurodataWithoutBorders/pynwb/issues/1332 and https://github.com/NeurodataWithoutBorders/pynwb/issues/942)

I realize that this is a pretty significant change to the GroupValidator code, and am very open to critical comments. Do you think the changes improve readability enough to warrant the change? Is there any clear misunderstanding of how validation should be done?

## How to test the behavior?

Execute the unit tests. All previously existing tests still pass after refactoring, in addition to the new tests.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
