### PR TITLE
ENH: Ensure that sys.path has the current directory in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.1.2 (Upcoming)
+
+### Fixes
+- Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @rly (#662)
+
 ## HDMF 3.1.1 (July 29, 2021)
 
 ### Fixes

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*
+import sys
+
 from setuptools import setup, find_packages
+
+# Some Python installations don't add the current directory to path.
+if '' not in sys.path:
+    sys.path.insert(0, '')
 
 import versioneer
 


### PR DESCRIPTION
## Motivation

See same PR in pynwb: https://github.com/NeurodataWithoutBorders/pynwb/pull/1395


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
