### PR TITLE
Add comments, rename name to required_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.2.2 (Upcoming)
+
+### Minor improvements
+- Improved readability of ``Container`` code. @rly (#707)
+
 ## HDMF 3.2.1 (February 22, 2022)
 
 ### Bug fixes

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -356,8 +356,9 @@ class Container(AbstractContainer):
         super_setter = AbstractContainer._setter(field)
         ret = [super_setter]
         # create setter with check for required name
+        # the AbstractContainer that is passed to the setter must have name = required_name
         if field.get('required_name', None) is not None:
-            name = field['required_name']
+            required_name = field['required_name']
             idx1 = len(ret) - 1
 
             def container_setter(self, val):
@@ -366,11 +367,11 @@ class Container(AbstractContainer):
                         msg = ("Field '%s' on %s has a required name and must be a subclass of AbstractContainer."
                                % (field['name'], self.__class__.__name__))
                         raise ValueError(msg)
-                    if val.name != name:
+                    if val.name != required_name:
                         msg = ("Field '%s' on %s must be named '%s'."
-                               % (field['name'], self.__class__.__name__, name))
+                               % (field['name'], self.__class__.__name__, required_name))
                         raise ValueError(msg)
-                ret[idx1](self, val)
+                ret[idx1](self, val)  # call the previous setter
 
             ret.append(container_setter)
 
@@ -379,7 +380,7 @@ class Container(AbstractContainer):
             idx2 = len(ret) - 1
 
             def container_setter(self, val):
-                ret[idx2](self, val)
+                ret[idx2](self, val)  # call the previous setter
                 if val is not None:
                     if isinstance(val, (tuple, list)):
                         pass
@@ -396,7 +397,7 @@ class Container(AbstractContainer):
                             self.set_modified()
 
             ret.append(container_setter)
-        return ret[-1]
+        return ret[-1]  # return the last setter (which should call the previous setters, if applicable)
 
     def __repr__(self):
         cls = self.__class__
@@ -1052,7 +1053,7 @@ class Table(Data):
                 name = {'name': 'name', 'type': str, 'doc': 'the name of this table'}
                 defname = getattr(cls, '__defaultname__', None)
                 if defname is not None:
-                    name['default'] = defname
+                    name['default'] = defname  # override the name with the default name if present
 
                 @docval(name,
                         {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the data in this table',


### PR DESCRIPTION
## Motivation

Very minor update to add comments and rename a variable to improve code readability based on discussion with @mavaylon1 .

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
