### PR TITLE
Fix missing version in prereleases

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -173,6 +173,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -128,6 +129,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -173,7 +175,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
Pre-release and releases are missing the correct version (it is set to 0.0.0) because versioneer requires git tags and the latest version of https://github.com/actions/checkout does not checkout tags by default. This PR fixes that issue hopefully.