### PR TITLE
Allow manual triggering of some GitHub Actions

### DIFF
--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
+  workflow_dispatch:
 
 jobs:
   check-external-links:

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:  # run only on new tags that follow semver
       - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
+  workflow_dispatch:
 
 jobs:
   run-all-tests:

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -7,6 +7,7 @@ on:
       - 'latest'
       - 'latest-tmp'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   run-coverage:

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
+  workflow_dispatch:
 
 jobs:
   run-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.4.0 (upcoming)
+
+### Minor improvements
+- Allow manual triggering of some GitHub Actions. @rly (#744)
+
 ## HDMF 3.3.2 (June 27, 2022)
 
 ### Bug fixes


### PR DESCRIPTION
## Motivation

The run all tests workflow runs the test suite on all relevant combinations of python version x OS x etc., not just on the select ones that are run for every PR or push. Currently this is scheduled to run once everyday at a scheduled time. Before making a release, it is useful to run this workflow (and similar workflows) to make sure all tests pass.

This PR allows us to manually trigger certain workflows on the dev branch.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
