### PR TITLE
Allow write_args=None to be passed to HDF5IO.export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Updated `hdmf.common.sparse.CSRMatrix` to avoid direct dependency on h5py as a particular storage backend. @oruebel (#697)
 - Improved readability of ``Container`` code. @rly (#707)
 - Use GitHub Actions for all CI. @rly (#718)
+- Allow `write_args=None` to be passed to `HDF5IO.export`. @rly (#733)
 
 ### Enhancements of tests
 - Moved test functions to ease reuse and updated tests accordingly.  @oruebel (#697)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -382,7 +382,7 @@ class HDF5IO(HDMFIO):
                  'exported'),
          'default': None},
         {'name': 'write_args', 'type': dict, 'doc': 'arguments to pass to :py:meth:`write_builder`',
-         'default': dict()},
+         'default': None},
         {'name': 'cache_spec', 'type': bool, 'doc': 'whether to cache the specification to file',
          'default': True}
     )
@@ -399,6 +399,8 @@ class HDF5IO(HDMFIO):
 
         src_io = getargs('src_io', kwargs)
         write_args, cache_spec = popargs('write_args', 'cache_spec', kwargs)
+        if write_args is None:
+            write_args = dict()
 
         if not isinstance(src_io, HDF5IO) and write_args.get('link_data', True):
             raise UnsupportedOperation("Cannot export from non-HDF5 backend %s to HDF5 with write argument "


### PR DESCRIPTION
## Motivation

This is a minor change. `HDF5IO.export` has the argument `write_args` which must be a dict. The default value in the method docval was previously `dict()`, which has the side-effect that `write_args=None` cannot be passed. This means that when a subclass calls `super` on arguments where `write_args=None`, that an error is raised. This could be fixed in several different ways -- here or in the subclass -- but I think allowing `write_args=None` is the most flexible and straightforward.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
