### PR TITLE
Fix CI for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,6 @@ jobs:
       - TEST_TOX_ENV: "py38"
       - BUILD_TOX_ENV: "build-py38"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
-      - UPLOAD_WHEELS: "true"
     <<: *ci-steps
 
   python39:
@@ -179,6 +178,7 @@ jobs:
       - TEST_TOX_ENV: "py39"
       - BUILD_TOX_ENV: "build-py39"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
+      - UPLOAD_WHEELS: "true"  # upload distributions from only this job to pypi
     <<: *ci-steps
 
   python39-upgrade-dev:


### PR DESCRIPTION
## Motivation

The `deploy-release` job on CircleCI failed because `InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'` because the distributions were saved in the wrong CI job. This PR should fix the issue.

https://app.circleci.com/pipelines/github/hdmf-dev/hdmf/3273/workflows/5024dee4-9cc7-4d0f-9a14-d34a27b4226e/jobs/37737

This PR will also be the last PR before releasing bugfix version 3.0.1 since 3.0.0 has already been tagged.


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
