### PR TITLE
Remove debugging for uploading to pypi

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:  # run only on new tags that follow semver MAJOR.MINOR.PATCH
       - '[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
 
 jobs:
   deploy-release:
@@ -40,11 +39,12 @@ jobs:
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
 
-      - name: Upload wheel and source distributions to PyPI  # TODO remove the --repository flag after testing
+      - name: Upload wheel and source distributions to PyPI
         run: |
           python -m pip install twine
           ls -1 dist
-          twine upload --repository testpypi -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
+          # twine upload --repository testpypi -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
+          twine upload -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
 
       - name: Publish wheel and source distributions as a GitHub release
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.3.1 (May 20, 2022)
+
+### Bug fixes
+- Fixed release deployment CI. @rly (#734, #735, #736)
+
 ## HDMF 3.3.0 (May 18, 2022)
 
 ### New features


### PR DESCRIPTION
## Motivation

The current deploy CI uploads the release to the testpypi repository while I made sure that the CI worked. It looks like it all works now, so this PR switches the upload target to the real pypi repository.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
