### PR TITLE
Fix DT.to_dataframe and DT.get when DT has DTR

### DIFF
--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -46,17 +46,16 @@ table = DynamicTable(
 # ``range(0, len(column_data))`` by default.
 
 from hdmf.common import VectorData, VectorIndex
-import numpy as np
 
 col1 = VectorData(
     name='col1',
     description='column #1',
-    data=np.array([1, 2]),
+    data=[1, 2],
 )
 col2 = VectorData(
     name='col2',
     description='column #2',
-    data=np.array(['a', 'b']),
+    data=['a', 'b'],
 )
 
 # this table will have two rows with ids 0 and 1
@@ -71,7 +70,7 @@ table_set_ids = DynamicTable(
     name='my table',
     description='an example table',
     columns=[col1, col2],
-    id=np.array([100, 200]),
+    id=[100, 200],
 )
 
 ###############################################################################
@@ -116,7 +115,7 @@ table.add_row(
 table.add_column(
     name='col3',
     description='column #3',
-    data=np.array([True, True, False, True]),  # specify data for the 4 rows in the table
+    data=[True, True, False, True],  # specify data for the 4 rows in the table
 )
 
 ###############################################################################
@@ -134,12 +133,12 @@ table.add_column(
 col1 = VectorData(
     name='col1',
     description='column #1',
-    data=np.array(['1a', '1b', '1c', '2a']),
+    data=['1a', '1b', '1c', '2a'],
 )
 col1_ind = VectorIndex(
     name='col1_index',
     target=col1,
-    data=np.array([3, 4]),
+    data=[3, 4],
 )
 
 table_ragged_col = DynamicTable(
@@ -175,8 +174,8 @@ new_table.add_column(
 table.add_column(
     name='col4',
     description='column #4',
-    data=np.array([1, 0, -1, 0, -1, 1, 1, -1]),
-    index=np.array([3, 4, 6, 8]),  # specify the end indices of data for each row
+    data=[1, 0, -1, 0, -1, 1, 1, -1],
+    index=[3, 4, 6, 8],  # specify the end indices of data for each row
 )
 
 ###############################################################################
@@ -403,12 +402,12 @@ table['col4'][:2]  # get a list of the 0th and 1st list elements
 col5 = VectorData(
     name='col5',
     description='column #5',
-    data=np.array([['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']]),
+    data=[['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']],
 )
 col5_ind = VectorIndex(
     name='col5_index',
     target=col5,
-    data=np.array([2, 3]),
+    data=[2, 3],
 )
 
 ###############################################################################
@@ -429,17 +428,17 @@ col5_ind = VectorIndex(
 col6 = VectorData(
     name='col6',
     description='column #6',
-    data=np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm']),
+    data=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
 )
 col6_ind = VectorIndex(
     name='col6_index',
     target=col6,
-    data=np.array([3, 6, 8, 10, 12, 13]),
+    data=[3, 6, 8, 10, 12, 13],
 )
 col6_ind_ind = VectorIndex(
     name='col6_index_index',
     target=col6_ind,
-    data=np.array([2, 5, 6]),
+    data=[2, 5, 6],
 )
 
 # All indices must be added to the table

--- a/docs/gallery/dynamictable.py
+++ b/docs/gallery/dynamictable.py
@@ -46,16 +46,17 @@ table = DynamicTable(
 # ``range(0, len(column_data))`` by default.
 
 from hdmf.common import VectorData, VectorIndex
+import numpy as np
 
 col1 = VectorData(
     name='col1',
     description='column #1',
-    data=[1, 2],
+    data=np.array([1, 2]),
 )
 col2 = VectorData(
     name='col2',
     description='column #2',
-    data=['a', 'b'],
+    data=np.array(['a', 'b']),
 )
 
 # this table will have two rows with ids 0 and 1
@@ -70,7 +71,7 @@ table_set_ids = DynamicTable(
     name='my table',
     description='an example table',
     columns=[col1, col2],
-    id=[100, 200],
+    id=np.array([100, 200]),
 )
 
 ###############################################################################
@@ -115,7 +116,7 @@ table.add_row(
 table.add_column(
     name='col3',
     description='column #3',
-    data=[True, True, False, True],  # specify data for the 4 rows in the table
+    data=np.array([True, True, False, True]),  # specify data for the 4 rows in the table
 )
 
 ###############################################################################
@@ -133,12 +134,12 @@ table.add_column(
 col1 = VectorData(
     name='col1',
     description='column #1',
-    data=['1a', '1b', '1c', '2a'],
+    data=np.array(['1a', '1b', '1c', '2a']),
 )
 col1_ind = VectorIndex(
     name='col1_index',
     target=col1,
-    data=[3, 4],
+    data=np.array([3, 4]),
 )
 
 table_ragged_col = DynamicTable(
@@ -174,8 +175,8 @@ new_table.add_column(
 table.add_column(
     name='col4',
     description='column #4',
-    data=[1, 0, -1, 0, -1, 1, 1, -1],
-    index=[3, 4, 6, 8],  # specify the end indices of data for each row
+    data=np.array([1, 0, -1, 0, -1, 1, 1, -1]),
+    index=np.array([3, 4, 6, 8]),  # specify the end indices of data for each row
 )
 
 ###############################################################################
@@ -402,12 +403,12 @@ table['col4'][:2]  # get a list of the 0th and 1st list elements
 col5 = VectorData(
     name='col5',
     description='column #5',
-    data=[['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']],
+    data=np.array([['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']]),
 )
 col5_ind = VectorIndex(
     name='col5_index',
     target=col5,
-    data=[2, 3],
+    data=np.array([2, 3]),
 )
 
 ###############################################################################
@@ -428,17 +429,17 @@ col5_ind = VectorIndex(
 col6 = VectorData(
     name='col6',
     description='column #6',
-    data=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+    data=np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm']),
 )
 col6_ind = VectorIndex(
     name='col6_index',
     target=col6,
-    data=[3, 6, 8, 10, 12, 13],
+    data=np.array([3, 6, 8, 10, 12, 13]),
 )
 col6_ind_ind = VectorIndex(
     name='col6_index_index',
     target=col6_ind,
-    data=[2, 5, 6],
+    data=np.array([2, 5, 6]),
 )
 
 # All indices must be added to the table

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@
 h5py==2.9,<3  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16,<1.19.4
 scipy==1.1,<2
-pandas==0.23,<2
+pandas==0.24,<2
 ruamel.yaml==0.15,<1
 jsonschema==2.6.0,<4

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -928,11 +928,12 @@ class DynamicTable(Container):
             col = self.__df_cols[self.__colids[name]]
 
             if isinstance(col, DynamicTableRegion):
-                # col[:] returns df with rows that map to rows of this table
-                # nest a df with a single element for each row in the table
+                # col[:] returns a single df where rows map to the rows of this table
+                # place dfs with a single element for each row in this table (results in nested dfs)
+                # TODO consider mangling column names and merging dataframes
                 data[name] = [col[:].iloc[[i]] for i in range(0, len(col[:]))]
             elif isinstance(col, VectorIndex) and isinstance(col.target, DynamicTableRegion):
-                data[name] = list(col[:])  # col[:] returns list of dfs
+                data[name] = list(col[:])  # col[:] returns a list of dfs, one element per row of this table
             elif isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
                 data[name] = list(col[:])
             else:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1114,7 +1114,7 @@ class DynamicTableRegion(VectorData):
             idx = arg
 
             # get the data at the specified indices
-            if isinstance(self.data, (tuple, list)) and isinstance(idx, list):
+            if isinstance(self.data, (tuple, list)) and isinstance(idx, (list, np.ndarray)):
                 ret = [self.data[i] for i in idx]
             else:
                 ret = self.data[idx]

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -825,14 +825,14 @@ class DynamicTable(Container):
                 if x:
                     msg = ("Row index %s out of range for %s '%s' (length %d)."
                            % (x.groups()[0], self.__class__.__name__, self.name, len(self)))
-                    raise IndexError(msg)
+                    raise IndexError(msg) from ve
                 else:  # pragma: no cover
                     raise ve
             except IndexError as ie:
                 if str(ie) == 'list index out of range':
                     msg = ("Row index out of range for %s '%s' (length %d)."
                            % (self.__class__.__name__, self.name, len(self)))
-                    raise IndexError(msg)
+                    raise IndexError(msg) from ie
                 else:  # pragma: no cover
                     raise ie
             if df:
@@ -864,7 +864,7 @@ class DynamicTable(Container):
                                 self.__merge_dataframes(retdf, ret[k][0], k, id_index)
                             else:  # list of multiple dfs
                                 self.__merge_ragged_dataframes(retdf, ret[k], k)
-                        elif len(id_index) == 1 and not isinstance(col, VectorIndex):
+                        elif len(id_index) == 1 and len(ret[k]) > 1:
                             # k is a multi-dimension column, and
                             # only one element has been selected
                             retdf[k] = [ret[k]]
@@ -1151,10 +1151,11 @@ class DynamicTableRegion(VectorData):
         ret = list()
         for col in result:
             if isinstance(col, list):
-                if isinstance(col[0], list):
-                    ret.append(self._index_lol(col, index, lut))
-                else:
-                    ret.append([col[lut[i]] for i in index])
+                # if isinstance(col[0], list):
+                #     breakpoint()
+                #     ret.append(self._index_lol(col, index, lut))
+                # else:
+                ret.append([col[lut[i]] for i in index])
             elif isinstance(col, np.ndarray):
                 ret.append(np.array([col[lut[i]] for i in index], dtype=col.dtype))
             else:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -882,14 +882,14 @@ class DynamicTable(Container):
 
     @staticmethod
     def __merge_dataframes(retdf, df, colname, id_index):
-        inner_index_colname = '%s_%s' % (colname, df.index.name)
+        inner_index_colname = (colname, df.index.name)
         retdf[inner_index_colname] = df.index.to_numpy()
         if len(id_index) == 1 and len(df) > 1:
             # one row is requested from this table and k has multiple rows
             # wrap the returned array in a list because the scalar index is wrapped in a list
             retdf[inner_index_colname] = [retdf[inner_index_colname]]
         for inner_col in df.columns:
-            new_colname = "%s_%s" % (colname, inner_col)
+            new_colname = (colname, inner_col)
             num_values = len(df[inner_col].values)
             retdf[new_colname] = df[inner_col].to_numpy()
             if len(id_index) == 1 and num_values > 1:
@@ -900,10 +900,10 @@ class DynamicTable(Container):
     @staticmethod
     def __merge_ragged_dataframes(retdf, dfs, colname):
         # dfs is a list of dfs - result of get call on ragged DTR
-        inner_index_colname = '%s_%s' % (colname, dfs[0].index.name)
+        inner_index_colname = (colname, dfs[0].index.name)
         retdf[inner_index_colname] = [df.index.to_numpy() for df in dfs]
         for inner_col in dfs[0].columns:
-            new_colname = "%s_%s" % (colname, inner_col)
+            new_colname = (colname, inner_col)
             retdf[new_colname] = [df[inner_col].to_numpy() for df in dfs]
 
     def __contains__(self, val):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -842,6 +842,7 @@ class DynamicTable(Container):
                     id_index = [id_index]
                 retdf = OrderedDict()
                 for k in ret:  # for each column
+                    col = self.__df_cols[self.__colids[k]]
                     if isinstance(ret[k], np.ndarray):
                         if ret[k].ndim == 1:
                             if len(id_index) == 1:
@@ -858,6 +859,9 @@ class DynamicTable(Container):
                             else:
                                 raise ValueError('unable to convert selection to DataFrame')
                     elif isinstance(ret[k], (list, tuple)):
+                        # if len(ret[k]) == 1 and isinstance(ret[k][0], pd.DataFrame):
+                        #     self.__merge_dataframes(retdf, ret[k][0], k, id_index)
+                        # elif len(id_index) == 1 and not isinstance(col, VectorIndex):
                         if len(id_index) == 1:
                             # k is a multi-dimension column, and
                             # only one element has been selected
@@ -869,15 +873,36 @@ class DynamicTable(Container):
                         for col in ret[k].columns:
                             newcolname = "%s_%s" % (k, col)
                             retdf[newcolname] = ret[k][col].values
+                        # retdf[k] = [ret[k]]
+                    #     retdf['%s_%s' % (k, ret[k].index.name)] = ret[k].index.values
+                    #     for col in ret[k].columns:
+                    #         newcolname = "%s_%s" % (k, col)
+                    #         retdf[newcolname] = ret[k][col].values
+                        # self.__merge_dataframes(retdf, ret[k], k, id_index)
                     else:
                         retdf[k] = ret[k]
                 ret = pd.DataFrame(retdf, index=pd.Index(name=self.id.name, data=id_index))
-                # if isinstance(key, (int, np.integer)):
-                #     ret = ret.iloc[0]
             else:
                 ret = list(ret.values())
 
         return ret
+
+    @staticmethod
+    def __merge_dataframes(retdf, df, colname, id_index):
+        inner_index_colname = '%s_%s' % (colname, df.index.name)
+        retdf[inner_index_colname] = df.index.to_numpy()
+        if len(id_index) == 1 and len(df) > 1:
+            # one row is requested from this table and k has multiple rows
+            # wrap the returned array in a list because the scalar index is wrapped in a list
+            retdf[inner_index_colname] = [retdf[inner_index_colname]]
+        for inner_col in df.columns:
+            new_colname = "%s_%s" % (colname, inner_col)
+            num_values = len(df[inner_col].values)
+            retdf[new_colname] = df[inner_col].to_numpy()
+            if num_values > 1:
+                # wrap the returned array in a list
+                # note: to_numpy does not copy. tolist also does not copy but does not maintain dtype
+                retdf[new_colname] = [retdf[new_colname]]
 
     def __contains__(self, val):
         """

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -854,6 +854,7 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
         self._assert_list_of_ndarray_equal(exp, rec)
 
 
+@unittest.skipIf(pd.__version__ < '1.0.0', 'Pandas testing code for <1 seems buggy with nested dataframes')
 class TestDynamicTableWithDTR(TestCase):
 
     def setUp(self):
@@ -891,6 +892,7 @@ class TestDynamicTableWithDTR(TestCase):
         data['dtr'].append(self.reftable[2])
         idx = [0, 1, 2]
         expected = pd.DataFrame(data, index=pd.Index(name='id', data=idx))
+        # this comparison fails with pandas < 1.0 due to a mysterious KeyError
         pd.testing.assert_frame_equal(df, expected)
 
     def test_dt_with_indexed_dtr(self):
@@ -910,6 +912,7 @@ class TestDynamicTableWithDTR(TestCase):
         data['dtr'].append(self.reftable[[]])
         idx = [0, 1, 2]
         expected = pd.DataFrame(data, index=pd.Index(name='id', data=idx))
+        # this comparison fails with pandas < 1.0 due to a mysterious KeyError
         pd.testing.assert_frame_equal(df, expected)
 
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1310,6 +1310,97 @@ class TestIndexedEnumData(TestCase):
 
 class IndexTestMixin:
 
+    def test_single_item(self):
+        elem = self.table[0]
+        self._check_one_row_df(elem)
+
+    def test_single_item_no_df(self):
+        elem = self.table.get(0, df=False)
+        self._check_one_row_no_df(elem)
+
+    def test_slice(self):
+        elem = self.table[0:2]
+        self._check_two_rows_df(elem)
+
+    def test_slice_single(self):
+        elem = self.table[0:1]
+        self._check_one_row_df(elem)
+
+    def test_slice_no_df(self):
+        elem = self.table.get(slice(0, 2), df=False)
+        self._check_two_rows_no_df(elem)
+
+    def test_slice_single_no_df(self):
+        elem = self.table.get(slice(0, 1), df=False)
+        self._check_one_row_multiselect_no_df(elem)
+
+    def test_list(self):
+        elem = self.table[[0, 1]]
+        self._check_two_rows_df(elem)
+
+    def test_list_single(self):
+        elem = self.table[[0]]
+        self._check_one_row_df(elem)
+
+    def test_list_no_df(self):
+        elem = self.table.get([0, 1], df=False)
+        self._check_two_rows_no_df(elem)
+
+    def test_list_single_no_df(self):
+        elem = self.table.get([0], df=False)
+        self._check_one_row_multiselect_no_df(elem)
+
+    def test_array(self):
+        elem = self.table[np.array([0, 1])]
+        self._check_two_rows_df(elem)
+
+    def test_array_single(self):
+        elem = self.table[np.array([0])]
+        self._check_one_row_df(elem)
+
+    def test_array_no_df(self):
+        elem = self.table.get(np.array([0, 1]), df=False)
+        self._check_two_rows_no_df(elem)
+
+    def test_array_single_no_df(self):
+        elem = self.table.get(np.array([0]), df=False)
+        self._check_one_row_multiselect_no_df(elem)
+
+
+class TestIndexingArrays(IndexTestMixin, TestCase):
+
+    def setUp(self):
+        self.other_table = DynamicTable(
+            name='table2',
+            description='a test table',
+            id=[10, 11, 12]
+        )
+        self.other_table.add_column('foo', 'scalar column', data=np.array([10.0, 11.0, 12.0]))
+        self.other_table.add_column('bar', 'ragged column', index=np.array([2, 3, 6]),
+                                    data=np.array(['s11', 's12', 's21', 's31', 's32', 's33']))
+        self.other_table.add_column('baz', 'multi-dimension column',
+                                    data=np.array([[110.0, 111.0, 112.0],
+                                                   [120.0, 121.0, 122.0],
+                                                   [130.0, 131.0, 132.0]]))
+        # TODO table with DTR pointing to table with DTR not yet tested
+        # TODO test when ragged DTR indices are not in ascending order
+
+        self.table = DynamicTable(
+            name='table1',
+            description='a table to test slicing',
+            id=[0, 1, 2]
+        )
+        self.table.add_column('foo', 'scalar column', data=np.array([0.0, 1.0, 2.0]))
+        self.table.add_column('bar', 'ragged column', index=np.array([2, 3, 6]),
+                              data=np.array(['r11', 'r12', 'r21', 'r31', 'r32', 'r33']))
+        self.table.add_column('baz', 'multi-dimension column',
+                              data=np.array([[10.0, 11.0, 12.0],
+                                             [20.0, 21.0, 22.0],
+                                             [30.0, 31.0, 32.0]]))
+        self.table.add_column('qux', 'DTR column', table=self.other_table, data=np.array([0, 1, 0]))
+        self.table.add_column('corge', 'ragged DTR column', index=np.array([2, 3, 6]), table=self.other_table,
+                              data=np.array([0, 1, 2, 0, 1, 2]))
+
     def _check_two_rows_df(self, elem):
         data = OrderedDict()
         data['foo'] = np.array([0.0, 1.0])
@@ -1453,64 +1544,8 @@ class IndexTestMixin:
         for i, j in zip(elem[5], expected):
             self.assertNestedRaggedArrayEqual(i, j)
 
-    def test_single_item(self):
-        elem = self.table[0]
-        self._check_one_row_df(elem)
 
-    def test_single_item_no_df(self):
-        elem = self.table.get(0, df=False)
-        self._check_one_row_no_df(elem)
-
-    def test_slice(self):
-        elem = self.table[0:2]
-        self._check_two_rows_df(elem)
-
-    def test_slice_single(self):
-        elem = self.table[0:1]
-        self._check_one_row_df(elem)
-
-    def test_slice_no_df(self):
-        elem = self.table.get(slice(0, 2), df=False)
-        self._check_two_rows_no_df(elem)
-
-    def test_slice_single_no_df(self):
-        elem = self.table.get(slice(0, 1), df=False)
-        self._check_one_row_multiselect_no_df(elem)
-
-    def test_list(self):
-        elem = self.table[[0, 1]]
-        self._check_two_rows_df(elem)
-
-    def test_list_single(self):
-        elem = self.table[[0]]
-        self._check_one_row_df(elem)
-
-    def test_list_no_df(self):
-        elem = self.table.get([0, 1], df=False)
-        self._check_two_rows_no_df(elem)
-
-    def test_list_single_no_df(self):
-        elem = self.table.get([0], df=False)
-        self._check_one_row_multiselect_no_df(elem)
-
-    def test_array(self):
-        elem = self.table[np.array([0, 1])]
-        self._check_two_rows_df(elem)
-
-    def test_array_single(self):
-        elem = self.table[np.array([0])]
-        self._check_one_row_df(elem)
-
-    def test_array_no_df(self):
-        elem = self.table.get(np.array([0, 1]), df=False)
-        self._check_two_rows_no_df(elem)
-
-    def test_array_single_no_df(self):
-        elem = self.table.get(np.array([0]), df=False)
-        self._check_one_row_multiselect_no_df(elem)
-
-
-class TestIndexingArrays(IndexTestMixin, TestCase):
+class TestIndexingLists(IndexTestMixin, TestCase):
 
     def setUp(self):
         self.other_table = DynamicTable(
@@ -1518,13 +1553,13 @@ class TestIndexingArrays(IndexTestMixin, TestCase):
             description='a test table',
             id=[10, 11, 12]
         )
-        self.other_table.add_column('foo', 'scalar column', data=np.array([10.0, 11.0, 12.0]))
-        self.other_table.add_column('bar', 'ragged column', index=np.array([2, 3, 6]),
-                                    data=np.array(['s11', 's12', 's21', 's31', 's32', 's33']))
+        self.other_table.add_column('foo', 'scalar column', data=[10.0, 11.0, 12.0])
+        self.other_table.add_column('bar', 'ragged column', index=[2, 3, 6],
+                                    data=['s11', 's12', 's21', 's31', 's32', 's33'])
         self.other_table.add_column('baz', 'multi-dimension column',
-                                    data=np.array([[110.0, 111.0, 112.0],
-                                                   [120.0, 121.0, 122.0],
-                                                   [130.0, 131.0, 132.0]]))
+                                    data=[[110.0, 111.0, 112.0],
+                                          [120.0, 121.0, 122.0],
+                                          [130.0, 131.0, 132.0]])
         # TODO table with DTR pointing to table with DTR not yet tested
         # TODO test when ragged DTR indices are not in ascending order
 
@@ -1533,86 +1568,159 @@ class TestIndexingArrays(IndexTestMixin, TestCase):
             description='a table to test slicing',
             id=[0, 1, 2]
         )
-        self.table.add_column('foo', 'scalar column', data=np.array([0.0, 1.0, 2.0]))
-        self.table.add_column('bar', 'ragged column', index=np.array([2, 3, 6]),
-                              data=np.array(['r11', 'r12', 'r21', 'r31', 'r32', 'r33']))
+        self.table.add_column('foo', 'scalar column', data=[0.0, 1.0, 2.0])
+        self.table.add_column('bar', 'ragged column', index=[2, 3, 6],
+                              data=['r11', 'r12', 'r21', 'r31', 'r32', 'r33'])
         self.table.add_column('baz', 'multi-dimension column',
-                              data=np.array([[10.0, 11.0, 12.0],
-                                             [20.0, 21.0, 22.0],
-                                             [30.0, 31.0, 32.0]]))
-        self.table.add_column('qux', 'DTR column', table=self.other_table, data=np.array([0, 1, 0]))
-        self.table.add_column('corge', 'ragged DTR column', index=np.array([2, 3, 6]), table=self.other_table,
-                              data=np.array([0, 1, 2, 0, 1, 2]))
+                              data=[[10.0, 11.0, 12.0],
+                                    [20.0, 21.0, 22.0],
+                                    [30.0, 31.0, 32.0]])
+        self.table.add_column('qux', 'DTR column', table=self.other_table, data=[0, 1, 0])
+        self.table.add_column('corge', 'ragged DTR column', index=[2, 3, 6], table=self.other_table,
+                              data=[0, 1, 2, 0, 1, 2])
 
-
-class TestIndexing(TestCase):
-
-    def setUp(self):
-        dt = DynamicTable(name='slice_test_table', description='a table to test slicing',
-                          id=[0, 1, 2])
-        dt.add_column('foo', 'scalar column', data=np.array([0.0, 1.0, 2.0]))
-        dt.add_column('bar', 'ragged column', index=np.array([2, 3, 6]),
-                      data=np.array(['r11', 'r12', 'r21', 'r31', 'r32', 'r33']))
-        dt.add_column('baz', 'multi-dimension column',
-                      data=np.array([[10.0, 11.0, 12.0],
-                                     [20.0, 21.0, 22.0],
-                                     [30.0, 31.0, 32.0]]))
-        self.table = dt
-
-    def test_single_item(self):
-        elem = self.table[0]
+    def _check_two_rows_df(self, elem):
         data = OrderedDict()
-        data['foo'] = 0.0
-        data['bar'] = [np.array(['r11', 'r12'])]
-        data['baz'] = [np.array([10.0, 11.0, 12.0])]
+        data['foo'] = [0.0, 1.0]
+        data['bar'] = [['r11', 'r12'], ['r21']]
+        data['baz'] = [[10.0, 11.0, 12.0],
+                       [20.0, 21.0, 22.0]]
+
+        qux_data = OrderedDict()
+        qux_data['foo'] = [10.0, 11.0]
+        qux_data['bar'] = [['s11', 's12'], ['s21']]
+        qux_data['baz'] = [[110.0, 111.0, 112.0],
+                           [120.0, 121.0, 122.0]]
+        qux_idx = [10, 11]
+        qux_df = pd.DataFrame(data=qux_data, index=pd.Index(name='id', data=qux_idx))
+
+        # qux.data = [0, 1]
+        data['qux_id'] = [qux_df.index.values[0], qux_df.index.values[1]]
+        data['qux_foo'] = [qux_df['foo'].values[0], qux_df['foo'].values[1]]
+        data['qux_bar'] = [qux_df['bar'].values[0], qux_df['bar'].values[1]]
+        data['qux_baz'] = [qux_df['baz'].values[0], qux_df['baz'].values[1]]
+
+        # to get the same behavior for nested dataframes, cannot construct a single dataframe
+        # must construct the nested df and pull rows from it
+        # corge.data = [[0, 1], [2]]
+        corge_data = OrderedDict()
+        corge_data['foo'] = [10.0, 11.0, 12.0]
+        corge_data['bar'] = [['s11', 's12'], ['s21'], ['s31', 's32', 's33']]
+        corge_data['baz'] = [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0],
+                             [130.0, 131.0, 132.0]]
+        corge_idx = [10, 11, 12]
+        corge_df = pd.DataFrame(data=corge_data, index=pd.Index(name='id', data=corge_idx))
+
+        data['corge_id'] = [corge_df.index.values[0:2], corge_df.index.values[[2]]]
+        data['corge_foo'] = [corge_df['foo'].values[0:2], corge_df['foo'].values[[2]]]
+        data['corge_bar'] = [corge_df['bar'].values[0:2], corge_df['bar'].values[[2]]]
+        data['corge_baz'] = [corge_df['baz'].values[0:2], corge_df['baz'].values[[2]]]
+        idx = [0, 1]
+        exp = pd.DataFrame(data=data, index=pd.Index(name='id', data=idx))
+
+        # test 'corge_bar' and 'corge_baz' series separately and then remove them
+        # because elementwise comparison for ragged arrays is not allowed
+        for colname in ['corge_bar', 'corge_baz']:
+            self.assertNestedRaggedArrayEqual(elem[colname].values, exp[colname].values)
+            del elem[colname], exp[colname]
+        pd.testing.assert_frame_equal(elem, exp)
+
+    def _check_one_row_df(self, elem):
+        data = OrderedDict()
+        data['foo'] = [0.0]
+        data['bar'] = [['r11', 'r12']]
+        data['baz'] = [[10.0, 11.0, 12.0]]
+
+        qux_data = OrderedDict()
+        qux_data['foo'] = [10.0]
+        qux_data['bar'] = [['s11', 's12']]
+        qux_data['baz'] = [[110.0, 111.0, 112.0]]
+        qux_idx = [10]
+        qux_df = pd.DataFrame(data=qux_data, index=pd.Index(name='id', data=qux_idx))
+
+        data['qux_id'] = [qux_df.index.values[0]]
+        data['qux_foo'] = [qux_df['foo'].values[0]]
+        data['qux_bar'] = [qux_df['bar'].values[0]]
+        data['qux_baz'] = [qux_df['baz'].values[0]]
+
+        # to get the same behavior for nested dataframes, cannot construct a single dataframe
+        # must construct the nested df and pull rows from it
+        corge_data = OrderedDict()
+        corge_data['foo'] = [10.0, 11.0]
+        corge_data['bar'] = [['s11', 's12'], ['s21']]
+        corge_data['baz'] = [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0]]
+        corge_idx = [10, 11]
+        corge_df = pd.DataFrame(data=corge_data, index=pd.Index(name='id', data=corge_idx))
+
+        data['corge_id'] = [corge_df.index.values[0:2]]
+        data['corge_foo'] = [corge_df['foo'].values[0:2]]
+        data['corge_bar'] = [corge_df['bar'].values[0:2]]
+        data['corge_baz'] = [corge_df['baz'].values[0:2]]
         idx = [0]
         exp = pd.DataFrame(data=data, index=pd.Index(name='id', data=idx))
+
+        # test 'corge_bar' and 'corge_baz' series separately and then remove them
+        # because elementwise comparison for ragged arrays is not allowed
+        for colname in ['corge_bar', 'corge_baz']:
+            self.assertNestedRaggedArrayEqual(elem[colname].values, exp[colname].values)
+            del elem[colname], exp[colname]
         pd.testing.assert_frame_equal(elem, exp)
 
-    def test_single_item_no_df(self):
-        elem = self.table.get(0, df=False)
+    def _check_two_rows_no_df(self, elem):
+        self.assertEqual(elem[0], [0, 1])
+        np.testing.assert_array_equal(elem[1], [0.0, 1.0])
+        np.testing.assert_array_equal(elem[2][0], ['r11', 'r12'])  # TODO do full array equal test
+        np.testing.assert_array_equal(elem[2][1], ['r21'])
+        np.testing.assert_array_equal(elem[3], [[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+        expected = [[10, 11],
+                    [10.0, 11.0],
+                    [['s11', 's12'], ['s21']],
+                    [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0]]]
+        for i, j in zip(elem[4], expected):
+            self.assertNestedRaggedArrayEqual(i, j)
+        expected = [[[10, 11],  # each row is wrapped in a list TODO verify that this is the intended behavior
+                     [10.0, 11.0],
+                     [['s11', 's12'], ['s21']],
+                     [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0]]],
+                    [[12],
+                     [12.0],
+                     [['s31', 's32', 's33']],
+                     [[130.0, 131.0, 132.0]]]]
+        for i, j in zip(elem[5], expected):
+            self.assertNestedRaggedArrayEqual(i, j)
+
+    def _check_one_row_no_df(self, elem):
         self.assertEqual(elem[0], 0)
         self.assertEqual(elem[1], 0.0)
-        np.testing.assert_array_equal(elem[2], np.array(['r11', 'r12']))
-        np.testing.assert_array_equal(elem[3], np.array([10.0, 11.0, 12.0]))
+        np.testing.assert_array_equal(elem[2], ['r11', 'r12'])
+        np.testing.assert_array_equal(elem[3], [10.0, 11.0, 12.0])
+        expected = [10, 10.0, ['s11', 's12'], [110., 111., 112.]]
+        for i, j in zip(elem[4], expected):
+            np.testing.assert_array_equal(i, j)
+        expected = [[10, 11],
+                    [10.0, 11.0],
+                    [['s11', 's12'], ['s21']],
+                    [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0]]]
+        for i, j in zip(elem[5], expected):
+            self.assertNestedRaggedArrayEqual(i, j)
 
-    def test_slice(self):
-        elem = self.table[0:2]
-        data = OrderedDict()
-        data['foo'] = [0.0, 1.0]
-        data['bar'] = [np.array(['r11', 'r12']), np.array(['r21'])]
-        data['baz'] = [np.array([10.0, 11.0, 12.0]),
-                       np.array([20.0, 21.0, 22.0])]
-        idx = [0, 1]
-        exp = pd.DataFrame(data=data, index=pd.Index(name='id', data=idx))
-        pd.testing.assert_frame_equal(elem, exp)
-
-    def test_slice_no_df(self):
-        elem = self.table.get(slice(0, 2), df=False)
-        self.assertEqual(elem[0], [0, 1])
-        np.testing.assert_array_equal(elem[1], np.array([0.0, 1.0]))
-        np.testing.assert_array_equal(elem[2][0], np.array(['r11', 'r12']))
-        np.testing.assert_array_equal(elem[2][1], np.array(['r21']))
-        np.testing.assert_array_equal(elem[3], np.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]]))
-
-    def test_list(self):
-        elem = self.table[[0, 1]]
-        data = OrderedDict()
-        data['foo'] = [0.0, 1.0]
-        data['bar'] = [np.array(['r11', 'r12']), np.array(['r21'])]
-        data['baz'] = [np.array([10.0, 11.0, 12.0]),
-                       np.array([20.0, 21.0, 22.0])]
-        idx = [0, 1]
-        exp = pd.DataFrame(data=data, index=pd.Index(name='id', data=idx))
-        pd.testing.assert_frame_equal(elem, exp)
-
-    def test_list_no_df(self):
-        elem = self.table.get([0, 1], df=False)
-        self.assertEqual(elem[0], [0, 1])
-        np.testing.assert_array_equal(elem[1], np.array([0.0, 1.0]))
-        np.testing.assert_array_equal(elem[2][0], np.array(['r11', 'r12']))
-        np.testing.assert_array_equal(elem[2][1], np.array(['r21']))
-        np.testing.assert_array_equal(elem[3], np.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]]))
+    def _check_one_row_multiselect_no_df(self, elem):
+        # difference from _check_one_row_no_df is that everything is wrapped in a list
+        self.assertEqual(elem[0], [0])
+        self.assertEqual(elem[1], [0.0])
+        np.testing.assert_array_equal(elem[2], [['r11', 'r12']])
+        np.testing.assert_array_equal(elem[3], [[10.0, 11.0, 12.0]])
+        # the individual elements are wrapped
+        expected = [[10], [10.0], [['s11', 's12']], [[110., 111., 112.]]]
+        for i, j in zip(elem[4], expected):
+            np.testing.assert_array_equal(i, j)
+        # the whole list (row) is wrapped
+        expected = [[[10, 11],
+                     [10.0, 11.0],
+                     [['s11', 's12'], ['s21']],
+                     [[110.0, 111.0, 112.0], [120.0, 121.0, 122.0]]]]
+        for i, j in zip(elem[5], expected):
+            self.assertNestedRaggedArrayEqual(i, j)
 
 
 class TestVectorIndex(TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -894,20 +894,20 @@ class TestDynamicTableWithDTR(TestCase):
         pd.testing.assert_frame_equal(df, expected)
 
     def test_dt_with_indexed_dtr(self):
-        dtr = DynamicTableRegion('dtr', [1, 2, 3, 0, 1], 'desc', table=self.reftable)
-        dtr_ind = VectorIndex(name='dtr_index', data=[2, 3, 5], target=dtr)
+        dtr = DynamicTableRegion('dtr', [1, 2, 4, 0], 'desc', table=self.reftable)
+        dtr_ind = VectorIndex(name='dtr_index', data=[3, 4, 4], target=dtr)
         columns = [dtr, dtr_ind]
         self.table = DynamicTable("test_table", 'a test table', columns=columns)
         self.assertTrue(isinstance(self.table['dtr'], VectorIndex))
         fetch_ids = self.table['dtr'].target[:].index.values
-        self.assertListEqual(fetch_ids.tolist(), [1, 2, 3, 0, 1])
+        self.assertListEqual(fetch_ids.tolist(), [1, 2, 4, 0])
 
         df = self.table.to_dataframe()
         data = OrderedDict()
         data['dtr'] = list()
-        data['dtr'].append(self.reftable[[1, 2]])
-        data['dtr'].append(self.reftable[[3]])
-        data['dtr'].append(self.reftable[[0, 1]])
+        data['dtr'].append(self.reftable[[1, 2, 4]])
+        data['dtr'].append(self.reftable[[0]])
+        data['dtr'].append(self.reftable[[]])
         idx = [0, 1, 2]
         expected = pd.DataFrame(data, index=pd.Index(name='id', data=idx))
         pd.testing.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Motivation

Fix #552.

- When a `DynamicTable dt` contains a `DynamicTableRegion dtr`, and `dt.to_dataframe()` is called, then in the resulting DataFrame, the dtr column will have a nested DataFrame for each row. This works for both non-indexed and indexed DTRs. The previous behavior was quite broken -- if the target table had one row, then the dtr column would have a tuple of column names or the letters in the first column name, and if the target table had multiple rows, an error was raised. New functionality will soon be added to introduce a method to return a hierarchical dataframe.

- When a `DynamicTable dt` contains a `DynamicTableRegion dtr` and `dt.get()` or `dt.__getitem__()` is called, then the selected rows of the dtr target table will be merged into the result table with name mangling. See tests for details.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
