### PR TITLE
Require setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## Upcoming
+
+### Bug fix
+- Add explicit `setuptools` requirement. @hrnciar (#596)
+
 ## HDMF 2.5.1 (April 23, 2021)
 
 ### Bug fix

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -6,3 +6,4 @@ scipy==1.1,<2
 pandas==0.23,<2
 ruamel.yaml==0.15,<1
 jsonschema==2.6.0,<4
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy==1.5.4
 pandas==1.1.5
 ruamel.yaml==0.17.4
 jsonschema==3.2.0
+setuptools==56.0.0


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

pkg_resources needs setuptools as a runtime dependency. Since it wasn't specified so far, there was a possibility of `ModuleNotFoundError: No module named 'pkg_resources'` in case of setuptools not being present. There is a way how to install packages without setuptools or setuptools can be uninstalled after hdmf package was installed. My PR prevents this error.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
