### PR TITLE
Add missing support for __columns__ having index=int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 2.5.3 (May 12, 2021)
+
+### Bug fix
+- Fix issue where tables with multi-indexed columns defined using `__columns__` did not have attributes properly set.
+  @rly (#605)
+
 ## HDMF 2.5.2 (May 11, 2021)
 
 ### Bug fix

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -497,7 +497,7 @@ class DynamicTable(Container):
                 data = list(df[name].values)
             index = d.get('index', False)
             if index is not False:
-                if isinstance(index, int):
+                if isinstance(index, int) and index > 1:
                     raise ValueError('Creating nested index columns using this method is not yet supported. Use '
                                      'add_column or define the columns using __columns__ instead.')
                 index_data = None

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -467,9 +467,17 @@ class DynamicTable(Container):
 
                     # set the table attributes for not yet init optional predefined columns
                     setattr(self, col['name'], None)
-                    if col.get('index', False):
-                        self.__uninit_cols[col['name'] + '_index'] = col
-                        setattr(self, col['name'] + '_index', None)
+                    index = col.get('index', False)
+                    if index is not False:
+                        if index is True:
+                            index = 1
+                        if isinstance(index, int):
+                            assert index > 0, ValueError("integer index value must be greater than 0")
+                            index_name = col['name']
+                            for i in range(index):
+                                index_name = index_name + '_index'
+                                self.__uninit_cols[index_name] = col
+                                setattr(self, index_name, None)
                     if col.get('enum', False):
                         self.__uninit_cols[col['name'] + '_elements'] = col
                         setattr(self, col['name'] + '_elements', None)
@@ -487,7 +495,11 @@ class DynamicTable(Container):
             data = None
             if df is not None:
                 data = list(df[name].values)
-            if d.get('index', False):
+            index = d.get('index', False)
+            if index is not False:
+                if isinstance(index, int):
+                    raise ValueError('Creating nested index columns using this method is not yet supported. Use '
+                                     'add_column or define the columns using __columns__ instead.')
                 index_data = None
                 if data is not None:
                     index_data = [len(data[0])]

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -262,16 +262,18 @@ class TestDynamicTable(TestCase):
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)
+        self.assertEqual(table.qux_index_index_index.data, [1, 2])
 
     def test_auto_multi_index(self):
 
         class TestTable(DynamicTable):
-            __columns__ = (dict(name='qux', description='qux column', index=2),)  # this is optional
+            __columns__ = (dict(name='qux', description='qux column', index=3),)  # this is optional
 
         table = TestTable('table_name', 'table_description')
         self.assertIsNone(table.qux)  # these are reserved as attributes but not yet initialized
         self.assertIsNone(table.qux_index)
         self.assertIsNone(table.qux_index_index)
