### PR TITLE
Refactor MCI to remove need for default init

### DIFF
--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -575,7 +575,6 @@ class MultiContainerInterface(Container):
         if cls is MultiContainerInterface:
             raise TypeError("Can't instantiate class MultiContainerInterface.")
         if not hasattr(cls, '__clsconf__'):
-            # either the API was incorrectly defined or only a subclass with __clsconf__ can be initialized
             raise TypeError("MultiContainerInterface subclass %s is missing __clsconf__ attribute. Please check that "
                             "the class is properly defined." % cls.__name__)
         return super().__new__(cls, *args, **kwargs)
@@ -778,7 +777,7 @@ class MultiContainerInterface(Container):
 
     @ExtenderMeta.pre_init
     def __build_class(cls, name, bases, classdict):
-        """Verify __clsconf__ and create methods based on that.
+        """Verify __clsconf__ and create methods based on __clsconf__.
         This method is called prior to __new__ and __init__ during class declaration in the metaclass.
         """
         if not hasattr(cls, '__clsconf__'):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -571,6 +571,15 @@ class MultiContainerInterface(Container):
     The keys 'attr', 'type', and 'add' are required.
     """
 
+    def __new__(cls, *args, **kwargs):
+        if cls is MultiContainerInterface:
+            raise TypeError("Can't instantiate class MultiContainerInterface.")
+        if not hasattr(cls, '__clsconf__'):
+            # either the API was incorrectly defined or only a subclass with __clsconf__ can be initialized
+            raise TypeError("MultiContainerInterface subclass %s is missing __clsconf__ attribute. Please check that "
+                            "the class is properly defined." % cls.__name__)
+        return super().__new__(cls, *args, **kwargs)
+
     @staticmethod
     def __add_article(noun):
         if isinstance(noun, tuple):

--- a/tests/unit/test_multicontainerinterface.py
+++ b/tests/unit/test_multicontainerinterface.py
@@ -329,22 +329,24 @@ class TestOverrideInit(TestCase):
 
 class TestNoClsConf(TestCase):
 
+    def test_mci_init(self):
+        """Test that an MCI class without a __clsconf__ can be initialized (nothing special happens)."""
+        mci = MultiContainerInterface(name='a')
+        self.assertEqual(mci.name, 'a')
+
     def test_init_no_cls_conf(self):
-        """Test that an MCI class without a __clsconf__ can be declared but __init__ raises an error."""
+        """Test that an MCI subclass without a __clsconf__ can be initialized (nothing special happens)."""
 
         class Bar(MultiContainerInterface):
-
             pass
 
-        msg = "Cannot initialize an instance of MultiContainerInterface subclass Bar."
-        with self.assertRaisesWith(TypeError, msg):
-            Bar(name='a')
+        bar = Bar(name='a')
+        self.assertEqual(bar.name, 'a')
 
     def test_init_superclass_no_cls_conf(self):
         """Test that a subclass of an MCI class without a __clsconf__ can be initialized."""
 
         class Bar(MultiContainerInterface):
-
             pass
 
         class Qux(Bar):

--- a/tests/unit/test_multicontainerinterface.py
+++ b/tests/unit/test_multicontainerinterface.py
@@ -330,18 +330,21 @@ class TestOverrideInit(TestCase):
 class TestNoClsConf(TestCase):
 
     def test_mci_init(self):
-        """Test that an MCI class without a __clsconf__ can be initialized (nothing special happens)."""
-        mci = MultiContainerInterface(name='a')
-        self.assertEqual(mci.name, 'a')
+        """Test that MultiContainerInterface cannot be instantiated."""
+        msg = "Can't instantiate class MultiContainerInterface."
+        with self.assertRaisesWith(TypeError, msg):
+            MultiContainerInterface(name='a')
 
     def test_init_no_cls_conf(self):
-        """Test that an MCI subclass without a __clsconf__ can be initialized (nothing special happens)."""
+        """Test that defining an MCI subclass without __clsconf__ raises an error."""
 
         class Bar(MultiContainerInterface):
             pass
 
-        bar = Bar(name='a')
-        self.assertEqual(bar.name, 'a')
+        msg = ("MultiContainerInterface subclass Bar is missing __clsconf__ attribute. Please check that "
+               "the class is properly defined.")
+        with self.assertRaisesWith(TypeError, msg):
+            Bar(name='a')
 
     def test_init_superclass_no_cls_conf(self):
         """Test that a subclass of an MCI class without a __clsconf__ can be initialized."""


### PR DESCRIPTION
## Motivation

This PR refactors `MultiContainerInterface` to remove the `__init__` method which is a hurdle in refactoring dynamic class generation (see #522). To dynamically generate a `MultiContainerInterface`, we have to call both `super().__init__` of the new class and `MultiContainerInterface.__init__`. The only thing that `MultiContainerInterface.__init__` does is initialize the attributes to LabelledDict. Since this is an object property as opposed to a class property it cannot be done at the class level. This PR moves initialization of the attributes to the getter property if it is not already defined. This might not be the best place to do so, so alternative solutions are welcome.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
