### PR TITLE
Revert breaking change of `TypeMap.get_container_cls` function header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 2.5.1 (April 23, 2021)
+
+### Bug fix
+- Revert breaking change in `TypeMap.get_container_cls`. While this function is returned to its original behavior,
+  it will be modified at the next major release. Please use the new `TypeMap.get_dt_container_cls` instead. @rly (#590)
+
 ## HDMF 2.5.0 (April 22, 2021)
 
 ### New features

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -147,7 +147,7 @@ class CustomClassGenerator:
         """Search all namespaces for the container class associated with the given data type.
         Raises TypeDoesNotExistError if type is not found in any namespace.
         """
-        container_type = type_map.get_container_cls(type_name)
+        container_type = type_map.get_dt_container_cls(type_name)
         if container_type is None:  # pragma: no cover
             # this should never happen after hdmf#322
             raise TypeDoesNotExistError("Type '%s' does not exist." % type_name)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -1,7 +1,6 @@
 import logging
 from collections import OrderedDict, deque
 from copy import copy
-from warnings import warn
 
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, BaseBuilder
 from .classgenerator import ClassGenerator, CustomClassGenerator, MCIClassGenerator

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -101,6 +101,18 @@ def available_namespaces():
     return __TYPE_MAP.namespace_catalog.namespaces
 
 
+# a function to get the container class for a give type
+@docval({'name': 'data_type', 'type': str,
+         'doc': 'the data_type to get the Container class for'},
+        {'name': 'namespace', 'type': str, 'doc': 'the namespace the data_type is defined in'},
+        is_method=False)
+def get_class(**kwargs):
+    """Get the class object of the Container subclass corresponding to a given neurdata_type.
+    """
+    data_type, namespace = getargs('data_type', 'namespace', kwargs)
+    return __TYPE_MAP.get_dt_container_cls(data_type, namespace)
+
+
 # load the hdmf-common namespace
 __resources = __get_resources()
 if os.path.exists(__resources['namespace_path']):
@@ -129,16 +141,16 @@ else:
     raise RuntimeError("Unable to load a TypeMap - no namespace file found")
 
 
-DynamicTable = __TYPE_MAP.get_container_cls('DynamicTable', CORE_NAMESPACE)
-VectorData = __TYPE_MAP.get_container_cls('VectorData', CORE_NAMESPACE)
-VectorIndex = __TYPE_MAP.get_container_cls('VectorIndex', CORE_NAMESPACE)
-ElementIdentifiers = __TYPE_MAP.get_container_cls('ElementIdentifiers', CORE_NAMESPACE)
-DynamicTableRegion = __TYPE_MAP.get_container_cls('DynamicTableRegion', CORE_NAMESPACE)
-EnumData = __TYPE_MAP.get_container_cls('EnumData', EXP_NAMESPACE)
-CSRMatrix = __TYPE_MAP.get_container_cls('CSRMatrix', CORE_NAMESPACE)
-ExternalResources = __TYPE_MAP.get_container_cls('ExternalResources', EXP_NAMESPACE)
-SimpleMultiContainer = __TYPE_MAP.get_container_cls('SimpleMultiContainer', CORE_NAMESPACE)
-AlignedDynamicTable = __TYPE_MAP.get_container_cls('AlignedDynamicTable', CORE_NAMESPACE)
+DynamicTable = get_class('DynamicTable', CORE_NAMESPACE)
+VectorData = get_class('VectorData', CORE_NAMESPACE)
+VectorIndex = get_class('VectorIndex', CORE_NAMESPACE)
+ElementIdentifiers = get_class('ElementIdentifiers', CORE_NAMESPACE)
+DynamicTableRegion = get_class('DynamicTableRegion', CORE_NAMESPACE)
+EnumData = get_class('EnumData', EXP_NAMESPACE)
+CSRMatrix = get_class('CSRMatrix', CORE_NAMESPACE)
+ExternalResources = get_class('ExternalResources', EXP_NAMESPACE)
+SimpleMultiContainer = get_class('SimpleMultiContainer', CORE_NAMESPACE)
+AlignedDynamicTable = get_class('AlignedDynamicTable', CORE_NAMESPACE)
 
 
 @docval({'name': 'extensions', 'type': (str, TypeMap, list),
@@ -188,18 +200,6 @@ def get_manager(**kwargs):
     '''
     type_map = call_docval_func(get_type_map, kwargs)
     return BuildManager(type_map)
-
-
-# a function to get the container class for a give type
-@docval({'name': 'data_type', 'type': str,
-         'doc': 'the data_type to get the Container class for'},
-        {'name': 'namespace', 'type': str, 'doc': 'the namespace the data_type is defined in'},
-        is_method=False)
-def get_class(**kwargs):
-    """Get the class object of the Container subclass corresponding to a given neurdata_type.
-    """
-    data_type, namespace = getargs('data_type', 'namespace', kwargs)
-    return __TYPE_MAP.get_container_cls(data_type, namespace)
 
 
 @docval({'name': 'io', 'type': HDMFIO,

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -56,7 +56,7 @@ class TestClassGenerator(TestCase):
         namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
         type_map = TypeMap(namespace_catalog)
         type_map.register_generator(MyClassGenerator)
-        cls = type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
 
         self.assertEqual(cls.process_field_spec, ['attr1'])
         self.assertTrue(cls.post_process)
@@ -108,7 +108,7 @@ class TestDynamicContainer(TestCase):
                              attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
                                          AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4'}
         received_args = set()
         for x in get_docval(cls.__init__):
@@ -124,7 +124,7 @@ class TestDynamicContainer(TestCase):
         baz_spec = GroupSpec('doc', default_name='bingo', data_type_def='Baz',
                              attributes=[AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         inst = cls(attr4=10.)
         self.assertEqual(inst.name, 'bingo')
 
@@ -134,7 +134,7 @@ class TestDynamicContainer(TestCase):
                              attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
                                          AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'foo'}
         received_args = set(map(lambda x: x['name'], get_docval(cls.__init__)))
         self.assertSetEqual(expected_args, received_args)
@@ -147,7 +147,7 @@ class TestDynamicContainer(TestCase):
                              attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
                                          AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         # TODO: test that constructor works!
         inst = cls('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0)
         self.assertEqual(inst.name, 'My Baz')
@@ -165,7 +165,7 @@ class TestDynamicContainer(TestCase):
                              attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
                                          AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
 
         with self.assertRaises(TypeError):
             inst = cls('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0)
@@ -188,7 +188,7 @@ class TestDynamicContainer(TestCase):
                                  attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
                                              AttributeSpec('attr4', 'another float attribute', 'float')])
             self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-            cls = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+            cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
 
             inst = cls([1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0)
             self.assertEqual(inst.name, 'A fixed name')
@@ -206,12 +206,12 @@ class TestDynamicContainer(TestCase):
                               groups=[GroupSpec('A composition inside', data_type_inc='Baz2')])
         self.spec_catalog.register_spec(baz_spec1, 'extension.yaml')
         self.spec_catalog.register_spec(baz_spec2, 'extension.yaml')
-        Baz2 = self.type_map.get_container_cls('Baz2', CORE_NAMESPACE)
-        Baz1 = self.type_map.get_container_cls('Baz1', CORE_NAMESPACE)
+        Baz2 = self.type_map.get_dt_container_cls('Baz2', CORE_NAMESPACE)
+        Baz1 = self.type_map.get_dt_container_cls('Baz1', CORE_NAMESPACE)
         Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0,
              baz2=Baz2('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0))
 
-        Bar = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
+        Bar = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
         bar = Bar('My Bar', [1, 2, 3, 4], 'string attribute', 1000)
 
         with self.assertRaises(TypeError):
@@ -230,12 +230,12 @@ class TestDynamicContainer(TestCase):
                               groups=[GroupSpec('A composition inside', data_type_inc='Baz2')])
         self.spec_catalog.register_spec(baz_spec1, 'extension.yaml')
         self.spec_catalog.register_spec(baz_spec2, 'extension.yaml')
-        Baz1 = self.type_map.get_container_cls('Baz1', CORE_NAMESPACE)
-        Baz2 = self.type_map.get_container_cls('Baz2', CORE_NAMESPACE)
+        Baz1 = self.type_map.get_dt_container_cls('Baz1', CORE_NAMESPACE)
+        Baz2 = self.type_map.get_dt_container_cls('Baz2', CORE_NAMESPACE)
         Baz1('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0,
              baz2=Baz2('My Baz', [1, 2, 3, 4], 'string attribute', 1000, attr3=98.6, attr4=1.0))
 
-        Bar = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
+        Bar = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
         bar = Bar('My Bar', [1, 2, 3, 4], 'string attribute', 1000)
 
         with self.assertRaises(TypeError):
@@ -250,14 +250,14 @@ class TestDynamicContainer(TestCase):
 
         msg = "No specification for 'Baz2' in namespace 'test_core'"
         with self.assertRaisesWith(ValueError, msg):
-            self.type_map.get_container_cls('Baz1', CORE_NAMESPACE)
+            self.type_map.get_dt_container_cls('Baz1', CORE_NAMESPACE)
 
     def test_dynamic_container_fixed_name(self):
         """Test that dynamic class generation for an extended type with a fixed name works."""
         baz_spec = GroupSpec('A test extension with no Container class',
                              data_type_def='Baz', data_type_inc=self.bar_spec, name='Baz')
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
-        Baz = self.type_map.get_container_cls('Baz', CORE_NAMESPACE)
+        Baz = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         obj = Baz([1, 2, 3, 4], 'string attribute', attr2=1000)
         self.assertEqual(obj.name, 'Baz')
 
@@ -273,8 +273,8 @@ class TestDynamicContainer(TestCase):
             ]
         )
         self.spec_catalog.register_spec(multi_spec, 'extension.yaml')
-        Bar = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
-        Multi = self.type_map.get_container_cls('Multi', CORE_NAMESPACE)
+        Bar = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
+        Multi = self.type_map.get_dt_container_cls('Multi', CORE_NAMESPACE)
         assert issubclass(Multi, MultiContainerInterface)
         assert Multi.__clsconf__ == [
             dict(
@@ -342,7 +342,7 @@ class TestGetClassSeparateNamespace(TestCase):
             type_map=self.type_map
         )
 
-        cls = self.type_map.get_container_cls('Baz', 'ndx-test')
+        cls = self.type_map.get_dt_container_cls('Baz', 'ndx-test')
         self.assertEqual(cls.__name__, 'Baz')
         self.assertTrue(issubclass(cls, Bar))
 
@@ -365,7 +365,7 @@ class TestGetClassSeparateNamespace(TestCase):
             type_map=self.type_map
         )
         # resolve Spam first so that ndx-qux is resolved first
-        self.type_map.get_container_cls('Spam', 'ndx-qux')
+        self.type_map.get_dt_container_cls('Spam', 'ndx-qux')
 
         baz_spec = GroupSpec(
             doc='A test extension',
@@ -404,69 +404,69 @@ class TestGetClassSeparateNamespace(TestCase):
 
     def test_get_class_include_from_separate_ns_1(self):
         """Test that get_class correctly sets the name and includes types correctly across namespaces.
-        This is one of multiple tests carried out to ensure that order of which get_container_cls is called
+        This is one of multiple tests carried out to ensure that order of which get_dt_container_cls is called
         does not impact the results
 
         first use EXTENSION namespace, then use ORIGINAL namespace
         """
         self._build_separate_namespaces()
 
-        baz_cls = self.type_map.get_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
-        bar_cls = self.type_map.get_container_cls('Bar', 'ndx-test')
-        bar_cls2 = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
-        qux_cls = self.type_map.get_container_cls('Qux', 'ndx-test')
-        qux_cls2 = self.type_map.get_container_cls('Qux', 'ndx-qux')
+        baz_cls = self.type_map.get_dt_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
+        bar_cls = self.type_map.get_dt_container_cls('Bar', 'ndx-test')
+        bar_cls2 = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
+        qux_cls = self.type_map.get_dt_container_cls('Qux', 'ndx-test')
+        qux_cls2 = self.type_map.get_dt_container_cls('Qux', 'ndx-qux')
 
         self._check_classes(baz_cls, bar_cls, bar_cls2, qux_cls, qux_cls2)
 
     def test_get_class_include_from_separate_ns_2(self):
         """Test that get_class correctly sets the name and includes types correctly across namespaces.
-        This is one of multiple tests carried out to ensure that order of which get_container_cls is called
+        This is one of multiple tests carried out to ensure that order of which get_dt_container_cls is called
         does not impact the results
 
         first use ORIGINAL namespace, then use EXTENSION namespace
         """
         self._build_separate_namespaces()
 
-        baz_cls = self.type_map.get_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
-        bar_cls2 = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
-        bar_cls = self.type_map.get_container_cls('Bar', 'ndx-test')
-        qux_cls = self.type_map.get_container_cls('Qux', 'ndx-test')
-        qux_cls2 = self.type_map.get_container_cls('Qux', 'ndx-qux')
+        baz_cls = self.type_map.get_dt_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
+        bar_cls2 = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
+        bar_cls = self.type_map.get_dt_container_cls('Bar', 'ndx-test')
+        qux_cls = self.type_map.get_dt_container_cls('Qux', 'ndx-test')
+        qux_cls2 = self.type_map.get_dt_container_cls('Qux', 'ndx-qux')
 
         self._check_classes(baz_cls, bar_cls, bar_cls2, qux_cls, qux_cls2)
 
     def test_get_class_include_from_separate_ns_3(self):
         """Test that get_class correctly sets the name and includes types correctly across namespaces.
-        This is one of multiple tests carried out to ensure that order of which get_container_cls is called
+        This is one of multiple tests carried out to ensure that order of which get_dt_container_cls is called
         does not impact the results
 
         first use EXTENSION namespace, then use EXTENSION namespace
         """
         self._build_separate_namespaces()
 
-        baz_cls = self.type_map.get_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
-        bar_cls = self.type_map.get_container_cls('Bar', 'ndx-test')
-        bar_cls2 = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
-        qux_cls2 = self.type_map.get_container_cls('Qux', 'ndx-qux')
-        qux_cls = self.type_map.get_container_cls('Qux', 'ndx-test')
+        baz_cls = self.type_map.get_dt_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
+        bar_cls = self.type_map.get_dt_container_cls('Bar', 'ndx-test')
+        bar_cls2 = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
+        qux_cls2 = self.type_map.get_dt_container_cls('Qux', 'ndx-qux')
+        qux_cls = self.type_map.get_dt_container_cls('Qux', 'ndx-test')
 
         self._check_classes(baz_cls, bar_cls, bar_cls2, qux_cls, qux_cls2)
 
     def test_get_class_include_from_separate_ns_4(self):
         """Test that get_class correctly sets the name and includes types correctly across namespaces.
-        This is one of multiple tests carried out to ensure that order of which get_container_cls is called
+        This is one of multiple tests carried out to ensure that order of which get_dt_container_cls is called
         does not impact the results
 
         first use ORIGINAL namespace, then use EXTENSION namespace
         """
         self._build_separate_namespaces()
 
-        baz_cls = self.type_map.get_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
-        bar_cls2 = self.type_map.get_container_cls('Bar', CORE_NAMESPACE)
-        bar_cls = self.type_map.get_container_cls('Bar', 'ndx-test')
-        qux_cls2 = self.type_map.get_container_cls('Qux', 'ndx-qux')
-        qux_cls = self.type_map.get_container_cls('Qux', 'ndx-test')
+        baz_cls = self.type_map.get_dt_container_cls('Baz', 'ndx-test')  # Qux and Bar are not yet resolved
+        bar_cls2 = self.type_map.get_dt_container_cls('Bar', CORE_NAMESPACE)
+        bar_cls = self.type_map.get_dt_container_cls('Bar', 'ndx-test')
+        qux_cls2 = self.type_map.get_dt_container_cls('Qux', 'ndx-qux')
+        qux_cls = self.type_map.get_dt_container_cls('Qux', 'ndx-test')
 
         self._check_classes(baz_cls, bar_cls, bar_cls2, qux_cls, qux_cls2)
 

--- a/tests/unit/common/test_common.py
+++ b/tests/unit/common/test_common.py
@@ -7,7 +7,7 @@ class TestCommonTypeMap(TestCase):
 
     def test_base_types(self):
         tm = get_type_map()
-        cls = tm.get_container_cls('Container', 'hdmf-common')
+        cls = tm.get_dt_container_cls('Container', 'hdmf-common')
         self.assertIs(cls, Container)
-        cls = tm.get_container_cls('Data', 'hdmf-common')
+        cls = tm.get_dt_container_cls('Data', 'hdmf-common')
         self.assertIs(cls, Data)

--- a/tests/unit/common/test_generate_table.py
+++ b/tests/unit/common/test_generate_table.py
@@ -133,8 +133,8 @@ class TestDynamicDynamicTable(TestCase):
         self.type_map.load_namespaces(namespace_fpath)
         self.manager = BuildManager(self.type_map)
 
-        self.TestTable = self.type_map.get_container_cls('TestTable', CORE_NAMESPACE)
-        self.TestDTRTable = self.type_map.get_container_cls('TestDTRTable', CORE_NAMESPACE)
+        self.TestTable = self.type_map.get_dt_container_cls('TestTable', CORE_NAMESPACE)
+        self.TestDTRTable = self.type_map.get_dt_container_cls('TestDTRTable', CORE_NAMESPACE)
 
     def tearDown(self) -> None:
         shutil.rmtree(self.test_dir)


### PR DESCRIPTION
## Motivation

#555 introduced a breaking change in the function header for `TypeMap.get_container_cls`, where the namespace and data_type arguments were swapped and namespace was made optional. Initially, this was thought to be OK for a minor release because this undocumented function is used internally within HDMF and externally only by `pynwb.get_class`. Given the tight relationship between our development of HDMF and PyNWB, we thought we would simply update PyNWB to address this breaking change. Although we are doing that, the versions of HDMF (>=2.1.0, <3) allowed by the current release of PyNWB (1.4.0) rely on the fact that all releases of HDMF up to version 3 would be compatible with this release of PyNWB. In other words, dependency versioning in PyNWB relies on the policy that breaking changes would occur only in major version bumps. Since that policy was not followed strictly, now PyNWB 1.4.0 is broken for all versions of HDMF 2.5.0 and up and users would not know that when they update HDMF but not PyNWB.

Proposed solution (this PR): Effectively revert these breaking changes for now and re-add them for the next major release. These breaking changes are not critical and we can add the new function as `get_dt_container_cls` before changing or removing the old `get_container_cls`. Make a new bugfix release 2.5.1 and perhaps remove 2.5.0 from PyPI and conda-forge.

See also #580 and https://github.com/AllenInstitute/AllenSDK/issues/2098 .

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