+        self.assertIsNone(table.qux_index_index_index)
         table.add_row(
             qux=[
                     [
@@ -302,6 +304,7 @@ class TestDynamicTable(TestCase):
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)
+        self.assertEqual(table.qux_index_index_index.data, [1, 2])
 
     def test_getitem_row_num(self):
         table = self.with_spec()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -225,31 +225,40 @@ class TestDynamicTable(TestCase):
     def test_auto_multi_index_required(self):
 
         class TestTable(DynamicTable):
-            __columns__ = (dict(name='qux', description='qux column', index=2, required=True),)
+            __columns__ = (dict(name='qux', description='qux column', index=3, required=True),)
 
         table = TestTable('table_name', 'table_description')
         self.assertIsInstance(table.qux, VectorData)  # check that the attribute is set
         self.assertIsInstance(table.qux_index, VectorIndex)  # check that the attribute is set
-        self.assertIsInstance(table.qux_index, VectorIndex)  # check that the attribute is set
+        self.assertIsInstance(table.qux_index_index, VectorIndex)  # check that the attribute is set
+        self.assertIsInstance(table.qux_index_index_index, VectorIndex)  # check that the attribute is set
         table.add_row(
             qux=[
-                [1, 2, 3],
-                [1, 2, 3, 4]
-            ]
+                    [
+                        [1, 2, 3],
+                        [1, 2, 3, 4]
+                    ]
+                ]
         )
         table.add_row(
             qux=[
-                [1, 2]
-            ]
+                    [
+                        [1, 2]
+                    ]
+                ]
         )
 
         expected = [
             [
-                [1, 2, 3],
-                [1, 2, 3, 4]
+                [
+                    [1, 2, 3],
+                    [1, 2, 3, 4]
+                ]
             ],
             [
-                [1, 2]
+                [
+                    [1, 2]
+                ]
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)
@@ -265,23 +274,31 @@ class TestDynamicTable(TestCase):
         self.assertIsNone(table.qux_index_index)
         table.add_row(
             qux=[
-                [1, 2, 3],
-                [1, 2, 3, 4]
-            ]
+                    [
+                        [1, 2, 3],
+                        [1, 2, 3, 4]
+                    ]
+                ]
         )
         table.add_row(
             qux=[
-                [1, 2]
-            ]
+                    [
+                        [1, 2]
+                    ]
+                ]
         )
 
         expected = [
             [
-                [1, 2, 3],
-                [1, 2, 3, 4]
+                [
+                    [1, 2, 3],
+                    [1, 2, 3, 4]
+                ]
             ],
             [
-                [1, 2]
+                [
+                    [1, 2]
+                ]
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -229,6 +229,8 @@ class TestDynamicTable(TestCase):
 
         table = TestTable('table_name', 'table_description')
         self.assertIsInstance(table.qux, VectorData)  # check that the attribute is set
+        self.assertIsInstance(table.qux_index, VectorIndex)  # check that the attribute is set
+        self.assertIsInstance(table.qux_index, VectorIndex)  # check that the attribute is set
         table.add_row(
             qux=[
                 [1, 2, 3],
@@ -258,7 +260,9 @@ class TestDynamicTable(TestCase):
             __columns__ = (dict(name='qux', description='qux column', index=2),)  # this is optional
 
         table = TestTable('table_name', 'table_description')
-        self.assertIsNone(table.qux)  # qux is reserved as an attribute but not yet initialized
+        self.assertIsNone(table.qux)  # these are reserved as attributes but not yet initialized
+        self.assertIsNone(table.qux_index)
+        self.assertIsNone(table.qux_index_index)
         table.add_row(
             qux=[
                 [1, 2, 3],
@@ -651,9 +655,10 @@ class TestDynamicTableRoundTrip(H5RoundTripMixin, TestCase):
         table.add_column('bar', 'a float column')
         table.add_column('baz', 'a string column')
         table.add_column('qux', 'a boolean column')
+        table.add_column('corge', 'a doubly indexed int column', index=2)
         table.add_column('quux', 'an enum column', enum=True)
-        table.add_row(foo=27, bar=28.0, baz="cat", qux=True, quux='a')
-        table.add_row(foo=37, bar=38.0, baz="dog", qux=False, quux='b')
+        table.add_row(foo=27, bar=28.0, baz="cat", corge=[[1, 2, 3], [4, 5, 6]], qux=True, quux='a')
+        table.add_row(foo=37, bar=38.0, baz="dog", corge=[[11, 12, 13], [14, 15, 16]], qux=False, quux='b')
         return table
 
     def test_index_out_of_bounds(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -222,20 +222,54 @@ class TestDynamicTable(TestCase):
                       ]
                       )
 
+    def test_auto_multi_index_required(self):
+
+        class TestTable(DynamicTable):
+            __columns__ = (dict(name='qux', description='qux column', index=2, required=True),)
+
+        table = TestTable('table_name', 'table_description')
+        self.assertIsInstance(table.qux, VectorData)  # check that the attribute is set
+        table.add_row(
+            qux=[
+                [1, 2, 3],
+                [1, 2, 3, 4]
+            ]
+        )
+        table.add_row(
+            qux=[
+                [1, 2]
+            ]
+        )
+
+        expected = [
+            [
+                [1, 2, 3],
+                [1, 2, 3, 4]
+            ],
+            [
+                [1, 2]
+            ]
+        ]
+        self.assertListEqual(table['qux'][:], expected)
+
     def test_auto_multi_index(self):
 
         class TestTable(DynamicTable):
-            __columns__ = (dict(name='qux', description='qux column', index=2),)
+            __columns__ = (dict(name='qux', description='qux column', index=2),)  # this is optional
 
         table = TestTable('table_name', 'table_description')
-        table.add_row(qux=[
-                          [1, 2, 3],
-                          [1, 2, 3, 4]
-                      ])
-        table.add_row(qux=[
-                          [1, 2]
-                      ]
-                      )
+        self.assertIsNone(table.qux)  # qux is reserved as an attribute but not yet initialized
+        table.add_row(
+            qux=[
+                [1, 2, 3],
+                [1, 2, 3, 4]
+            ]
+        )
+        table.add_row(
+            qux=[
+                [1, 2]
+            ]
+        )
 
         expected = [
             [


### PR DESCRIPTION
## Motivation

Fix #603.

This PR does not handle #604 but raises an error message when that situation occurs.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
