### PR TITLE
Fix sphinx gallery issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add explicit `setuptools` requirement. @hrnciar (#596)
 - Fix issue with generated custom classes that use a custom fields name (e.g., PyNWB uses `__nwbfields__` instead
   of `__fields__`). @rly (#598)
+- Fix issue with Sphinx Gallery. @rly (#601)
 
 ## HDMF 2.5.1 (April 23, 2021)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ sphinx_gallery_conf = {
     'examples_dirs': ['../gallery'],
     # path where to save gallery generated examples
     'gallery_dirs': ['tutorials'],
-    'subsection_order': ExplicitOrder(['../gallery/general', '../gallery/domain']),
+    # 'subsection_order': ExplicitOrder(['../gallery/section1', '../gallery/section2']),
     'backreferences_dir': 'gen_modules/backreferences',
     'min_reported_time': 5,
     'remove_config_comments': True
@@ -73,7 +73,7 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None),
-    'h5py': ('http://docs.h5py.org/en/latest/', None),
+    'h5py': ('https://docs.h5py.org/en/latest/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,6 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['tutorials'],
     'subsection_order': ExplicitOrder(['../gallery/general', '../gallery/domain']),
     'backreferences_dir': 'gen_modules/backreferences',
-    'download_section_examples': False,
     'min_reported_time': 5,
     'remove_config_comments': True
 }


### PR DESCRIPTION
## Motivation

Fix #600. 
Also update h5py intersphinx URL.
Removing 'download_section_examples'=False seems to not do anything, even after adding sections. Apparently this feature was removed some time ago but the docs never updated: https://github.com/sphinx-gallery/sphinx-gallery/issues/376

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
Where 'download_section_examples' is now an unknown key. Fix #600.