### PR TITLE
Fix postprocess set of fields in custom class generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 2.5.7 (June 7, 2021)
+
+### Bug fix
+- Fix generation of extension classes that extend MultiContainerInterface and use a custom _fieldsname. @rly (#626)
+
 ## HDMF 2.5.6 (May 19, 2021)
 
 ### Bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 2.5.7 (June 7, 2021)
+## HDMF 2.5.7 (June 4, 2021)
 
 ### Bug fix
 - Fix generation of extension classes that extend MultiContainerInterface and use a custom _fieldsname. @rly (#626)

--- a/src/hdmf/build/__init__.py
+++ b/src/hdmf/build/__init__.py
@@ -1,5 +1,5 @@
 from .builders import Builder, DatasetBuilder, GroupBuilder, LinkBuilder, ReferenceBuilder, RegionBuilder
-from .classgenerator import CustomClassGenerator
+from .classgenerator import CustomClassGenerator, MCIClassGenerator
 from .errors import (BuildError, OrphanContainerBuildError, ReferenceTargetNotBuiltError, ContainerConfigurationError,
                      ConstructError)
 from .manager import BuildManager, TypeMap

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -268,9 +268,10 @@ class CustomClassGenerator:
         :param spec: The spec for the container class to generate.
         """
         # convert classdict['__fields__'] from list to tuple if present
-        fields = classdict.get(bases[0]._fieldsname)
-        if fields is not None:
-            classdict[bases[0]._fieldsname] = tuple(fields)
+        for b in bases:
+            fields = classdict.get(b._fieldsname)
+            if fields is not None and not isinstance(fields, tuple):
+                classdict[b._fieldsname] = tuple(fields)
 
         # if spec provides a fixed name for this type, remove the 'name' arg from docval_args so that values cannot
         # be passed for a name positional or keyword arg


### PR DESCRIPTION
## Motivation

Fix #625 

Also expose MCIClassGenerator in case other code wants to subclass it (e.g. in PyNWB so that `pynwb.MultiContainerInterface` is used instead of `hdmf.MultiContainerInterface`)

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
