### PR TITLE
Drop python 3.6 support, add python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,6 @@ references:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
-  py36: &py36
-    docker:
-    - image: circleci/python:3.6.13-buster
-      auth:
-        username: hdmf
-        password: $DOCKERHUB_PASSWORD
-
   conda-image: &conda-image
     docker:
     - image: continuumio/miniconda3:4.9.2
@@ -163,14 +156,6 @@ jobs:
       - run:
           <<: *run-style-check
 
-  python36:
-    <<: *py36
-    environment:
-      - TEST_TOX_ENV: "py36"
-      - BUILD_TOX_ENV: "build-py36"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall"
-    <<: *ci-steps
-
   python37:
     <<: *py37
     environment:
@@ -196,22 +181,6 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
 
-  python38-upgrade-dev:
-    <<: *py38
-    environment:
-      - TEST_TOX_ENV: "py38-upgrade-dev"
-      - BUILD_TOX_ENV: "build-py38-upgrade-dev"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall"
-    <<: *ci-steps
-
-  python38-upgrade-dev-pre:
-    <<: *py38
-    environment:
-      - TEST_TOX_ENV: "py38-upgrade-dev-pre"
-      - BUILD_TOX_ENV: "build-py38-upgrade-dev-pre"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall"
-    <<: *ci-steps
-
   python39-upgrade-dev:
     <<: *py39
     environment:
@@ -228,22 +197,13 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
 
-  python36-min-req:
-    <<: *py36
+  python37-min-req:
+    <<: *py37
     environment:
-      - TEST_TOX_ENV: "py36-min-req"
-      - BUILD_TOX_ENV: "build-py36-min-req"
+      - TEST_TOX_ENV: "py37-min-req"
+      - BUILD_TOX_ENV: "build-py37-min-req"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
-
-  miniconda36:
-    <<: *conda-image
-    environment:
-      - CONDA_PYTHON_VER: "3.6.*=*_cpython"  # avoid using pypy compiler
-      - TEST_TOX_ENV: "py36"
-      - BUILD_TOX_ENV: "build-py36"
-      - TEST_WHEELINSTALL_ENV: "wheelinstall"
-    <<: *conda-steps
 
   miniconda37:
     <<: *conda-image
@@ -272,12 +232,6 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *conda-steps
 
-  gallery36:
-    <<: *py36
-    environment:
-      - TEST_TOX_ENV: "gallery-py36"
-    <<: *gallery-steps
-
   gallery37:
     <<: *py37
     environment:
@@ -296,18 +250,6 @@ jobs:
       - TEST_TOX_ENV: "gallery-py39"
     <<: *gallery-steps
 
-  gallery38-upgrade-dev:
-    <<: *py38
-    environment:
-      - TEST_TOX_ENV: "gallery-py38-upgrade-dev"
-    <<: *gallery-steps
-
-  gallery38-upgrade-dev-pre:
-    <<: *py38
-    environment:
-      - TEST_TOX_ENV: "gallery-py38-upgrade-dev-pre"
-    <<: *gallery-steps
-
   gallery39-upgrade-dev:
     <<: *py39
     environment:
@@ -320,14 +262,14 @@ jobs:
       - TEST_TOX_ENV: "gallery-py39-upgrade-dev-pre"
     <<: *gallery-steps
 
-  gallery36-min-req:
-    <<: *py36
+  gallery37-min-req:
+    <<: *py37
     environment:
-      - TEST_TOX_ENV: "gallery-py36-min-req"
+      - TEST_TOX_ENV: "gallery-py37-min-req"
     <<: *gallery-steps
 
   deploy-dev:
-    <<: *py38
+    <<: *py39
     steps:
       - checkout
       - attach_workspace:
@@ -347,7 +289,7 @@ jobs:
                 --re-upload
 
   deploy-release:
-    <<: *py38
+    <<: *py39
     steps:
       - attach_workspace:
           at: ./
