### PR TITLE
Add HDF5IO.get_namespaces() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # HDMF Changelog
 
-## HDMF 2.4.1 (Upcoming)
+## HDMF 2.5.0 (Upcoming)
+
+### New features
+- Add `HDF5IO.get_namespaces(path=path, file=file)` method which returns a dict of namespace name mapped to the
+  namespace version (the largest one if there are multiple) for each namespace cached in the given HDF5 file.
+  @rly (#527)
 
 ### Bug fixes
 - Fix CI testing on Python 3.9. @rly (#523)

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -307,8 +307,9 @@ class H5SpecWriter(SpecWriter):
 
 
 class H5SpecReader(SpecReader):
+    """Class that reads cached JSON-formatted namespace and spec data from an HDF5 group."""
 
-    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 file to read specs from'})
+    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 group to read specs from'})
     def __init__(self, **kwargs):
         self.__group = getargs('group', kwargs)
         super_kwargs = {'source': "%s:%s" % (os.path.abspath(self.__group.file.name), self.__group.name)}
@@ -317,13 +318,12 @@ class H5SpecReader(SpecReader):
 
     def __read(self, path):
         s = self.__group[path][()]
-
-        if isinstance(s, np.ndarray) \
-           and s.shape == (1,):
+        if isinstance(s, np.ndarray) and s.shape == (1,):  # unpack scalar spec dataset
             s = s[0]
 
         if isinstance(s, bytes):
             s = s.decode('UTF-8')
+
         d = json.loads(s)
         return d
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -123,7 +123,9 @@ class HDF5IO(HDMFIO):
             {'name': 'namespaces', 'type': list, 'doc': 'the namespaces to load', 'default': None},
             {'name': 'file', 'type': File, 'doc': 'a pre-existing h5py.File object', 'default': None},
             {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None},
-            returns="dict with the loaded namespaces", rtype=dict)
+            returns=("dict mapping the names of the loaded namespaces to a dict mapping included namespace names and "
+                     "the included data types"),
+            rtype=dict)
     def load_namespaces(cls, **kwargs):
         """Load cached namespaces from a file.
 
@@ -146,7 +148,8 @@ class HDF5IO(HDMFIO):
     def __load_namespaces(cls, namespace_catalog, namespaces, file_obj):
         d = {}
 
-        if SPEC_LOC_ATTR not in file_obj.attrs:
+        if SPEC_LOC_ATTR not in file_obj.attrs:  # pragma: no cover
+            # this should never happen
             msg = "No cached namespaces found in %s" % file_obj.filename
             warnings.warn(msg)
             return d
@@ -238,8 +241,8 @@ class HDF5IO(HDMFIO):
         Order namespaces according to dependency for loading into a NamespaceCatalog
 
         Args:
-            deps (dict): a dictionary that maps a namespace name to a list of name of
-                         the namespaces on which the the namespace is directly dependent
+            deps (dict): a dictionary that maps a namespace name to a list of names of
+                         the namespaces on which the namespace is directly dependent
                          Example: {'a': ['b', 'c'], 'b': ['d'], c: ['d'], 'd': []}
                          Expected output: ['d', 'b', 'c', 'a']
         """

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -183,13 +183,16 @@ class HDF5IO(HDMFIO):
     @docval({'name': 'path', 'type': (str, Path), 'doc': 'the path to the HDF5 file', 'default': None},
             {'name': 'file', 'type': File, 'doc': 'a pre-existing h5py.File object', 'default': None},
             {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None},
-            returns="list with the names of the namespaces in the file", rtype=list)
+            returns="dict mapping names to versions of the namespaces in the file", rtype=dict)
     def get_namespaces(cls, **kwargs):
-        """Get the names of the cached namespaces from a file.
+        """Get the names and versions of the cached namespaces from a file.
 
         If `file` is not supplied, then an :py:class:`h5py.File` object will be opened for the given `path`, the
         namespaces will be read, and the File object will be closed. If `file` is supplied, then
         the given File object will be read from and not closed.
+
+        If there are multiple versions of a namespace cached in the file, then only the latest one (using alphanumeric
+        ordering) is returned. This is the version of the namespace that is loaded by HDF5IO.load_namespaces(...).
 
         :raises ValueError: if both `path` and `file` are supplied but `path` is not the same as the path of `file`.
         """


### PR DESCRIPTION
## Motivation

Work for https://github.com/NeurodataWithoutBorders/nwb-schema/issues/319#issuecomment-781469270

Add `HDF5IO.get_namespaces(path=path, file=file)` method which returns a dict of namespace name mapped to the
namespace version (the largest one if there are multiple) for each namespace cached in the given HDF5 file (`path` and/or `file` must be provided)

I also did some refactoring.

@yarikoptic let me know what you think of this. Once released, since `NWBHDF5IO` extends `HDF5IO`, you can also call `NWBHDF5IO.get_namespaces(path=path, file=file)`.

We could also make `get_namespaces` read the cached spec data into `SpecNamespace` objects  which contains all the properties of a namespace (e.g., docstring, authors, dependencies). The downside is that this would make `SpecNamespace` more public/user-facing than I think we would like. The contents could be converted into a dictionary though.

We could also make `get_namespaces` show *all* of the versions cached for each namespace in a file. I think this would be confusing and not so useful though since the versions not reported are not used by HDMF. Really, they should be removed when a later version is written, but there might be value in preserving that history.

## How to test the behavior?
```python
filepath = 'test.nwb'
print(HDF5IO.get_namespaces(path=filepath))

file = h5py.File('test.nwb', 'r')
print(HDF5IO.get_namespaces(file=file))
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
