### PR TITLE
Update DynamicTableRegion.get_linked_tables to return named tuples 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## HDMF 3.1.1 (July 29, 2021)
 
 ### Fixes
-- Update the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
-  objects rather than lists of dicts @oruebel (#660)
+- Updated the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
+  objects rather than lists of dicts. @oruebel (#660)
 
 ## HDMF 3.1.0 (July 29, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 3.1.1 (July 29, 2021)
+
+### Fixes
+- Update the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
+  objects rather than lists of dicts @oruebel (#660)
+
 ## HDMF 3.1.0 (July 29, 2021)
 
 ### New features

--- a/tests/unit/common/test_linkedtables.py
+++ b/tests/unit/common/test_linkedtables.py
@@ -257,13 +257,13 @@ class TestLinkedAlignedDynamicTables(TestCase):
         # check with subcateogries
         linked_tables = self.aligned_table.get_linked_tables()
         self.assertEqual(len(linked_tables), 2)
-        self.assertTupleEqual((linked_tables[0]['source_table'].name,
-                               linked_tables[0]['source_column'].name,
-                               linked_tables[0]['target_table'].name),
+        self.assertTupleEqual((linked_tables[0].source_table.name,
+                               linked_tables[0].source_column.name,
+                               linked_tables[0].target_table.name),
                               ('category0', 'child_table_ref1', 'level0_0'))
-        self.assertTupleEqual((linked_tables[1]['source_table'].name,
-                               linked_tables[1]['source_column'].name,
-                               linked_tables[1]['target_table'].name),
+        self.assertTupleEqual((linked_tables[1].source_table.name,
+                               linked_tables[1].source_column.name,
+                               linked_tables[1].target_table.name),
                               ('category1', 'child_table_ref1', 'level0_1'))
 
     def test_get_linked_tables_none(self):
@@ -305,17 +305,17 @@ class TestLinkedAlignedDynamicTables(TestCase):
         linked_tables = temp_aligned_table.get_linked_tables()
         self.assertEqual(len(linked_tables), 2)
         for i, v in enumerate([('my_aligned_table', 'a2', 't1'), ('t1', 'c2', 't0')]):
-            self.assertTupleEqual((linked_tables[i]['source_table'].name,
-                                   linked_tables[i]['source_column'].name,
-                                   linked_tables[i]['target_table'].name), v)
+            self.assertTupleEqual((linked_tables[i].source_table.name,
+                                   linked_tables[i].source_column.name,
+                                   linked_tables[i].target_table.name), v)
         # Now, since our main table links to the category table the result should remain the same
         # even if we ignore the category table
         linked_tables = temp_aligned_table.get_linked_tables(ignore_category_tables=True)
         self.assertEqual(len(linked_tables), 2)
         for i, v in enumerate([('my_aligned_table', 'a2', 't1'), ('t1', 'c2', 't0')]):
-            self.assertTupleEqual((linked_tables[i]['source_table'].name,
-                                   linked_tables[i]['source_column'].name,
-                                   linked_tables[i]['target_table'].name), v)
+            self.assertTupleEqual((linked_tables[i].source_table.name,
+                                   linked_tables[i].source_column.name,
+                                   linked_tables[i].target_table.name), v)
 
     def test_get_linked_tables_simple_link(self):
         temp_table0 = DynamicTable(name='t0', description='t1',
@@ -339,17 +339,17 @@ class TestLinkedAlignedDynamicTables(TestCase):
         linked_tables = temp_aligned_table.get_linked_tables()
         self.assertEqual(len(linked_tables), 2)
         for i, v in enumerate([('my_aligned_table', 'a2', 't0'), ('t1', 'c2', 't0')]):
-            self.assertTupleEqual((linked_tables[i]['source_table'].name,
-                                   linked_tables[i]['source_column'].name,
-                                   linked_tables[i]['target_table'].name), v)
+            self.assertTupleEqual((linked_tables[i].source_table.name,
+                                   linked_tables[i].source_column.name,
+                                   linked_tables[i].target_table.name), v)
         # Since no table ever link to our category temp_table we should only get the link from our
         # main table here, in contrast to what happens in the test_get_linked_tables_complex_link case
         linked_tables = temp_aligned_table.get_linked_tables()
         self.assertEqual(len(linked_tables), 2)
         for i, v in enumerate([('my_aligned_table', 'a2', 't0'), ]):
-            self.assertTupleEqual((linked_tables[i]['source_table'].name,
-                                   linked_tables[i]['source_column'].name,
-                                   linked_tables[i]['target_table'].name), v)
+            self.assertTupleEqual((linked_tables[i].source_table.name,
+                                   linked_tables[i].source_column.name,
+                                   linked_tables[i].target_table.name), v)
 
 
 class TestHierarchicalTable(TestCase):
@@ -696,21 +696,21 @@ class TestLinkedDynamicTables(TestCase):
         # check level1
         temp = self.table_level1.get_linked_tables()
         self.assertEqual(len(temp), 2)
-        self.assertEqual(temp[0]['source_table'].name, self.table_level1.name)
-        self.assertEqual(temp[0]['source_column'].name, 'child_table_ref1')
-        self.assertEqual(temp[0]['target_table'].name, self.table_level0_0.name)
-        self.assertEqual(temp[1]['source_table'].name, self.table_level1.name)
-        self.assertEqual(temp[1]['source_column'].name, 'child_table_ref2')
-        self.assertEqual(temp[1]['target_table'].name, self.table_level0_1.name)
+        self.assertEqual(temp[0].source_table.name, self.table_level1.name)
+        self.assertEqual(temp[0].source_column.name, 'child_table_ref1')
+        self.assertEqual(temp[0].target_table.name, self.table_level0_0.name)
+        self.assertEqual(temp[1].source_table.name, self.table_level1.name)
+        self.assertEqual(temp[1].source_column.name, 'child_table_ref2')
+        self.assertEqual(temp[1].target_table.name, self.table_level0_1.name)
         # check level2
         temp = self.table_level2.get_linked_tables()
         self.assertEqual(len(temp), 3)
-        self.assertEqual(temp[0]['source_table'].name, self.table_level2.name)
-        self.assertEqual(temp[0]['source_column'].name, 'child_table_ref1')
-        self.assertEqual(temp[0]['target_table'].name, self.table_level1.name)
-        self.assertEqual(temp[1]['source_table'].name, self.table_level1.name)
-        self.assertEqual(temp[1]['source_column'].name, 'child_table_ref1')
-        self.assertEqual(temp[1]['target_table'].name, self.table_level0_0.name)
-        self.assertEqual(temp[2]['source_table'].name, self.table_level1.name)
-        self.assertEqual(temp[2]['source_column'].name, 'child_table_ref2')
-        self.assertEqual(temp[2]['target_table'].name, self.table_level0_1.name)
+        self.assertEqual(temp[0].source_table.name, self.table_level2.name)
+        self.assertEqual(temp[0].source_column.name, 'child_table_ref1')
+        self.assertEqual(temp[0].target_table.name, self.table_level1.name)
+        self.assertEqual(temp[1].source_table.name, self.table_level1.name)
+        self.assertEqual(temp[1].source_column.name, 'child_table_ref1')
+        self.assertEqual(temp[1].target_table.name, self.table_level0_0.name)
+        self.assertEqual(temp[2].source_table.name, self.table_level1.name)
+        self.assertEqual(temp[2].source_column.name, 'child_table_ref2')
+        self.assertEqual(temp[2].target_table.name, self.table_level0_1.name)


### PR DESCRIPTION
The recently added ``DynamicTableRegion.get_linked_tables`` function currently returns lists of dicts. Since we have a fixed set of values, using NamedTuple rather than dict is a more appropriate type here. This PR changes this behavior. Since this functionality is currently only on the dev branch and has not been released yet, this change should not affect any users or break backward compatibility. This  functionality is used in https://github.com/NeurodataWithoutBorders/pynwb/pull/1349
 

## Checklist

- [-] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
