### PR TITLE
Do not add MCI as a base if base is already subclass of MCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add `HDF5IO.get_namespaces(path=path, file=file)` method which returns a dict of namespace name mapped to the
   namespace version (the largest one if there are multiple) for each namespace cached in the given HDF5 file.
   @rly (#527)
-- Add experimental namespace to HDMF common schema. New data types should go in the experimental namespace 
+- Add experimental namespace to HDMF common schema. New data types should go in the experimental namespace
   (hdmf-experimental) prior to being added to the core (hdmf-common) namespace. The purpose of this is to provide
   a place to test new data types that may break backward compatibility as they are refined. @ajtritt (#545)
 
@@ -24,6 +24,8 @@
 - Fix CI testing on Python 3.9. @rly (#523)
 - Fix certain edge cases where `GroupValidator` would not validate all of the child groups or datasets
   attached to a `GroupBuilder`. @dsleiter (#526)
+- Fix generation of classes that extends both `MultiContainerInterface` and another class that extends
+  `MultiContainerInterface`. @rly (#567)
 
 ## HDMF 2.4.0 (February 23, 2021)
 

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -341,7 +341,7 @@ class MCIClassGenerator(CustomClassGenerator):
         if '__clsconf__' in classdict:
             # do not add MCI as a base if a base is already a subclass of MultiContainerInterface
             for b in bases:
-                if MultiContainerInterface in b.__mro__:
+                if issubclass(b, MultiContainerInterface):
                     break
             else:
                 bases.insert(0, MultiContainerInterface)

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -339,4 +339,9 @@ class MCIClassGenerator(CustomClassGenerator):
         :param spec: The spec for the container class to generate.
         """
         if '__clsconf__' in classdict:
-            bases.insert(0, MultiContainerInterface)
+            # do not add MCI as a base if a base is already a subclass of MultiContainerInterface
+            for b in bases:
+                if MultiContainerInterface in b.__mro__:
+                    break
+            else:
+                bases.insert(0, MultiContainerInterface)

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -828,9 +828,6 @@ class TestMCIProcessFieldSpec(TestCase):
             groups=[
                 GroupSpec(data_type_inc='EmptyBar', doc='test multi', quantity='*')
             ],
-            attributes=[
-                AttributeSpec(name='attr3', doc='a float attribute', dtype='float')
-            ]
         )
         classdict = dict(
             __clsconf__=[
@@ -847,3 +844,31 @@ class TestMCIProcessFieldSpec(TestCase):
         docval_args = []
         MCIClassGenerator.post_process(classdict, bases, docval_args, multi_spec)
         self.assertEqual(bases, [MultiContainerInterface, Container])
+
+    def test_post_process_already_multi(self):
+        class Multi1(MultiContainerInterface):
+            pass
+
+        multi_spec = GroupSpec(
+            doc='A test extension that contains a multi and extends a multi',
+            data_type_def='Multi2',
+            data_type_inc='Multi1',
+            groups=[
+                GroupSpec(data_type_inc='EmptyBar', doc='test multi', quantity='*')
+            ],
+        )
+        classdict = dict(
+            __clsconf__=[
+                dict(
+                    attr='empty_bars',
+                    type=EmptyBar,
+                    add='add_empty_bars',
+                    get='get_empty_bars',
+                    create='create_empty_bars'
+                )
+            ]
+        )
+        bases = [Multi1]
+        docval_args = []
+        MCIClassGenerator.post_process(classdict, bases, docval_args, multi_spec)
+        self.assertEqual(bases, [Multi1])


### PR DESCRIPTION
## Motivation

When generating a class from a spec that is a `MultiContainerInterface` (because it contains quantity * or + of a group or dataset), `MultiContainerInterface` should be added as a base class. However, sometimes the other base class (X) is already a subclass of `MultiContainerInterface`. This results in:

```TypeError: Cannot create a consistent method resolution order (MRO) for bases MultiContainerInterface, X```

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
