### PR TITLE
Fix to_hierarchical_dataframe with VectorIndex data columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 - Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @rly (#662)
+- Fixed `to_hierarchcial_dataframe` failing when a table contains a `VectorIndex` column as a regular data column.
+  @oruebel (#666)
 
 ## HDMF 3.1.1 (July 29, 2021)
 

--- a/src/hdmf/common/hierarchicaltable.py
+++ b/src/hdmf/common/hierarchicaltable.py
@@ -134,24 +134,26 @@ def to_hierarchical_dataframe(dynamic_table):
                        hcol_hdf.index.names)
         columns = hcol_hdf.columns
 
+    # Check if the index contains any unhashable types. If a table contains a VectorIndex column
+    # (other than the DynamicTableRegion column) then "TypeError: unhashable type: 'list'" will
+    # occur when converting the index to pd.MultiIndex. To avoid this error, we next check if any
+    # of the columns in our index are of type list of np.ndarray
+    unhashable_index_cols = []
+    if len(index) > 0:
+        unhashable_index_cols = [i for i, v in enumerate(index[0]) if isinstance(v, (list, np.ndarray))]
+
+    # If we have any unhashable list or np.array objects in the index then update them to tuples.
+    # Ideally we would detect this case when constructing the index, but it is easier to do this
+    # here and it should not be much more expensive, but it requires iterating over all rows again
+    if len(unhashable_index_cols) > 0:
+        for i, v in enumerate(index):
+            temp = list(v)
+            for ci in unhashable_index_cols:
+                temp[ci] = tuple(temp[ci])
+            index[i] = tuple(temp)
+
     # Construct the pandas dataframe with the hierarchical multi-index
-    try:
-        multi_index = pd.MultiIndex.from_tuples(index, names=index_names)
-    except TypeError as e:
-        # If our table contains a VectorIndex column then "TypeError: unhashable type: 'list'" will
-        # occur when converting the index to pd.MultiIndex. If this is the case, then we need to
-        # update the lists to tuples. Ideally we would detect this case when constructing the index
-        # but it is easier to do this here and it should not be much more expensive
-        if len(index) > 0:  # This should always be true as otherwise not TypeError should have been raised
-            list_type_index_cols = [i for i, v in enumerate(index[0]) if isinstance(v, (list, np.ndarray))]
-            for i, v in enumerate(index):
-                temp = list(v)
-                for ci in list_type_index_cols:
-                    temp[ci] = tuple(temp[ci])
-                index[i] = tuple(temp)
-            multi_index = pd.MultiIndex.from_tuples(index, names=index_names)
-        else:  # pragma: no cover
-            raise e
+    multi_index = pd.MultiIndex.from_tuples(index, names=index_names)
     out_df = pd.DataFrame(data=data, index=multi_index, columns=columns)
     return out_df
 

--- a/src/hdmf/common/hierarchicaltable.py
+++ b/src/hdmf/common/hierarchicaltable.py
@@ -142,15 +142,15 @@ def to_hierarchical_dataframe(dynamic_table):
         # occur when converting the index to pd.MultiIndex. If this is the case, then we need to
         # update the lists to tuples. Ideally we would detect this case when constructing the index
         # but it is easier to do this here and it should not be much more expensive
-        if len(index) > 0: # This should always be true
-            list_type_index_cols = [i for i, v in enumerate(index[0]) if isinstance(v, list)]
+        if len(index) > 0:  # This should always be true as otherwise not TypeError should have been raised
+            list_type_index_cols = [i for i, v in enumerate(index[0]) if isinstance(v, (list, np.ndarray))]
             for i, v in enumerate(index):
                 temp = list(v)
                 for ci in list_type_index_cols:
-                    temp[ci] =  tuple(temp[ci])
+                    temp[ci] = tuple(temp[ci])
                 index[i] = tuple(temp)
             multi_index = pd.MultiIndex.from_tuples(index, names=index_names)
-        else: # pragma: no cover
+        else:  # pragma: no cover
             raise e
     out_df = pd.DataFrame(data=data, index=multi_index, columns=columns)
     return out_df

--- a/src/hdmf/common/hierarchicaltable.py
+++ b/src/hdmf/common/hierarchicaltable.py
@@ -137,7 +137,7 @@ def to_hierarchical_dataframe(dynamic_table):
     # Check if the index contains any unhashable types. If a table contains a VectorIndex column
     # (other than the DynamicTableRegion column) then "TypeError: unhashable type: 'list'" will
     # occur when converting the index to pd.MultiIndex. To avoid this error, we next check if any
-    # of the columns in our index are of type list of np.ndarray
+    # of the columns in our index are of type list or np.ndarray
     unhashable_index_cols = []
     if len(index) > 0:
         unhashable_index_cols = [i for i, v in enumerate(index[0]) if isinstance(v, (list, np.ndarray))]


### PR DESCRIPTION
## Motivation

Fix https://github.com/hdmf-dev/hdmf/issues/665

Add check in ``to_hierarchical_dataframe`` to convert ``list`` and ``np.ndarray`` objects in the index to ``tuples``. Since ``list`` and ``np.ndarray`` are not hashable this leads to a ``TypeError`` when creating the ``pandas.MultiIndex``. By converting these items to tuples we can avoid this problem. This issue occurs if a hierarchical table contains ``VectorIndex`` columns as part of regular data columns, rather than indexed ``DynamicTableRegion`` columns which are resolved separately. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
