### PR TITLE
Add copy button for code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Moved `Baz`, `BazData`, `BazCpdData`, `BazBucket`, `get_baz_buildmanager` test data classes from `tests.unit.test_io_hdf5_h5tools` to `tests.unit.utils` to ease reuse and updated tests accordingly. Also `_get_baz_manager` was renamed to `get_baz_buildmanager` as part of this move. @oruebel (#697)
 - Added numerous tests to `tests/unit/common/test_sparse.py` to enhance testing of the `CSRMatrix` type. @oruebel (#697)
 
+### Documentation and tutorial enhancements:
+- Add copy button to code blocks @weiglszonja @oruebel (#726)
 
 ## HDMF 3.2.1 (February 22, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Bug fixes
 - Fixed error with modifying files that contain external links to other files (e.g., shallow copies). @rly (#709)
 - Fixed opening of files in append mode on Windows when the files contain links to other open files. @rly (#710)
+- Updated `HDF5IO` to always set the `location` attribute of `GroupBuilders`, `DatasetBuilders`, and `LinkBuilders` on read.   @oruebel (#697)
+- Updated `HDF5IO.get_types` to correctly determine the data type for `bytes` data. @oruebel (#697)
 
 ### Minor improvements
 - Updated `HDF5IO` to use the new `WriteStatusTracker`, `NamespaceToBuilderHelper`, and `HDF5IODataChunkIteratorQueue` helper classes. @oruebel (#697)
@@ -20,14 +22,11 @@
 - Improved readability of ``Container`` code. @rly (#707)
 - Use GitHub Actions for all CI. @rly (#718)
 
-### Bug fixes
-- Updated `HDF5IO` to always set the `location` attribute of `GroupBuilders`, `DatasetBuilders`, and `LinkBuilders` on read.   @oruebel (#697)
-- Updated `HDF5IO.get_types` to correctly determine the data type for `bytes` data. @oruebel (#697)
-
 ### Enhancements of tests
 - Moved test functions to ease reuse and updated tests accordingly.  @oruebel (#697)
 - Moved `Baz`, `BazData`, `BazCpdData`, `BazBucket`, `get_baz_buildmanager` test data classes from `tests.unit.test_io_hdf5_h5tools` to `tests.unit.utils` to ease reuse and updated tests accordingly. Also `_get_baz_manager` was renamed to `get_baz_buildmanager` as part of this move. @oruebel (#697)
 - Added numerous tests to `tests/unit/common/test_sparse.py` to enhance testing of the `CSRMatrix` type. @oruebel (#697)
+
 
 ## HDMF 3.2.1 (February 22, 2022)
 

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -5,3 +5,12 @@
 .wy-nav-content {
   max-width: 1000px !important;
 }
+
+button.copybtn {
+    height:25px;
+    width:25px;
+    opacity: 0.5;
+    padding: 0;
+    border: none;
+    background: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
-    'sphinx_gallery.gen_gallery'
+    'sphinx_gallery.gen_gallery',
+    'sphinx_copybutton'
 ]
 
 from sphinx_gallery.sorting import ExplicitOrder

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,3 +3,4 @@ matplotlib
 sphinx
 sphinx_rtd_theme
 sphinx-gallery
+sphinx-copybutton


### PR DESCRIPTION
## Motivation

This PR adds the copy button feature for copying code cells from the docs also to the HDMF docs. 

These changes were originally proposed by @weiglszonja on PyNWB. This PR just adds the same changes to the HDMF docs. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
