### PR TITLE
Call DTGenerator.set_init only on DynamicTables

### DIFF
--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -122,6 +122,9 @@ class DynamicTableGenerator(CustomClassGenerator):
 
     @classmethod
     def set_init(cls, classdict, bases, docval_args, not_inherited_fields, name):
+        if '__columns__' not in classdict:
+            return
+
         base_init = classdict.get('__init__')
         if base_init is None:  # pragma: no cover
             raise ValueError("Generated class dictionary is missing base __init__ method.")


### PR DESCRIPTION
## Motivation

`DynamicTableGenerator.set_init` (which adds special handling for the keyword argument 'target_tables' on `__init__` is being called on all generated classes, instead of only on the classes that are `DynamicTable` types. This PR fixes the issue.


## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