@@ -371,8 +313,8 @@ jobs:
               create $CIRCLE_TAG --name $CIRCLE_TAG \
               --publish ./dist/*
 
-  pynwb-dev-python38:
-    <<: *py38
+  pynwb-dev-python39:
+    <<: *py39
     steps:
       - checkout
       - run: git submodule sync
@@ -410,27 +352,27 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
-      - python36-min-req:
+      - python37-min-req:
           <<: *no_filters
-      - python38:
+      - python39:
           <<: *no_filters
-      - miniconda36:
+      - miniconda37:
           <<: *no_filters
-      - miniconda38:
+      - miniconda39:
           <<: *no_filters
-      - gallery36-min-req:
+      - gallery37-min-req:
           <<: *no_filters
-      - gallery38:
+      - gallery39:
           <<: *no_filters
       - deploy-dev:
           requires:
             - flake8
-            - python38
-            - python36-min-req
-            - miniconda36
-            - miniconda38
-            - gallery38
-            - gallery36-min-req
+            - python37-min-req
+            - python39
+            - miniconda37
+            - miniconda39
+            - gallery37-min-req
+            - gallery39
           filters:
             tags:
               ignore:
@@ -444,12 +386,12 @@ workflows:
       - deploy-release:
           requires:
             - flake8
-            - python38
-            - python36-min-req
-            - miniconda36
-            - miniconda38
-            - gallery38
-            - gallery36-min-req
+            - python37-min-req
+            - python39
+            - miniconda37
+            - miniconda39
+            - gallery37-min-req
+            - gallery39
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
@@ -474,17 +416,11 @@ workflows:
     jobs:
       - flake8:
           <<: *no_filters
-      - python36:
-          <<: *no_filters
-      - python36-min-req:
-          <<: *no_filters
       - python37:
           <<: *no_filters
+      - python37-min-req:
+          <<: *no_filters
       - python38:
-          <<: *no_filters
-      - python38-upgrade-dev:
-          <<: *no_filters
-      - python38-upgrade-dev-pre:
           <<: *no_filters
       - python39:
           <<: *no_filters
@@ -492,25 +428,17 @@ workflows:
           <<: *no_filters
       - python39-upgrade-dev-pre:
           <<: *no_filters
-      - miniconda36:
-          <<: *no_filters
       - miniconda37:
           <<: *no_filters
       - miniconda38:
           <<: *no_filters
       - miniconda39:
           <<: *no_filters
-      - gallery36:
-          <<: *no_filters
-      - gallery36-min-req:
-          <<: *no_filters
       - gallery37:
           <<: *no_filters
+      - gallery37-min-req:
+          <<: *no_filters
       - gallery38:
-          <<: *no_filters
-      - gallery38-upgrade-dev:
-          <<: *no_filters
-      - gallery38-upgrade-dev-pre:
           <<: *no_filters
       - gallery39:
           <<: *no_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ workflows:
               ignore: /.*/
           context:
             - docker-hub-creds
-      - pynwb-dev-python38:
+      - pynwb-dev-python39:
           filters:
             branches:
               ignore: dev

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ assignees: ''
 <!--Please describe your environment according to the following bullet points.-->
 
     Python Executable: Conda or Python
