### PR TITLE
Fix restricting click version to <8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ jobs:
           command: |
             python -m venv ../venv
             . ../venv/bin/activate
-            pip install click<8 githubrelease
+            pip install "click<8" githubrelease
             githubrelease release $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
               create $CIRCLE_TAG --name $CIRCLE_TAG \
               --publish ./dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 2.5.5 (May 17, 2021)
+
+### Bug fix
+- Fix incompatibility issue with downstream github-release tool used to deploy releases to GitHub. @rly (#614)
+
 ## HDMF 2.5.4 (May 17, 2021)
 
 ### Bug fix


### PR DESCRIPTION
## Motivation

Unfortunately, #607 did not use the correct `pip` syntax. This syntax should work and has been tested locally.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
