### PR TITLE
Add FutureWarning when positional args are used for Container __init__

### DIFF
--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -6,7 +6,7 @@ import numpy as np
 from ..container import Container, Data, DataRegion, MultiContainerInterface
 from ..spec import AttributeSpec, LinkSpec, RefSpec, GroupSpec
 from ..spec.spec import BaseStorageSpec, ZERO_OR_MANY, ONE_OR_MANY
-from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args
+from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args, AllowPositional
 
 
 class ClassGenerator:
@@ -294,7 +294,7 @@ class CustomClassGenerator:
             if attr_name not in parent_docval_args:
                 new_args.append(attr_name)
 
-        @docval(*docval_args)
+        @docval(*docval_args, allow_positional=AllowPositional.WARNING)
         def __init__(self, **kwargs):
             if name is not None:  # force container name to be the fixed name in the spec
                 kwargs.update(name=name)

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from . import register_class
 from .table import DynamicTable
-from ..utils import docval, getargs, call_docval_func, popargs, get_docval
+from ..utils import docval, getargs, call_docval_func, popargs, get_docval, AllowPositional
 
 
 @register_class('AlignedDynamicTable')
@@ -33,7 +33,8 @@ class AlignedDynamicTable(DynamicTable):
                     'DynamicTables are allowed. Using AlignedDynamicTable as a category for '
                     'AlignedDynamicTable is currently not supported.', 'default': None},
             {'name': 'categories', 'type': 'array_data',
-             'doc': 'List of names with the ordering of category tables', 'default': None})
+             'doc': 'List of names with the ordering of category tables', 'default': None},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):  # noqa: C901
         in_category_tables = popargs('category_tables', kwargs)
         in_categories = popargs('categories', kwargs)

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -185,7 +185,8 @@ class AlignedDynamicTable(DynamicTable):
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},
             {'name': 'enforce_unique_id', 'type': bool, 'doc': 'enforce that the id in the table must be unique',
              'default': False},
-            allow_extra=True)
+            allow_extra=True,
+            allow_positional=AllowPositional.WARNING)
     def add_row(self, **kwargs):
         """
         We can either provide the row data as a single dict or by specifying a dict for each category

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -2,7 +2,7 @@ from .. import register_map
 from ..table import DynamicTable, VectorData, VectorIndex, DynamicTableRegion
 from ...build import ObjectMapper, BuildManager, CustomClassGenerator
 from ...spec import Spec
-from ...utils import docval, getargs
+from ...utils import docval, getargs, AllowPositional
 
 
 @register_map(DynamicTable)
@@ -129,7 +129,7 @@ class DynamicTableGenerator(CustomClassGenerator):
         if base_init is None:  # pragma: no cover
             raise ValueError("Generated class dictionary is missing base __init__ method.")
 
-        @docval(*docval_args)
+        @docval(*docval_args, allow_positional=AllowPositional.WARNING)
         def __init__(self, **kwargs):
             base_init(self, **kwargs)
 

--- a/src/hdmf/common/multi.py
+++ b/src/hdmf/common/multi.py
@@ -1,6 +1,6 @@
 from . import register_class
 from ..container import Container, Data, MultiContainerInterface
-from ..utils import docval, call_docval_func, popargs
+from ..utils import docval, call_docval_func, popargs, AllowPositional
 
 
 @register_class('SimpleMultiContainer')
@@ -15,7 +15,8 @@ class SimpleMultiContainer(MultiContainerInterface):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
             {'name': 'containers', 'type': (list, tuple), 'default': None,
-             'doc': 'the Container or Data objects in this file'})
+             'doc': 'the Container or Data objects in this file'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         containers = popargs('containers', kwargs)
         call_docval_func(super().__init__, kwargs)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from . import register_class, EXP_NAMESPACE
 from ..container import Table, Row, Container, AbstractContainer
-from ..utils import docval, popargs
+from ..utils import docval, popargs, AllowPositional
 
 
 class KeyTable(Table):
@@ -145,7 +145,8 @@ class ExternalResources(Container):
             {'name': 'objects', 'type': ObjectTable, 'default': None,
              'doc': 'the table storing object information'},
             {'name': 'object_keys', 'type': ObjectKeyTable, 'default': None,
-             'doc': 'the table storing object-resource relationships'})
+             'doc': 'the table storing object-resource relationships'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         name = popargs('name', kwargs)
         super().__init__(name)

--- a/src/hdmf/common/sparse.py
+++ b/src/hdmf/common/sparse.py
@@ -4,7 +4,7 @@ import scipy.sparse as sps
 
 from . import register_class
 from ..container import Container
-from ..utils import docval, getargs, call_docval_func, to_uint_array
+from ..utils import docval, getargs, call_docval_func, to_uint_array, AllowPositional
 
 
 @register_class('CSRMatrix')
@@ -16,7 +16,8 @@ class CSRMatrix(Container):
             {'name': 'indices', 'type': (np.ndarray, h5py.Dataset), 'doc': 'CSR index array', 'default': None},
             {'name': 'indptr', 'type': (np.ndarray, h5py.Dataset), 'doc': 'CSR index pointer array', 'default': None},
             {'name': 'shape', 'type': (list, tuple, np.ndarray), 'doc': 'the shape of the matrix', 'default': None},
-            {'name': 'name', 'type': str, 'doc': 'the name to use for this when storing', 'default': 'csr_matrix'})
+            {'name': 'name', 'type': str, 'doc': 'the name to use for this when storing', 'default': 'csr_matrix'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         call_docval_func(super().__init__, kwargs)
         data = getargs('data', kwargs)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -562,7 +562,8 @@ class DynamicTable(Container):
             {'name': 'id', 'type': int, 'doc': 'the ID for the row', 'default': None},
             {'name': 'enforce_unique_id', 'type': bool, 'doc': 'enforce that the id in the table must be unique',
              'default': False},
-            allow_extra=True)
+            allow_extra=True,
+            allow_positional=AllowPositional.WARNING)
     def add_row(self, **kwargs):
         """
         Add a row to the table. If *id* is not provided, it will auto-increment.

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -14,7 +14,7 @@ import pandas as pd
 from . import register_class, EXP_NAMESPACE
 from ..container import Container, Data
 from ..data_utils import DataIO, AbstractDataChunkIterator
