### PR TITLE
Fix upload to PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ jobs:
       - TEST_TOX_ENV: "py39"
       - BUILD_TOX_ENV: "build-py39"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
-      - UPLOAD_WHEELS: "true"  # upload distributions from only this job to pypi
     <<: *ci-steps
 
   python310:
@@ -202,7 +201,6 @@ jobs:
       - TEST_TOX_ENV: "py310"
       - BUILD_TOX_ENV: "build-py310"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
-      - UPLOAD_WHEELS: "true"  # upload distributions from only this job to pypi
     <<: *ci-steps
 
   python310-opt:
@@ -219,6 +217,7 @@ jobs:
       - TEST_TOX_ENV: "py310-upgrade-dev"
       - BUILD_TOX_ENV: "build-py310-upgrade-dev"
       - TEST_WHEELINSTALL_ENV: "wheelinstall"
+      - UPLOAD_WHEELS: "true"  # keep distributions from this job for upload to PyPI
     <<: *ci-steps
 
   python310-upgrade-dev-pre:
@@ -415,7 +414,7 @@ workflows:
           requires:
             - flake8
             - python37-min-req
-            - python310-upgrade-dev
+            - python310-upgrade-dev  # distributions from this job uploaded to PyPI
             - miniconda37
             - miniconda310
             - gallery37-min-req
@@ -434,14 +433,15 @@ workflows:
           requires:
             - flake8
             - python37-min-req
-            - python310-upgrade-dev
+            - python310-upgrade-dev  # distributions from this job uploaded to PyPI
             - miniconda37
             - miniconda310
             - gallery37-min-req
             - gallery310
           filters:
+            # run only on new tags that follow semver
             tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
+              only: /^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/
             branches:
               ignore: /.*/
           context:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # HDMF Changelog
 
-## HDMF 3.2 (February 22, 2022)
+## HDMF 3.2.1 (February 22, 2022)
+
+### Bug fixes
+- Fixed release CI that prevented distribution from being uploaded to PyPI. @rly (#693)
+
+## HDMF 3.2.0 (February 22, 2022)
 
 ### New features
 - Added ``hdmf.container.Row.__str__`` to improve print of rows. @oruebel (#667)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 3.2.1 (February 22, 2022)
 
 ### Bug fixes
-- Fixed release CI that prevented distribution from being uploaded to PyPI. @rly (#693)
+- Fixed release CI that prevented distribution from being uploaded to PyPI. @rly (#699)
 
 ## HDMF 3.2.0 (February 22, 2022)
 


### PR DESCRIPTION
## Motivation

The CI to upload releases to PyPI was messed up in the earlier release. This should fix it.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
