### PR TITLE
Fix #576 Add matplotlib as a requirement for the docs

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,3 +2,4 @@
 sphinx
 sphinx_rtd_theme
 sphinx-gallery
+matplotlib


### PR DESCRIPTION
Fix #576 Add matplotlib as a requirement for the docs

## Checklist

- [X] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
