### PR TITLE
Improve DynamicTable equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,19 @@
 - Add `HDF5IO.get_namespaces(path=path, file=file)` method which returns a dict of namespace name mapped to the
   namespace version (the largest one if there are multiple) for each namespace cached in the given HDF5 file.
   @rly (#527)
-- Add experimental namespace to HDMF common schema. New data types should go in the experimental namespace 
+- Add experimental namespace to HDMF common schema. New data types should go in the experimental namespace
   (hdmf-experimental) prior to being added to the core (hdmf-common) namespace. The purpose of this is to provide
   a place to test new data types that may break backward compatibility as they are refined. @ajtritt (#545)
-
 - Add `EnumData` type for storing data that comes from a fixed set of values. This replaces `VocabData` i.e.
   `VocabData` has been removed. `VocabData` stored vocabulary elements in an attribute, which has a size limit.
   `EnumData` now stores elements in a separate dataset, referenced by an attribute stored on the `EnumData` dataset.
   @ajtritt (#537)
+- Equality check for `DynamicTable` now also checks that the name and description of the table are the same. @rly (#566)
 
 ### Internal improvements
 - Update CI and copyright year. @rly (#523, #524)
+- Equality check for `DynamicTable` returns False if the other object is a `DynamicTable` instead of raising an error.
+  @rly (#566)
 
 ### Bug fixes
 - Fix CI testing on Python 3.9. @rly (#523)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -593,6 +593,8 @@ class DynamicTable(Container):
 
         :return: Bool indicating whether the two DynamicTables contain the same data
         """
+        if other is self:
+            return True
         if not isinstance(other, DynamicTable):
             return False
         if self.name != other.name or self.description != other.description:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -583,18 +583,20 @@ class DynamicTable(Container):
                 c.add_row(data[colname])
 
     def __eq__(self, other):
-        """
-        Compare if the two DynamicTables contain the same data
+        """Compare if the two DynamicTables contain the same data.
 
-        This implemented by converting the DynamicTables to a pandas dataframe and
-        comparing the equality of the two tables.
+        First this returns False if the other DynamicTable has a different name or
+        description. Then, this table and the other table are converted to pandas
+        dataframes and the equality of the two tables is returned.
 
         :param other: DynamicTable to compare to
 
-        :raises: An error will be raised with to_dataframe is not defined or other
-
         :return: Bool indicating whether the two DynamicTables contain the same data
         """
+        if not isinstance(other, DynamicTable):
+            return False
+        if self.name != other.name or self.description != other.description:
+            return False
         return self.to_dataframe().equals(other.to_dataframe())
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorData'},  # noqa: C901

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -550,6 +550,63 @@ Fields:
         pd.testing.assert_frame_equal(df, df2)
         pd.testing.assert_frame_equal(table.get(0), df2)
 
+    def test_eq(self):
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec, self.data)
+        ]
+        test_table = DynamicTable("with_columns_and_data", 'a test table', columns=columns)
+
+        table = self.with_columns_and_data()
+        self.assertTrue(table == test_table)
+
+    def test_eq_from_df(self):
+        df = pd.DataFrame({
+            'foo': [1, 2, 3, 4, 5],
+            'bar': [10.0, 20.0, 30.0, 40.0, 50.0],
+            'baz': ['cat', 'dog', 'bird', 'fish', 'lizard']
+        }).loc[:, ('foo', 'bar', 'baz')]
+
+        test_table = DynamicTable.from_dataframe(df, 'with_columns_and_data', table_description='a test table')
+        table = self.with_columns_and_data()
+        self.assertTrue(table == test_table)
+
+    def test_eq_diff_missing_col(self):
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec, self.data)
+        ]
+        del columns[-1]
+        test_table = DynamicTable("with_columns_and_data", 'a test table', columns=columns)
+
+        table = self.with_columns_and_data()
+        self.assertFalse(table == test_table)
+
+    def test_eq_diff_name(self):
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec, self.data)
+        ]
+        test_table = DynamicTable("wrong name", 'a test table', columns=columns)
+
+        table = self.with_columns_and_data()
+        self.assertFalse(table == test_table)
+
+    def test_eq_diff_desc(self):
+        columns = [
+            VectorData(name=s['name'], description=s['description'], data=d)
+            for s, d in zip(self.spec, self.data)
+        ]
+        test_table = DynamicTable("with_columns_and_data", 'wrong description', columns=columns)
+
+        table = self.with_columns_and_data()
+        self.assertFalse(table == test_table)
+
+    def test_eq_bad_type(self):
+        container = Container('test_container')
+        table = self.with_columns_and_data()
+        self.assertFalse(table == container)
+
 
 class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
 


### PR DESCRIPTION
## Motivation

When iterating through the `Container` objects in a `MultiContainerInterface` or testing whether a Container is in a `MultiContainerInterface`, the equality method `__eq__` is useful (e.g., `if container in proc_module.data_interfaces`). 

`DynamicTable.__eq__` assumes that the other object is a `DynamicTable` and calls `.to_dataframe()` on it. But if the other object is not a `DynamicTable`, an error is raised, saying the method doesn't exist. 

`DynamicTable.__eq__` should first check that the other object is a `DynamicTable`.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
