### PR TITLE
Remove regex test for setting an unsettable property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # HDMF Changelog
 
+## HDMF 3.1.2 (TBD)
+
+### Bug fixes
+- Fix broken tests in Python 3.10. @rly (#664)
+
 ## HDMF 3.1.1 (July 29, 2021)
 
-### Fixes
+### Bug fixes
 - Updated the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
   objects rather than lists of dicts. @oruebel (#660)
 

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -33,7 +33,7 @@ class TestLabelledDict(TestCase):
     def test_set_key_attr(self):
         """Test that the key attribute cannot be set after initialization."""
         ld = LabelledDict(label='all_objects')
-        with self.assertRaisesWith(AttributeError, "can't set attribute"):
+        with self.assertRaises(AttributeError):
             ld.key_attr = 'another_name'
 
     def test_getitem_unknown_val(self):


### PR DESCRIPTION
Python 3.10 changed the message of the AttributeError, and it's not 
important to check for a perfect match of the error message here anyway.

Fix #663.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
