### PR TITLE
Fix githubrelease in deploy CI

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           # use click<8 until https://github.com/j0057/github-release/issues/62 is resolved
           python -m pip install "click<8" githubrelease
-          githubrelease release hdmf-dev/hdmf \
+          githubrelease --github-token ${{ secrets.BOT_GITHUB_TOKEN }} release hdmf-dev/hdmf \
             create ${{ github.ref_name }} --name ${{ github.ref_name }} \
-            --github-token ${{ secrets.BOT_GITHUB_TOKEN }} \
             --publish dist/*


### PR DESCRIPTION
## Motivation

The new GitHub Action for publishing release assets as a GitHub release uses incorrect syntax, and that is fixed here.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
