### PR TITLE
Do not build wheel for python 2, restrict to >=3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # HDMF Changelog
 
+## Upcoming (TBD)
+
+### Bug fixes
+- Do not build wheels compatible with Python 2 because HDMF requires Python 3.7. @rly (#642)
+
+## HDMF 3.0.1 (July 7, 2021)
+
+### Bug fixes
+- Fixed release CI that prevented distribution from being uploaded to PyPI. @rly (#641)
+
 ## HDMF 3.0.0 (July 6, 2021)
 
 ### New features

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -32,8 +32,8 @@ jobs:
       macOS-py3.9-upgrade-dev:
         imageName: 'macos-10.15'
         pythonVersion: '3.9'
-        testToxEnv: 'py39'
-        buildToxEnv: 'build-py39'
+        testToxEnv: 'py39-upgrade-dev'
+        buildToxEnv: 'build-py39-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
       macOS-py3.8:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [versioneer]
 VCS = git
 versionfile_source = src/hdmf/_version.py

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup_args = {
     'packages': pkgs,
     'package_dir': {'': 'src'},
     'package_data': {'hdmf': ["%s/*.yaml" % schema_dir, "%s/*.json" % schema_dir]},
+    'python_requires': '>=3.7',
     'classifiers': [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## Motivation

Released wheels are named `hdmf-3.0.1-py2.py3-none-any.whl` which means it can be installed on Python 2, but Python >=3.7 is required. This PR fixes the issue.

Also fixes a minor CI typo where the wrong tox environments were being run for a job.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
