### PR TITLE
Provide code example for export with new ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added support for Python 3.10. @rly (#679)
 - Updated requirements. @rly @TheChymera (#681)
 - Improved testing for `ExternalResources`. @mavaylon (#673)
+- Improved docs for export. @rly (#674)
 
 ### Bug fixes
 - Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @rly (#662)

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -45,7 +45,9 @@ file and not the read file.
 .. note::
 
   Modifications to :py:class:`h5py.Dataset <h5py.Dataset>` objects act *directly* on the read file on disk.
-  Changes are applied immediately and do not require exporting or writing the file. If you want to modify a dataset only in the new file, than you should replace the whole object with a new array holding the modified data. To prevent unintentional changes to the source file, the source file should be opened with ``mode='r'``.
+  Changes are applied immediately and do not require exporting or writing the file. If you want to modify a dataset
+  only in the new file, than you should replace the whole object with a new array holding the modified data. To
+  prevent unintentional changes to the source file, the source file should be opened with ``mode='r'``.
 
 Can I export a newly instantiated container?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -33,6 +33,15 @@ file and not the read file.
   :py:meth:`Container.set_modified() <hdmf.container.AbstractContainer.set_modified>` must be called
   on the container before exporting.
 
+.. code-block:: python
+
+   with HDF5IO(self.read_path, manager=manager, mode='r') as read_io:
+       container = read_io.read()
+       # ...  # modify container
+       container.set_modified()  # this may be necessary if the modifications are changes to attributes
+       with HDF5IO(self.export_path, mode='w') as export_io:
+           export_io.export(src_io=read_io, container=container)
+
 .. note::
 
   Modifications to :py:class:`h5py.Dataset <h5py.Dataset>` objects act *directly* on the read file on disk.

--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -5,8 +5,8 @@ Export is a new feature in HDMF 2.0. You can use export to take a container that
 a different file, with or without modifications to the container in memory.
 The in-memory container being exported will be written to the exported file as if it was never read from a file.
 
-To export a container, first read the container from a file, then create a new 
-:py:class:`~hdmf.backends.hdf5.h5tools.HDF5IO` object for exporting the data, then call 
+To export a container, first read the container from a file, then create a new
+:py:class:`~hdmf.backends.hdf5.h5tools.HDF5IO` object for exporting the data, then call
 :py:meth:`~hdmf.backends.hdf5.h5tools.HDF5IO.export` on the
 :py:class:`~hdmf.backends.hdf5.h5tools.HDF5IO` object, passing in the IO object used to read the container
 and optionally, the container itself, which may be modified in memory between reading and exporting.
@@ -91,3 +91,11 @@ new IDs. Note: calling the :py:meth:`generate_new_id <hdmf.container.AbstractCon
 changes the object IDs of the containers in memory. These changes are not reflected in the original file from
 which the containers were read unless the :py:meth:`HDF5IO.write <hdmf.backends.hdf5.h5tools.HDF5IO.write>`
 method is subsequently called.
+
+.. code-block:: python
+
+   with HDF5IO(self.read_path, manager=manager, mode='r') as read_io:
+       container = read_io.read()
+       container.generate_new_id()
+       with HDF5IO(self.export_path, mode='w') as export_io:
+           export_io.export(src_io=read_io, container=container)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -2925,6 +2925,26 @@ class TestExport(TestCase):
                 with self.assertRaisesWith(UnsupportedOperation, msg):
                     export_io.export(src_io=read_io)
 
+    def test_with_new_id(self):
+        """Test that exporting with a src_io without a manager raises an error."""
+        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        foobucket = FooBucket('bucket1', [foo1])
+        foofile = FooFile([foobucket])
+
+        with HDF5IO(self.paths[0], manager=_get_manager(), mode='w') as write_io:
+            write_io.write(foofile)
+
+        with HDF5IO(self.paths[0], manager=_get_manager(), mode='r') as read_io:
+            data = read_io.read()
+            original_id = data.object_id
+            data.generate_new_id()
+            with HDF5IO(self.paths[1], mode='w') as export_io:
+                export_io.export(src_io=read_io, container=data)
+
+        with HDF5IO(self.paths[1], manager=_get_manager(), mode='r') as read_io:
+            data = read_io.read()
+            self.assertTrue(original_id != data.object_id)
+
 
 class TestDatasetRefs(TestCase):
 


### PR DESCRIPTION
## Motivation

A user was confused about how to export a container with a new ID. This PR adds a code example to the export docs and a unit test.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