-from ..utils import docval, getargs, ExtenderMeta, call_docval_func, popargs, pystr
+from ..utils import docval, getargs, ExtenderMeta, call_docval_func, popargs, pystr, AllowPositional
 
 
 @register_class('VectorData')
@@ -36,7 +36,8 @@ class VectorData(Data):
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorData'},
             {'name': 'description', 'type': str, 'doc': 'a description for this column'},
             {'name': 'data', 'type': ('array_data', 'data'),
-             'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()})
+             'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         call_docval_func(super().__init__, kwargs)
         self.description = getargs('description', kwargs)
@@ -91,7 +92,8 @@ class VectorIndex(VectorData):
             {'name': 'data', 'type': ('array_data', 'data'),
              'doc': 'a 1D dataset containing indexes that apply to VectorData object'},
             {'name': 'target', 'type': VectorData,
-             'doc': 'the target dataset that this index applies to'})
+             'doc': 'the target dataset that this index applies to'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         target = getargs('target', kwargs)
         kwargs['description'] = "Index for VectorData '%s'" % target.name
@@ -207,7 +209,8 @@ class ElementIdentifiers(Data):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this ElementIdentifiers'},
             {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'a 1D dataset containing identifiers',
-             'default': list()})
+             'default': list()},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         call_docval_func(super().__init__, kwargs)
 
@@ -285,7 +288,8 @@ class DynamicTable(Container):
             {'name': 'columns', 'type': (tuple, list), 'doc': 'the columns in this table', 'default': None},
             {'name': 'colnames', 'type': 'array_data',
              'doc': 'the ordered names of the columns in this table. columns must also be provided.',
-             'default': None})
+             'default': None},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):  # noqa: C901
         id, columns, desc, colnames = popargs('id', 'columns', 'description', 'colnames', kwargs)
         call_docval_func(super().__init__, kwargs)
@@ -1170,7 +1174,8 @@ class DynamicTableRegion(VectorData):
              'doc': 'a dataset where the first dimension is a concatenation of multiple vectors'},
             {'name': 'description', 'type': str, 'doc': 'a description of what this region represents'},
             {'name': 'table', 'type': DynamicTable,
-             'doc': 'the DynamicTable this region applies to', 'default': None})
+             'doc': 'the DynamicTable this region applies to', 'default': None},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         t = popargs('table', kwargs)
         call_docval_func(super().__init__, kwargs)
