### PR TITLE
Fix wrong data_type_inc key being used in type resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   `MultiContainerInterface`. @rly (#567)
 - Fix `make clean` command for docs to clean up sphinx-gallery tutorial files. @oruebel (#571)
 - Make sure we cannot set ``AlignedDynamicTable`` as a category on an ``AlignedDynamicTable``. @oruebel (#571)
+- Fix included data type resolution between HDMF and custom classes that customize the data_type_inc key. @rly (#586)
 
 ## HDMF 2.4.0 (February 23, 2021)
 


### PR DESCRIPTION
## Motivation

PyNWB loads the spec for `AlignedDynamicTable` and resolves the included datasets from `DynamicTable`, namely:
```
(
    {'shape': [None], 'dims': ['num_rows'], 'dtype': 'int', 'name': 'id', 'doc': 'Array of unique identifiers for the rows of this dynamic table.', 'neurodata_type_inc': 'ElementIdentifiers'}, 
    {'doc': 'Vector columns, including index columns, of this dynamic table.', 'quantity': '*', 'neurodata_type_inc': 'VectorData'}
)
```

However, when the cached spec is read from a file, the included datasets are not resolved. `AlignedDynamicTable` has no datasets.

This only happens when PyNWB loads hdmf-common. In HDMF, both the original spec and the cached spec contain resolved datasets. 

The root error seems to be that the wrong data type inc key is being updated when the spec is resolved. This PR fixes that and cleans up some of the surrounding code.

See https://github.com/hdmf-dev/hdmf/pull/550#issuecomment-824472387 for error message.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
