### PR TITLE
Added functionality to load plugins for HDMF 

### DIFF
--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -60,10 +60,13 @@ def configure_macro_plugins():
         if hasattr(plugin, 'configure_hdmf_docval_macros'):
             update_macros = getattr(plugin, 'configure_hdmf_docval_macros')()
             if update_macros is not None:
+                # update_macros is a list of tuples with the changes
                 for macro in update_macros:
+                    # create a new macro
                     if macro[0] not in __macros:
                         __macros[macro[0]] = list()
                         __macros[macro[0]].append(macro[1])
+                    # update an existing macro by adding a new allowable type
                     else:
                         if macro[1] not in __macros[macro[0]]:
                             __macros[macro[0]].append(macro[1])


### PR DESCRIPTION
## Motivation

I am trying to create a new data backend for HDMF and would like to define it as a separate library outside of HDMF. However, since the backend uses a different type of array data type that is not part of the default ``hdmf.utils.__macros`` definition, I need to modify the definition to add the custom array type. The challenge is that once HDMF is loaded, updating the ``hdmf.utils.__macros``does not propagate such that, e.g., classes like ``DataIO`` or ``DatasetBuilder`` will still not accept the additional array types.  

One solution to this problem is to make the updates to ``hdmf.utils.__macros`` before HDMF is fully loaded. This is the approach that this PR implements by defining the concept of plugins for HDMF. To do this, this PR adds:

* ``hdmf.utils.get_available_plugins`` to find all available plugins
* ``hdmf.utils.configure_macro_plugins`` which is called during the import of `hdmf.utils``. The function iterates over all plugins to collect and implement all modifications to ``hdmf.utils.__macros``

The plugin mechanism is based on a simple naming convention, i.e., plugins for HDMF must start with ``hdmf_`` and end with ``_plugin``. To define changes to the ``hdmf.utils.__macros`` the plugin must the implement the ``configure_hdmf_docval_macros`` function which simply returns a list of modifications to be made to ``hdmf.utils.__macros``. 

The main question is: a) is this the best approach to do this and b) is there an alternate approach that would allow modifications of ``hdmf.utils.__macros``  and have HDMF still honor those changes in docval?


## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
