### PR TITLE
Start nightly testing against Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,30 +17,37 @@ references:
       python -m virtualenv ../venv || python -m venv ../venv
       . ../venv/bin/activate
 
+  py310: &py310
+    docker:
+    - image: circleci/python:3.10
+      auth:
+        username: hdmf
+        password: $DOCKERHUB_PASSWORD
+
   py39: &py39
     docker:
-    - image: circleci/python:3.9.2-buster
+    - image: circleci/python:3.9
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   py38: &py38
     docker:
-    - image: circleci/python:3.8.8-buster
+    - image: circleci/python:3.8
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   py37: &py37
     docker:
-    - image: circleci/python:3.7.10-buster
+    - image: circleci/python:3.7
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
 
   conda-image: &conda-image
     docker:
-    - image: continuumio/miniconda3:4.9.2
+    - image: continuumio/miniconda3:latest
       auth:
         username: hdmf
         password: $DOCKERHUB_PASSWORD
@@ -56,8 +63,8 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
-            # Installing HDF5 is required for building h5py 2.10 wheels for Python 3.9
-            if [[ "${TEST_TOX_ENV}" == *"py39"* ]]; then
+            # Installing HDF5 is required for building h5py 2.10 wheels for Python 3.9+
+            if [[ "${TEST_TOX_ENV}" == *"py39"* ]] || [[ "${TEST_TOX_ENV}" == *"py310"* ]]; then
               sudo apt-get install libhdf5-dev
             fi
             pip install tox
@@ -128,8 +135,8 @@ references:
           name: Run the gallery tests
           command: |
             . ../venv/bin/activate
-            # Installing HDF5 is required for building h5py 2.10 wheels for Python 3.9
-            if [[ "${TEST_TOX_ENV}" == *"py39"* ]]; then
+            # Installing HDF5 is required for building h5py 2.10 wheels for Python 3.9+
+            if [[ "${TEST_TOX_ENV}" == *"py39"* ]] || [[ "${TEST_TOX_ENV}" == *"py310"* ]]; then
               sudo apt-get install libhdf5-dev
             fi
             pip install tox
@@ -148,7 +155,7 @@ references:
 
 jobs:
   flake8:
-    <<: *py38
+    <<: *py39
     steps:
       - checkout
       - run:
@@ -181,19 +188,28 @@ jobs:
       - UPLOAD_WHEELS: "true"  # upload distributions from only this job to pypi
     <<: *ci-steps
 
-  python39-upgrade-dev:
-    <<: *py39
+  python310:
+    <<: *py310
     environment:
-      - TEST_TOX_ENV: "py39-upgrade-dev"
-      - BUILD_TOX_ENV: "build-py39-upgrade-dev"
+      - TEST_TOX_ENV: "py310"
+      - BUILD_TOX_ENV: "build-py310"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall"
+      - UPLOAD_WHEELS: "true"  # upload distributions from only this job to pypi
+    <<: *ci-steps
+
+  python310-upgrade-dev:
+    <<: *py310
+    environment:
+      - TEST_TOX_ENV: "py310-upgrade-dev"
+      - BUILD_TOX_ENV: "build-py310-upgrade-dev"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
 
-  python39-upgrade-dev-pre:
-    <<: *py39
+  python310-upgrade-dev-pre:
+    <<: *py310
     environment:
-      - TEST_TOX_ENV: "py39-upgrade-dev-pre"
-      - BUILD_TOX_ENV: "build-py39-upgrade-dev-pre"
+      - TEST_TOX_ENV: "py310-upgrade-dev-pre"
+      - BUILD_TOX_ENV: "build-py310-upgrade-dev-pre"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *ci-steps
 
@@ -232,6 +248,15 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
     <<: *conda-steps
 
+  miniconda310:
+    <<: *conda-image
+    environment:
+      - CONDA_PYTHON_VER: "3.10"
+      - TEST_TOX_ENV: "py310"
+      - BUILD_TOX_ENV: "build-py310"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall"
+    <<: *conda-steps
+
   gallery37:
     <<: *py37
     environment:
@@ -250,16 +275,22 @@ jobs:
       - TEST_TOX_ENV: "gallery-py39"
     <<: *gallery-steps
 
-  gallery39-upgrade-dev:
-    <<: *py39
+  gallery310:
+    <<: *py310
     environment:
-      - TEST_TOX_ENV: "gallery-py39-upgrade-dev"
+      - TEST_TOX_ENV: "gallery-py310"
     <<: *gallery-steps
 
-  gallery39-upgrade-dev-pre:
-    <<: *py39
+  gallery310-upgrade-dev:
+    <<: *py310
     environment:
-      - TEST_TOX_ENV: "gallery-py39-upgrade-dev-pre"
+      - TEST_TOX_ENV: "gallery-py310-upgrade-dev"
+    <<: *gallery-steps
+
+  gallery310-upgrade-dev-pre:
+    <<: *py310
+    environment:
+      - TEST_TOX_ENV: "gallery-py310-upgrade-dev-pre"
     <<: *gallery-steps
 
   gallery37-min-req:
@@ -424,15 +455,19 @@ workflows:
           <<: *no_filters
       - python39:
           <<: *no_filters
-      - python39-upgrade-dev:
+      - python310:
           <<: *no_filters
-      - python39-upgrade-dev-pre:
+      - python310-upgrade-dev:
+          <<: *no_filters
+      - python310-upgrade-dev-pre:
           <<: *no_filters
       - miniconda37:
           <<: *no_filters
       - miniconda38:
           <<: *no_filters
       - miniconda39:
+          <<: *no_filters
+      - miniconda310:
           <<: *no_filters
       - gallery37:
           <<: *no_filters
@@ -442,7 +477,9 @@ workflows:
           <<: *no_filters
       - gallery39:
           <<: *no_filters
-      - gallery39-upgrade-dev:
+      - gallery310:
           <<: *no_filters
