### PR TITLE
Close all files linked to from the closed file by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HDMF 3.2.2 (Upcoming)
 
+### Bug fixes
+- Fixed opening of files in append mode on Windows when the files contain links to other open files. @rly ()
+
 ### Minor improvements
 - Improved readability of ``Container`` code. @rly (#707)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -773,7 +773,14 @@ class HDF5IO(HDMFIO):
 
             self.__file = File(self.source, open_flag, **kwargs)
 
-    def close(self):
+    def close(self, close_links=True):
+        """Close this file and any files linked to from this file.
+
+        :param close_links: Whether to close all files linked to from this file. (default: True)
+        :type close_links: bool
+        """
+        if close_links:
+            self.close_linked_files()
         if self.__file is not None:
             self.__file.close()
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1132,7 +1132,7 @@ class TestCloseLinks(TestCase):
         self.assertFalse(read_foofile2.foo_link.my_data)
 
         # should be able to reopen both files
-        with HDF5IO(self.path1, mode='a', manager=_get_manager()) as new_io3:
+        with HDF5IO(self.path1, mode='a', manager=get_foo_buildmanager()) as new_io3:
             new_io3.read()
 
     def test_close_linked_files_explicit(self):
@@ -1144,11 +1144,11 @@ class TestCloseLinks(TestCase):
         foofile1 = FooFile(buckets=[bucket1])
 
         # Write the first file
-        with HDF5IO(self.path1, mode='w', manager=_get_manager()) as io:
+        with HDF5IO(self.path1, mode='w', manager=get_foo_buildmanager()) as io:
             io.write(foofile1)
 
         # Create the second file
-        manager = _get_manager()  # use the same manager for read and write so that links work
+        manager = get_foo_buildmanager()  # use the same manager for read and write so that links work
         with HDF5IO(self.path1, mode='r', manager=manager) as read_io:
             read_foofile1 = read_io.read()
             foofile2 = FooFile(foo_link=read_foofile1.buckets['bucket1'].foos['foo1'])  # cross-file link
@@ -1157,7 +1157,7 @@ class TestCloseLinks(TestCase):
             with HDF5IO(self.path2, mode='w', manager=manager) as write_io:
                 write_io.write(foofile2)
 
-        new_io1 = HDF5IO(self.path2, mode='a', manager=_get_manager())
+        new_io1 = HDF5IO(self.path2, mode='a', manager=get_foo_buildmanager())
         read_foofile2 = new_io1.read()  # keep reference to container in memory
         new_io1.close(close_links=False)  # do not close the links
 
@@ -1209,11 +1209,11 @@ class TestCloseLinks(TestCase):
         foofile1 = FooFile(buckets=[bucket1])
 
         # Write the first file
-        with HDF5IO(self.path1, mode='w', manager=_get_manager()) as io:
+        with HDF5IO(self.path1, mode='w', manager=get_foo_buildmanager()) as io:
             io.write(foofile1)
 
         # Create the second file
-        manager = _get_manager()  # use the same manager for read and write so that links work
+        manager = get_foo_buildmanager()  # use the same manager for read and write so that links work
         with HDF5IO(self.path1, mode='r', manager=manager) as read_io:
             read_foofile1 = read_io.read()
             foofile2 = FooFile(foo_link=read_foofile1.buckets['bucket1'].foos['foo1'])  # cross-file link
@@ -1225,7 +1225,7 @@ class TestCloseLinks(TestCase):
         read_io = HDF5IO(self.path1, mode='r', manager=manager)
         read_foofile1 = read_io.read()
 
-        with HDF5IO(self.path2, mode='a', manager=_get_manager()) as new_io1:
+        with HDF5IO(self.path2, mode='a', manager=get_foo_buildmanager()) as new_io1:
             new_io1.read()  # keep reference to container in memory
 
         self.assertTrue(read_io)  # make sure read_io is not closed


### PR DESCRIPTION
Fix one of the issues from https://github.com/NeurodataWithoutBorders/pynwb/issues/1239 :
On Windows only, if file X is closed, then all files Y1, Y2, ..., linked to from file X remain open and must be explicitly closed.
Attempting to open any linked-to file , e.g., Y1, later in append mode will result in opaque broken links and unexpected behavior.

From https://github.com/hdmf-dev/hdmf/pull/383 , it was decided that `close_links=True` should be the default. This PR makes it the default. Even though this changes default behavior, I consider this a bug fix.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
