### PR TITLE
Do not test against base Python error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   (#683)
 - Fixed `to_hierarchcial_dataframe` failing when a table contains a `VectorIndex` column as a regular data column.
   @oruebel (#666)
+- Stop testing against base Python error messages because they may change in the future. @rly (#689)
 
 ## HDMF 3.1.1 (July 29, 2021)
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -918,7 +918,7 @@ class DynamicTableRegionRoundTrip(H5RoundTripMixin, TestCase):
             self._getitem(12)
 
     def test_getitem_badcol(self):
-        with self.assertRaisesWith(KeyError, '\'boo\''):
+        with self.assertRaises(KeyError):
             self._getitem('boo')
 
     def _assert_two_elem_df(self, rec):
@@ -1163,7 +1163,7 @@ class TestDynamicTableClassColumns(TestCase):
         self.assertIsNone(table.col11_index)
 
         # uninitialized optional predefined columns cannot be accessed in this manner
-        with self.assertRaisesWith(KeyError, "'col2'"):
+        with self.assertRaises(KeyError):
             table['col2']
 
     def test_gather_columns_inheritance(self):

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -345,7 +345,7 @@ class TestAbstractContainerFieldsConf(TestCase):
         obj = NamedFieldsNotSettable('test name')
 
         obj.field1 = 'field1 value'
-        with self.assertRaisesWith(AttributeError, "can't set attribute"):
+        with self.assertRaises(AttributeError):
             obj.field2 = 'field2 value'
 
     def test_inheritance(self):
@@ -379,7 +379,7 @@ class TestAbstractContainerFieldsConf(TestCase):
         self.assertEqual(ret[0], {'name': 'field1', 'doc': 'overridden field', 'settable': False})
 
         # obj = NamedFieldsChild('test name')
-        # with self.assertRaisesWith(AttributeError, "can't set attribute"):
+        # with self.assertRaises(AttributeError):
         #     obj.field1 = 'field1 value'
 
     def test_mult_inheritance_base_mixin(self):

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -39,7 +39,7 @@ class TestLabelledDict(TestCase):
     def test_getitem_unknown_val(self):
         """Test that dict[unknown_key] where the key unknown_key is not in the dict raises an error."""
         ld = LabelledDict(label='all_objects', key_attr='prop1')
-        with self.assertRaisesWith(KeyError, "'unknown_key'"):
+        with self.assertRaises(KeyError):
             ld['unknown_key']
 
     def test_getitem_eqeq_unknown_val(self):
@@ -161,7 +161,7 @@ class TestLabelledDict(TestCase):
         ld = LabelledDict(label='all_objects', key_attr='prop1')
         obj1 = MyTestClass('a', 'b')
         ld.add(obj1)
-        with self.assertRaisesWith(KeyError, "'unknown_val'"):
+        with self.assertRaises(KeyError):
             ld['prop1 == unknown_val']  # same as ld['unknown_val']
 
     def test_getitem_eqeq_nonempty_unknown_attr(self):


### PR DESCRIPTION
## Motivation

This is a minor code maintenance update to stop testing the exact message presented by a Python native `KeyError` and `AttributeError`, which is subject to change across Python versions. Related to #687.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