-      - gallery39-upgrade-dev-pre:
+      - gallery310-upgrade-dev:
+          <<: *no_filters
+      - gallery310-upgrade-dev-pre:
           <<: *no_filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### New features
 - Added ``hdmf.container.Row.__str__`` to improve print of rows. @oruebel (#667)
-- Added ``to_dataframe`` method for ``hdmf.common.resources.ExternalResource`` to improve visualization @oruebel (#667)
-- Added ``export_to_sqlite`` method for ``hdmf.common.resources.ExternalResource``  @oruebel (#667)
+- Added ``to_dataframe`` method for ``hdmf.common.resources.ExternalResource`` to improve visualization. @oruebel (#667)
+- Added ``export_to_sqlite`` method for ``hdmf.common.resources.ExternalResource``. @oruebel (#667)
 
 ### Minor improvements
-- Plot results in external resources tutorial.  @oruebel (#667)
+- Plot results in external resources tutorial. @oruebel (#667)
+- Add testing against Python 3.10. @rly (#679)
 
 
 ## HDMF 3.1.2 (Upcoming)

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -15,25 +15,32 @@ jobs:
 
   strategy:
     matrix:
+      macOS-py3.10:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310'
+        buildToxEnv: 'build-py310'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.10-upgrade-dev-pre:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310-upgrade-dev-pre'
+        buildToxEnv: 'build-py310-upgrade-dev-pre'
+        testWheelInstallEnv: 'wheelinstall'
+
+      macOS-py3.10-upgrade-dev:
+        imageName: 'macos-10.15'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310-upgrade-dev'
+        buildToxEnv: 'build-py310-upgrade-dev'
+        testWheelInstallEnv: 'wheelinstall'
+
       macOS-py3.9:
         imageName: 'macos-10.15'
         pythonVersion: '3.9'
         testToxEnv: 'py39'
         buildToxEnv: 'build-py39'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.9-upgrade-dev-pre:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.9'
-        testToxEnv: 'py39-upgrade-dev-pre'
-        buildToxEnv: 'build-py39-upgrade-dev-pre'
-        testWheelInstallEnv: 'wheelinstall'
-
-      macOS-py3.9-upgrade-dev:
-        imageName: 'macos-10.15'
-        pythonVersion: '3.9'
-        testToxEnv: 'py39-upgrade-dev'
-        buildToxEnv: 'build-py39-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
       macOS-py3.8:
@@ -57,25 +64,32 @@ jobs:
         buildToxEnv: 'build-py37-min-req'
         testWheelInstallEnv: 'wheelinstall'
 
+      Windows-py3.10:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310'
+        buildToxEnv: 'build-py310'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.10-upgrade-dev-pre:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310-upgrade-dev-pre'
+        buildToxEnv: 'build-py310-upgrade-dev-pre'
+        testWheelInstallEnv: 'wheelinstall'
+
+      Windows-py3.10-upgrade-dev:
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.10'
+        testToxEnv: 'py310-upgrade-dev'
+        buildToxEnv: 'build-py310-upgrade-dev'
+        testWheelInstallEnv: 'wheelinstall'
+
       Windows-py3.9:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.9'
         testToxEnv: 'py39'
         buildToxEnv: 'build-py39'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.9-upgrade-dev-pre:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.9'
-        testToxEnv: 'py39-upgrade-dev-pre'
-        buildToxEnv: 'build-py39-upgrade-dev-pre'
-        testWheelInstallEnv: 'wheelinstall'
-
-      Windows-py3.9-upgrade-dev:
-        imageName: 'vs2017-win2016'
-        pythonVersion: '3.9'
-        testToxEnv: 'py39-upgrade-dev'
-        buildToxEnv: 'build-py39-upgrade-dev'
         testWheelInstallEnv: 'wheelinstall'
 
       Windows-py3.8:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 usedevelop = True
@@ -27,18 +27,18 @@ commands =
     python -m coverage run test.py -u
     coverage html -d tests/coverage/htmlcov
 
-# Test with python 3.9, pinned dev reqs, and upgraded run requirements
-[testenv:py39-upgrade-dev]
-basepython = python3.9
+# Test with python 3.10, pinned dev reqs, and upgraded run requirements
+[testenv:py310-upgrade-dev]
+basepython = python3.10
 install_command =
     pip install -U -e . {opts} {packages}
 deps =
     -rrequirements-dev.txt
 commands = {[testenv]commands}
 
-# Test with python 3.9, pinned dev reqs, and pre-release run requirements
-[testenv:py39-upgrade-dev-pre]
-basepython = python3.9
+# Test with python 3.10, pinned dev reqs, and pre-release run requirements
+[testenv:py310-upgrade-dev-pre]
+basepython = python3.10
 install_command =
     pip install -U --pre -e . {opts} {packages}
 deps =
@@ -71,16 +71,20 @@ commands = {[testenv:build]commands}
 basepython = python3.9
 commands = {[testenv:build]commands}
 
-[testenv:build-py39-upgrade-dev]
-basepython = python3.9
+[testenv:build-py310]
+basepython = python3.10
+commands = {[testenv:build]commands}
+
+[testenv:build-py310-upgrade-dev]
+basepython = python3.10
 install_command =
     pip install -U -e . {opts} {packages}
 deps =
     -rrequirements-dev.txt
 commands = {[testenv:build]commands}
 
-[testenv:build-py39-upgrade-dev-pre]
-basepython = python3.9
+[testenv:build-py310-upgrade-dev-pre]
+basepython = python3.10
 install_command =
     pip install -U --pre -e . {opts} {packages}
 deps =
@@ -127,9 +131,14 @@ basepython = python3.9
 deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.9, pinned dev and doc reqs, and upgraded run requirements
-[testenv:gallery-py39-upgrade-dev]
-basepython = python3.9
+[testenv:gallery-py310]
+basepython = python3.10
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+# Test with python 3.10, pinned dev and doc reqs, and upgraded run requirements
+[testenv:gallery-py310-upgrade-dev]
+basepython = python3.10
 install_command =
     pip install -U -e . {opts} {packages}
 deps =
@@ -137,9 +146,9 @@ deps =
     -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.9, pinned dev and doc reqs, and pre-release run requirements
-[testenv:gallery-py39-upgrade-dev-pre]
-basepython = python3.9
+# Test with python 3.10, pinned dev and doc reqs, and pre-release run requirements
+[testenv:gallery-py310-upgrade-dev-pre]
+basepython = python3.10
 install_command =
     pip install -U --pre -e . {opts} {packages}
 deps =


### PR DESCRIPTION
## Motivation

[Python 3.10](https://www.python.org/downloads/release/python-3100/) was released on Oct 4, 2021. This PR updates the nightly CI to test against Python 3.10. If all dependencies are compatible with Python 3.10 and all tests pass, I will create a separate PR to update the per-PR CI.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
