### PR TITLE
Added test of column as attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@
 - Added ``export_to_sqlite`` method for ``hdmf.common.resources.ExternalResource``. @oruebel (#667)
 
 ### Minor improvements
-- Plot results in external resources tutorial. @oruebel (#667)
-- Add support for Python 3.10. @rly (#679)
-- Update requirements. @rly @TheChymera (#681)
-
-## HDMF 3.1.2 (Upcoming)
+- Plotted results in external resources tutorial. @oruebel (#667)
+- Added support for Python 3.10. @rly (#679)
+- Updated requirements. @rly @TheChymera (#681)
+- Improved testing for `ExternalResources`. @mavaylon (#673)
 
 ### Bug fixes
 - Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @rly (#662)

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -376,7 +376,7 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
 
     def test_add_ref_attribute(self):
         # Test to make sure the attribute object is being used for the id
-        # for the ecternal reference.
+        # for the external reference.
         table = DynamicTable(name='table', description='table')
         table.add_column(name='col1', description="column")
         table.add_row(id=0, col1='data')
@@ -394,6 +394,27 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
         self.assertEqual(er.resources.data, [('resource0', 'resource0_uri')])
         self.assertEqual(er.entities.data, [(0, 0, 'entity_0', 'entity_0_uri')])
         self.assertEqual(er.objects.data, [(table.id.object_id, '', '')])
+
+    def test_add_ref_column_as_attribute(self):
+        # Test to make sure the attribute object is being used for the id
+        # for the external reference.
+        table = DynamicTable(name='table', description='table')
+        table.add_column(name='col1', description="column")
+        table.add_row(id=0, col1='data')
+
+        er = ExternalResources(name='example')
+        er.add_ref(container=table,
+                   attribute='col1',
+                   key='key1',
+                   resource_name='resource0',
+                   resource_uri='resource0_uri',
+                   entity_id='entity_0',
+                   entity_uri='entity_0_uri')
+
+        self.assertEqual(er.keys.data, [('key1',)])
+        self.assertEqual(er.resources.data, [('resource0', 'resource0_uri')])
+        self.assertEqual(er.entities.data, [(0, 0, 'entity_0', 'entity_0_uri')])
+        self.assertEqual(er.objects.data, [(table['col1'].object_id, '', '')])
 
     def test_add_ref_compound_data(self):
         er = ExternalResources(name='example')


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

We wanted to ensure that when a user adds an external resource to a column that both ways of adding the resource is tested and supported.

## How to test the behavior?
Unit test

```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