@@ -1351,7 +1356,8 @@ class EnumData(VectorData):
             {'name': 'data', 'type': ('array_data', 'data'),
              'doc': 'integers that index into elements for the value of each row', 'default': list()},
             {'name': 'elements', 'type': ('array_data', 'data', VectorData), 'default': list(),
-             'doc': 'lookup values for each integer in ``data``'})
+             'doc': 'lookup values for each integer in ``data``'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         elements = popargs('elements', kwargs)
         super().__init__(**kwargs)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from .data_utils import DataIO, append_data, extend_data
 from .utils import (docval, get_docval, call_docval_func, getargs, ExtenderMeta, get_data_shape, fmt_docval_args,
-                    popargs, LabelledDict)
+                    popargs, LabelledDict, AllowPositional)
 
 
 def _set_exp(cls):
@@ -187,7 +187,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
         inst.parent = kwargs.pop('parent', None)
         return inst
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'})
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         name = getargs('name', kwargs)
         if '/' in name:
@@ -485,7 +486,8 @@ class Data(AbstractContainer):
     """
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
-            {'name': 'data', 'type': ('scalar_data', 'array_data', 'data'), 'doc': 'the source of the data'})
+            {'name': 'data', 'type': ('scalar_data', 'array_data', 'data'), 'doc': 'the source of the data'},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         call_docval_func(super().__init__, kwargs)
         self.__data = getargs('data', kwargs)
@@ -758,7 +760,7 @@ class MultiContainerInterface(Container):
 
         args.append({'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': cls.__name__})
 
-        @docval(*args, func_name='__init__')
+        @docval(*args, func_name='__init__', allow_positional=AllowPositional.WARNING)
         def _func(self, **kwargs):
             call_docval_func(super(cls, self).__init__, kwargs)
             for conf in clsconf:
@@ -1036,7 +1038,8 @@ class Table(Data):
 
                 @docval(name,
                         {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the data in this table',
-                         'default': list()})
+                         'default': list()},
+                        allow_positional=AllowPositional.WARNING)
                 def __init__(self, **kwargs):
                     name, data = getargs('name', 'data', kwargs)
                     colnames = [i['name'] for i in columns]
@@ -1054,7 +1057,8 @@ class Table(Data):
 
     @docval({'name': 'columns', 'type': (list, tuple), 'doc': 'a list of the columns in this table'},
             {'name': 'name', 'type': str, 'doc': 'the name of this container'},
-            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the source of the data', 'default': list()})
+            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the source of the data', 'default': list()},
+            allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
         self.__columns = tuple(popargs('columns', kwargs))
         self.__col_index = {name: idx for idx, name in enumerate(self.__columns)}

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -230,10 +230,11 @@ def __parse_args(validator, args, kwargs, enforce_type=True, enforce_shape=True,
 
         if args:
             if allow_positional == AllowPositional.WARNING:
-                msg = 'Positional arguments are discouraged and may be forbidden in a future release.'
+                msg = ('Using positional arguments for this method is discouraged and will be deprecated '
+                       'in a future major release. Please use keyword arguments to ensure future compatibility.')
                 future_warnings.append(msg)
             elif allow_positional == AllowPositional.ERROR:
-                msg = 'Only keyword arguments (e.g., func(argname=value, ...)) are allowed.'
+                msg = 'Only keyword arguments (e.g., func(argname=value, ...)) are allowed for this method.'
                 syntax_errors.append(msg)
 
         # iterate through the docval specification and find a matching value in args / kwargs


### PR DESCRIPTION
## Motivation
This is a proposed change to raise a `FutureWarning` whenever the user calls an `[AbstractContainer subtype].__init__` with positional arguments instead of keyword arguments.

This follows up on https://github.com/NeurodataWithoutBorders/pynwb/issues/1189 for HDMF. It allows us to change the order of the arguments in an `[AbstractContainer subtype].__init__` without breaking the API.

@oruebel @ajtritt @bendichter I wanted to get your input on this before I update the tests.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
