### PR TITLE
Add reset_parent functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added ``hdmf.container.Row.__str__`` to improve print of rows. @oruebel (#667)
 - Added ``to_dataframe`` method for ``hdmf.common.resources.ExternalResource`` to improve visualization. @oruebel (#667)
 - Added ``export_to_sqlite`` method for ``hdmf.common.resources.ExternalResource``. @oruebel (#667)
+- Added ``reset_parent`` method for ``hdmf.container.Container``. @rly (#692)
 
 ### Minor improvements
 - Plotted results in external resources tutorial. @oruebel (#667)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1121,6 +1121,8 @@ class HDF5IO(HDMFIO):
                     elif parent.name != data.parent.name:  # dataset is in export source and has different path
                         # so create a soft link to the dataset in this file
                         # possible if user adds a link to a dataset in export source after reading to memory
+                        # TODO check that there is/will be still a dataset at data.name -- if the dataset has
+                        # been removed, then this link will be broken
                         link = SoftLink(data.name)
                         self.logger.debug("    Creating SoftLink '%s/%s' to '%s'"
                                           % (parent.name, name, link.path))

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -332,6 +332,18 @@ class AbstractContainer(metaclass=ExtenderMeta):
         child.set_modified()
         self.set_modified()
 
+    def reset_parent(self):
+        """Reset the parent of this Container to None and remove the Container from the children of its parent.
+
+        Use with caution. This can result in orphaned containers and broken links.
+        """
+        if self.parent is None:
+            return
+        elif isinstance(self.parent, AbstractContainer):
+            self.parent._remove_child(self)
+        else:
+            raise ValueError("Cannot reset parent when parent is not an AbstractContainer: %s" % repr(self.parent))
+
 
 class Container(AbstractContainer):
     """A container that can contain other containers and has special functionality for printing."""

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -175,6 +175,7 @@ class TestContainer(TestCase):
         child_obj.parent = parent_obj
         child_obj3.parent = parent_obj
         parent_obj._remove_child(child_obj)
+        self.assertIsNone(child_obj.parent)
         self.assertTupleEqual(parent_obj.children, (child_obj3, ))
         self.assertTrue(parent_obj.modified)
         self.assertTrue(child_obj.modified)
@@ -192,6 +193,36 @@ class TestContainer(TestCase):
         msg = "Container 'dummy' is not a child of Container 'obj1'."
         with self.assertRaisesWith(ValueError, msg):
             Container('obj1')._remove_child(Container('dummy'))
+
+    def test_reset_parent(self):
+        """Test that removing a child removes only the child.
+        """
+        parent_obj = Container('obj1')
+        child_obj = Container('obj2')
+        child_obj3 = Container('obj3')
+        child_obj.parent = parent_obj
+        child_obj3.parent = parent_obj
+        child_obj.reset_parent()
+        self.assertIsNone(child_obj.parent)
+        self.assertTupleEqual(parent_obj.children, (child_obj3, ))
+        self.assertTrue(parent_obj.modified)
+        self.assertTrue(child_obj.modified)
+
+    def test_reset_parent_parent_noncontainer(self):
+        """Test that resetting a parent that is not a container raises an error.
+        """
+        obj = Container('obj1')
+        obj.parent = object()
+        msg = "Cannot reset parent when parent is not an AbstractContainer: %s" % repr(obj.parent)
+        with self.assertRaisesWith(ValueError, msg):
+            obj.reset_parent()
+
+    def test_reset_parent_no_parent(self):
+        """Test that resetting a non-existent parent has no effect.
+        """
+        obj = Container('obj1')
+        obj.reset_parent()
+        self.assertIsNone(obj.parent)
 
 
 class TestData(TestCase):


### PR DESCRIPTION
## Motivation

Add less hacky workaround for #691 by allowing users to reset the parent of a container which more or less exposes the private `_remove_child` function. Another idea is to add some sort of `move_container` functionality.

This is different from just allowing users to reset parent via `container.parent = None` (which is not allowed) because it makes the resetting explicit and allows us to document and warn about this function specifically. I can fold this into the `parent` setter if that is cleaner though.

Both ideas require the user to understand the parent/child hierarchy of each container, which is intuitive in a file system but may not be so intuitive here in HDMF.

Also added a gotcha note to the export dataset function where soft links are made. This does not work correctly when a dataset is moved within a file. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
