### PR TITLE
Improve class generation across namespace dependencies

### DIFF
--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -542,10 +542,10 @@ class TypeMap:
             return None
         ret = self.__container_types[namespace][data_type]
         if isinstance(ret, TypeSource):  # data_type is a dependency from ret.namespace
-            klass = self.get_container_cls(ret.namespace, ret.data_type)  # get class / generate class
+            cls = self.get_container_cls(ret.namespace, ret.data_type)  # get class / generate class
             # register the same class into this namespace (replaces TypeSource)
-            self.register_container_type(namespace, data_type, klass)
-            ret = klass
+            self.register_container_type(namespace, data_type, cls)
+            ret = cls
         return ret
 
     @docval({'name': 'obj', 'type': (GroupBuilder, DatasetBuilder, LinkBuilder, GroupSpec, DatasetSpec),

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -388,11 +388,15 @@ class TestGetClassSeparateNamespace(TestCase):
         )
 
         baz_cls = self.type_map.get_container_cls('ndx-test', 'Baz')  # Qux and Bar are not yet resolved
-        bar_cls = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
-        qux_cls = self.type_map.get_container_cls('ndx-qux', 'Qux')
+        bar_cls = self.type_map.get_container_cls('ndx-test', 'Bar')
+        bar_cls2 = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')
+        qux_cls = self.type_map.get_container_cls('ndx-test', 'Qux')
+        qux_cls2 = self.type_map.get_container_cls('ndx-qux', 'Qux')
         self.assertEqual(qux_cls.__name__, 'Qux')
         self.assertEqual(baz_cls.__name__, 'Baz')
         self.assertEqual(bar_cls.__name__, 'Bar')
+        self.assertIs(bar_cls, bar_cls2)  # same class, two different namespaces
+        self.assertIs(qux_cls, qux_cls2)
         self.assertTrue(issubclass(qux_cls, Data))
         self.assertTrue(issubclass(baz_cls, bar_cls))
         self.assertTrue(issubclass(bar_cls, Container))

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -387,6 +387,7 @@ class TestGetClassSeparateNamespace(TestCase):
             type_map=self.type_map
         )
 
+        # order of generation should not matter as long as dependencies are listed correctly in namespaces
         baz_cls = self.type_map.get_container_cls('ndx-test', 'Baz')  # Qux and Bar are not yet resolved
         bar_cls = self.type_map.get_container_cls('ndx-test', 'Bar')
         bar_cls2 = self.type_map.get_container_cls(CORE_NAMESPACE, 'Bar')


### PR DESCRIPTION
## Motivation

Proposed modification of #555 to handle the failing test and improve cross-namespace class generation. Merging would be into the enh/get_class_fix branch used by #555.

Scenario:
Namespace N1 contains group type A. 
Namespace N2 contains group type B extends A. If class A for type A in namespace N1 does not exist, then the TypeMap now generates this class A, maps type A in namespace N1 to this class A, and maps type A in namespace N2 to *the same class A*.
Namespace N3 contains group type C which includes subgroup type A. The TypeMap now uses the same class A for all three namespaces.

The order of calling get_class on classes and their dependencies thus does not matter.

Note: If get_class is called such that a class is dynamically generated for class A, and later a custom API class is mapped to class A, then the two class As will not be the same, which could lead to unexpected behavior. This is not new behavior -- I just mention that this could happen.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
