### PR TITLE
Fix latex built of docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 ### Bug fixes
 - Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @rly (#662)
-- Fix broken tests in Python 3.10. @rly (#664)
+- Fixed broken tests in Python 3.10. @rly (#664)
+- Fixed broken LaTeX PDF build of the docs. @oruebel (#669)
 
 ## HDMF 3.1.1 (July 29, 2021)
 
 ### Bug fixes
 - Updated the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
   objects rather than lists of dicts. @oruebel (#660)
-- Update docstring of ``AlignedDynamicTable.get`` to fix broken latex PDF build of the docs. @oruebel (#669)
 
 ## HDMF 3.1.0 (July 29, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 - Updated the new ``DynamicTableRegion.get_linked_tables`` function (added in 3.1.0) to return lists of ``typing.NamedTuple``
   objects rather than lists of dicts. @oruebel (#660)
+- Update docstring of ``AlignedDynamicTable.get`` to fix broken latex PDF build of the docs. @oruebel (#669)
 
 ## HDMF 3.1.0 (July 29, 2021)
 

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -277,22 +277,22 @@ class AlignedDynamicTable(DynamicTable):
               * ``self['my_category']`` : Returns a DataFrame of the ``my_category`` category table.
                 This is a shorthand for ``self.get_category('my_category').to_dataframe()``.
 
-        * **tuple**: Get a column, row, or cell from a particular category table.
-               The tuple is expected to consist of the following elements:
+        * **tuple**: Get a column, row, or cell from a particular category table. The tuple is expected to
+          consist of the following elements:
 
-               * ``category``: string with the name of the category. To select from the main
-                 table use ``self.name`` or ``None``.
-               * ``column``: string with the name of the column, and
-               * ``row``: integer index of the row.
+              * ``category``: string with the name of the category. To select from the main
+                table use ``self.name`` or ``None``.
+              * ``column``: string with the name of the column, and
+              * ``row``: integer index of the row.
 
-               The tuple itself then may take the following forms:
+          The tuple itself then may take the following forms:
 
-               * Select a single column from a table via:
+              * Select a single column from a table via:
                    * ``self[category, column]``
-               * Select a single full row of a given category table via:
+              * Select a single full row of a given category table via:
                    * ``self[row, category]`` (recommended, for consistency with DynamicTable)
                    * ``self[category, row]``
-               * Select a single cell via:
+              * Select a single cell via:
                    * ``self[row, (category, column)]`` (recommended, for consistency with DynamicTable)
                    * ``self[row, category, column]``
                    * ``self[category, column, row]``


### PR DESCRIPTION
Fix #668 

* Update docstring of AlignedDyanmicTable.get to avoid deep nexting error in latex build

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
