### PR TITLE
Do not reset child builder if it already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HDMF 3.2.2 (Upcoming)
 
+### Bug fixes
+- Fixed error with modifying files that contain external links to other files (e.g., shallow copies). @rly (#709)
+
 ### Minor improvements
 - Improved readability of ``Container`` code. @rly (#707)
 

--- a/src/hdmf/build/builders.py
+++ b/src/hdmf/build/builders.py
@@ -234,6 +234,11 @@ class GroupBuilder(BaseBuilder):
     def __set_builder(self, builder, obj_type):
         name = builder.name
         self.__check_obj_type(name, obj_type)
+        # if child builder already exists (e.g., read from file), do not reset it.
+        # resetting the child builder will change the python object ID / hash of the child builder
+        # and make the IO backend think that the child builder has not yet been written.
+        if self.get(name) == builder:
+            return
         super().__getitem__(obj_type)[name] = builder
         self.obj_type[name] = obj_type
         if builder.parent is None:


### PR DESCRIPTION
## Motivation

Fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1239#issuecomment-1072911822

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