-    Python Version: Python 3.6, 3.7, or 3.8
+    Python Version: Python 3.7, 3.8, or 3.9
     Operating System: Windows, macOS or Linux
     HDMF Version:
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.8'
+      PYTHON: '3.9'
     steps:
     - name: Cancel Workflow Action
       uses: styfle/cancel-workflow-action@0.6.0
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.0.0 (Upcoming)
+
+### Major features
+- Add support for Python 3.9, drop support for Python 3.6. @rly (#620)
+
 ## HDMF 2.5.6 (May 19, 2021)
 
 ### Bug fix

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -36,20 +36,6 @@ jobs:
         buildToxEnv: 'build-py39'
         testWheelInstallEnv: 'wheelinstall'
 
-      macOS-py3.8-upgrade-dev-pre:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev-pre'
-        buildToxEnv: 'build-py38-upgrade-dev-pre'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.8-upgrade-dev:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev'
-        buildToxEnv: 'build-py38-upgrade-dev'
-        testWheelInstallEnv: 'wheelinstall'
-
       macOS-py3.8:
         imageName: 'macos-10.15'
         pythonVersion: '3.8'
@@ -64,18 +50,11 @@ jobs:
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall'
 
-      macOS-py3.6:
+      macOS-py3.7-min-req:
         imageName: 'macos-10.15'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36'
-        buildToxEnv: 'build-py36'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.6-min-req:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36-min-req'
-        buildToxEnv: 'build-py36-min-req'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37-min-req'
+        buildToxEnv: 'build-py37-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
       Windows-py3.9:
@@ -99,20 +78,6 @@ jobs:
         buildToxEnv: 'build-py39-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.8-upgrade-dev-pre:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev-pre'
-        buildToxEnv: 'build-py38-upgrade-dev-pre'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.8-upgrade-dev:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38-upgrade-dev'
-        buildToxEnv: 'build-py38-upgrade-dev'
-        testWheelInstallEnv: 'wheelinstall'
-
       Windows-py3.8:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.8'
@@ -127,18 +92,11 @@ jobs:
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.6:
+      Windows-py3.7-min-req:
         imageName: 'vs2017-win2016'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36'
-        buildToxEnv: 'build-py36'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.6-min-req:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36-min-req'
-        buildToxEnv: 'build-py36-min-req'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37-min-req'
+        buildToxEnv: 'build-py37-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,32 +8,32 @@ jobs:
 
   strategy:
     matrix:
-      macOS-py3.8:
+      macOS-py3.9:
         imageName: 'macos-10.15'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38'
-        buildToxEnv: 'build-py38'
+        pythonVersion: '3.9'
+        testToxEnv: 'py39'
+        buildToxEnv: 'build-py39'
         testWheelInstallEnv: 'wheelinstall'
 
-      macOS-py3.6-min-req:
+      macOS-py3.7-min-req:
         imageName: 'macos-10.15'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36-min-req'
-        buildToxEnv: 'build-py36-min-req'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37-min-req'
+        buildToxEnv: 'build-py37-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.8:
+      Windows-py3.9:
         imageName: 'vs2017-win2016'
-        pythonVersion: '3.8'
-        testToxEnv: 'py38'
-        buildToxEnv: 'build-py38'
+        pythonVersion: '3.9'
+        testToxEnv: 'py39'
+        buildToxEnv: 'build-py39'
         testWheelInstallEnv: 'wheelinstall'
 
-      Windows-py3.6-min-req:
+      Windows-py3.7-min-req:
         imageName: 'vs2017-win2016'
-        pythonVersion: '3.6'
-        testToxEnv: 'py36-min-req'
-        buildToxEnv: 'build-py36-min-req'
+        pythonVersion: '3.7'
+        testToxEnv: 'py37-min-req'
+        buildToxEnv: 'build-py37-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
   pool:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ sphinx_gallery_conf = {
 }
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.8', None),
+    'python': ('https://docs.python.org/3.9', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None),

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,7 +6,7 @@ Dependencies
 
 HDMF has the following minimum requirements, which must be installed before you can get started using HDMF.
 
-#. Python 3.6, 3.7, or 3.8
+#. Python 3.7, 3.8, or 3.9
 #. pip
 
 ------------
@@ -82,7 +82,7 @@ work better on Windows.
 
 .. code::
 
-    $ conda create --name hdmf-dev python=3.8
+    $ conda create --name hdmf-dev python=3.9
     $ conda activate hdmf-dev
 
 Then clone the git repository for HDMF, install the HDMF package requirements using the pip_ Python package manager, and

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml==0.15.34
+ruamel.yaml==0.15.1
 jsonschema==2.6.0
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml~=0.15.1  # cannot find 0.15.* release that works for all OS
+ruamel.yaml==0.16
 jsonschema==2.6.0
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml==0.15.19
+ruamel.yaml~=0.15.1  # cannot find 0.15.* release that works for all OS
 jsonschema==2.6.0
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml==0.15
+ruamel.yaml==0.15.34
 jsonschema==2.6.0
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml==0.15.2
+ruamel.yaml==0.15.19
 jsonschema==2.6.0
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,6 @@ h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 numpy==1.16
 scipy==1.1
 pandas==1.0.5
-ruamel.yaml==0.15.1
+ruamel.yaml==0.15.2
 jsonschema==2.6.0
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15.1,<1',
+    'ruamel.yaml>=0.16,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15.19,<1',
+    'ruamel.yaml>=0.15.1,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15.34,<1',
+    'ruamel.yaml>=0.15.1,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15.1,<1',
+    'ruamel.yaml>=0.15.2,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup_args = {
     'package_data': {'hdmf': ["%s/*.yaml" % schema_dir, "%s/*.json" % schema_dir]},
     'classifiers': [
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15,<1',
+    'ruamel.yaml>=0.15.34,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ reqs = [
     'numpy>=1.16,<1.21',
     'scipy>=1.1,<2',
     'pandas>=1.0.5,<2',
-    'ruamel.yaml>=0.15.2,<1',
+    'ruamel.yaml>=0.15.19,<1',
     'jsonschema>=2.6.0,<4',
     'setuptools',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39
 
 [testenv]
 usedevelop = True
@@ -22,28 +22,10 @@ commands =
 
 # Env to create coverage report locally
 [testenv:localcoverage]
-basepython = python3.8
+basepython = python3.9
 commands =
     python -m coverage run test.py -u
     coverage html -d tests/coverage/htmlcov
-
-# Test with python 3.8, pinned dev reqs, and upgraded run requirements
-[testenv:py38-upgrade-dev]
-basepython = python3.8
-install_command =
-    pip install -U -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-commands = {[testenv]commands}
-
-# Test with python 3.8, pinned dev reqs, and pre-release run requirements
-[testenv:py38-upgrade-dev-pre]
-basepython = python3.8
-install_command =
-    pip install -U --pre -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-commands = {[testenv]commands}
 
 # Test with python 3.9, pinned dev reqs, and upgraded run requirements
 [testenv:py39-upgrade-dev]
@@ -63,9 +45,9 @@ deps =
     -rrequirements-dev.txt
 commands = {[testenv]commands}
 
-# Test with python 3.6, pinned dev reqs, and minimum run requirements
-[testenv:py36-min-req]
-basepython = python3.6
+# Test with python 3.7, pinned dev reqs, and minimum run requirements
+[testenv:py37-min-req]
+basepython = python3.7
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -77,10 +59,6 @@ commands =
     python setup.py sdist
     python setup.py bdist_wheel
 
-[testenv:build-py36]
-basepython = python3.6
-commands = {[testenv:build]commands}
-
 [testenv:build-py37]
 basepython = python3.7
 commands = {[testenv:build]commands}
@@ -91,22 +69,6 @@ commands = {[testenv:build]commands}
 
 [testenv:build-py39]
 basepython = python3.9
-commands = {[testenv:build]commands}
-
-[testenv:build-py38-upgrade-dev]
-basepython = python3.8
-install_command =
-    pip install -U -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-commands = {[testenv:build]commands}
-
-[testenv:build-py38-upgrade-dev-pre]
-basepython = python3.8
-install_command =
-    pip install -U --pre -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
 commands = {[testenv:build]commands}
 
 [testenv:build-py39-upgrade-dev]
@@ -125,8 +87,8 @@ deps =
     -rrequirements-dev.txt
 commands = {[testenv:build]commands}
 
-[testenv:build-py36-min-req]
-basepython = python3.6
+[testenv:build-py37-min-req]
+basepython = python3.7
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -150,11 +112,6 @@ deps =
 commands =
     python test.py --example
 
-[testenv:gallery-py36]
-basepython = python3.6
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
 [testenv:gallery-py37]
 basepython = python3.7
 deps = {[testenv:gallery]deps}
@@ -168,26 +125,6 @@ commands = {[testenv:gallery]commands}
 [testenv:gallery-py39]
 basepython = python3.9
 deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
-# Test with python 3.8, pinned dev and doc reqs, and upgraded run requirements
-[testenv:gallery-py38-upgrade-dev]
-basepython = python3.8
-install_command =
-    pip install -U -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-doc.txt
-commands = {[testenv:gallery]commands}
-
-# Test with python 3.8, pinned dev and doc reqs, and pre-release run requirements
-[testenv:gallery-py38-upgrade-dev-pre]
-basepython = python3.8
-install_command =
-    pip install -U --pre -e . {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
 # Test with python 3.9, pinned dev and doc reqs, and upgraded run requirements
@@ -210,9 +147,9 @@ deps =
     -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.6, pinned dev reqs, and minimum run requirements
-[testenv:gallery-py36-min-req]
-basepython = python3.6
+# Test with python 3.7, pinned dev reqs, and minimum run requirements
+[testenv:gallery-py37-min-req]
+basepython = python3.7
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt


### PR DESCRIPTION
## Motivation

Python 3.6 end of life is 23 Dec 2021. The latest versions of h5py, numpy, pandas, scipy do not provide wheels for python 3.6. It seems that generally, if a package added 3.9 support, they dropped 3.6 support. This makes it difficult to test against. 

This PR will merge into the `enh/h5py3` branch to drop python 3.6 support and add python 3.9 support. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
