### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,8 +1,9 @@
 name: Deploy release
 on:
   push:
-    tags:  # run only on new tags that follow semver
-      - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
+    tags:  # run only on new tags that follow semver MAJOR.MINOR.PATCH
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
   deploy-release:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         include:
           - { name: linux-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: linux-python3.7              , test-tox-env: py37            , build-tox-env: build-py37            , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: linux-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.10-upgraded    , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF
 h5py==3.6.0
 jsonschema==4.5.1
-numpy==1.21.5  # note that numpy 1.22.0 dropped python 3.7 support
-pandas==1.4.2
+numpy==1.21.5  # note that numpy 1.22 dropped python 3.7 support
+pandas==1.3.5  # note that pandas 1.4 dropped python 3.7 support
 ruamel.yaml==0.17.21
 scipy==1.8.0
 setuptools==62.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jsonschema==4.5.1
 numpy==1.21.5  # note that numpy 1.22 dropped python 3.7 support
 pandas==1.3.5  # note that pandas 1.4 dropped python 3.7 support
 ruamel.yaml==0.17.21
-scipy==1.8.0
+scipy==1.7.3   # note that scipy 1.8 dropped python 3.7 support
 setuptools==62.2.0


### PR DESCRIPTION
- Fix CI trigger for deploying releases based on tag. It can also be triggered manually
- Downgrade pandas requirement in `requirements.txt` because pandas 1.4 is not supported with python 3.7
- Add CI tests using `requirements.txt` for each PR

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.