### PR TITLE
Fix CI prerelease and release

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -19,24 +19,36 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Download wheel and source distributions from artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: distributions
-          path: dist
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+          python -m pip list
+
+      - name: Run tox tests
+        run: |
+          tox -e py310-upgraded
+
+      - name: Build wheel and source distribution
+        run: |
+          tox -e build-py310-upgraded
+          ls -1 dist
+
+      - name: Test installation from a wheel
+        run: |
+          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
 
       - name: Upload wheel and source distributions to PyPI  # TODO remove the --repository flag after testing
         run: |
-          python -m pip install --upgrade pip
           python -m pip install twine
           ls -1 dist
-          twine upload --repository testpypi -u ${{ secrets.PYPI_USER }} -p ${{ secrets.PYPI_PASSWORD }} --skip-existing dist/*
+          twine upload --repository testpypi -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
 
       - name: Publish wheel and source distributions as a GitHub release
         run: |
           # use click<8 until https://github.com/j0057/github-release/issues/62 is resolved
           python -m pip install "click<8" githubrelease
-          echo ${{ github.ref_name }}
-          # githubrelease release hdmf-dev/hdmf \
-          #   create ${{ github.ref_name }} --name ${{ github.ref_name }} \
-          #   --publish dist/*
+          githubrelease release hdmf-dev/hdmf \
+            create ${{ github.ref_name }} --name ${{ github.ref_name }} \
+            --github-token ${{ secrets.BOT_GITHUB_TOKEN }} \
+            --publish dist/*

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -194,4 +194,5 @@ jobs:
               --prerelease-sha $GITHUB_SHA \
               --prerelease-packages-clear-pattern "*" \
               --prerelease-packages-keep-pattern "*dev<COMMIT_DISTANCE>*" \
+              --token ${{ secrets.BOT_GITHUB_TOKEN }} \
               --re-upload


### PR DESCRIPTION
A parameter was missing for generating prereleases on push to the dev branch.
