### PR TITLE
Improve error message when using GDCI and chunk shape > dataset size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.3.2 (June 23, 2022)
+
+### Bug fixes
+- Fix error message when using ``GenericDataChunkIterator`` and chunk shape is larger than dataset size. @rly ()
+
 ## HDMF 3.3.1 (May 20, 2022)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 3.3.2 (June 23, 2022)
 
 ### Bug fixes
-- Fix error message when using ``GenericDataChunkIterator`` and chunk shape is larger than dataset size. @rly ()
+- Fix error message when using ``GenericDataChunkIterator`` and chunk shape is larger than dataset size. @rly (#743)
 
 ## HDMF 3.3.1 (May 20, 2022)
 

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -222,11 +222,14 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         array_maxshape = np.array(self.maxshape)
         assert all(array_buffer_shape > 0), f"Some dimensions of buffer_shape ({self.buffer_shape}) are less than zero!"
         assert all(
+            array_chunk_shape <= array_maxshape
+        ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the data dimensions ({self.maxshape})!"
+        assert all(
             array_buffer_shape <= array_maxshape
         ), f"Some dimensions of buffer_shape ({self.buffer_shape}) exceed the data dimensions ({self.maxshape})!"
         assert all(
             array_chunk_shape <= array_buffer_shape
-        ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the manual buffer shape ({self.buffer_shape})!"
+        ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the buffer shape ({self.buffer_shape})!"
         assert all((array_buffer_shape % array_chunk_shape == 0)[array_buffer_shape != array_maxshape]), (
             f"Some dimensions of chunk_shape ({self.chunk_shape}) do not "
             f"evenly divide the buffer shape ({self.buffer_shape})!"

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -84,12 +84,24 @@ class GenericDataChunkIteratorTests(TestCase):
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, chunk_shape=(1580, 316), chunk_mb=1)
 
+        chunk_shape = (2001, 384)
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg=(
+                f"Some dimensions of chunk_shape ({chunk_shape}) exceed the "
+                f"data dimensions ((2000, 384))!"
+            ),
+        ):
+            self.TestNumpyArrayDataChunkIterator(
+                array=self.test_array, chunk_shape=chunk_shape
+            )
+
         buffer_shape = (1000, 192)
         chunk_shape = (100, 384)
         with self.assertRaisesWith(
             exc_type=AssertionError,
             exc_msg=(
-                f"Some dimensions of chunk_shape ({chunk_shape}) exceed the manual "
+                f"Some dimensions of chunk_shape ({chunk_shape}) exceed the "
                 f"buffer shape ({buffer_shape})!"
             ),
         ):


### PR DESCRIPTION
## Motivation

When using ``GenericDataChunkIterator`` and passing a chunk shape that happens to be larger than the dataset size, e.g., the chunk shape = (2000, 10) and the dataset size, or max shape, is (1000, 10), then an error is raised with the message "Some dimensions of chunk_shape ((2000, 10)) exceed the manual buffer shape ((1000, 10))". This is confusing because I did not set the buffer shape. 

This PR adds a check for chunk shape > dataset size and provides a error message that more clearly indicates the problem.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
