### PR TITLE
Add missing thumbnail for external resources tutorial

### DIFF
--- a/docs/gallery/External_Resources.py
+++ b/docs/gallery/External_Resources.py
@@ -77,6 +77,7 @@ improve the structure and access of data stored with this type for your use case
 # Creating an instance of the ExternalResources class
 # ------------------------------------------------------
 
+# sphinx_gallery_thumbnail_path = 'figures/gallery_thumbnail_externalresources.png'
 from hdmf.common import ExternalResources
 from hdmf.common import DynamicTable
 from hdmf import Data


### PR DESCRIPTION
## Motivation

#571 added thumbnails for all tutorials. It appears that at some point the thumbnail for the external resources tutorial has been accidentally removed. This PR adds the thumbnail back in. 

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
