### PR TITLE
Setup HDF5 dataset without having data ahead of time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HDMF 3.3.3 (Upcoming)
 - Relax input validation of `HDF5IO` to allow for s3fs support. Existing arguments of `HDF5IO` are modified as follows: i) `mode` was given a default value of "r", ii) `path` was given a default value of `None`, and iii) `file` can now accept an `S3File` type argument. @bendichter ([#746](https://github.com/hdmf-dev/hdmf/pull/746))
+- Added ability to create and get back handle to empty HDF5 dataset. @ajtritt (#747)
 
 ## HDMF 3.3.2 (June 27, 2022)
 

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -478,11 +478,11 @@ class H5DataIO(DataIO):
              'default': False},
             {'name': 'shape',
              'type': tuple,
-             'doc': 'the shape of the new dataset',
+             'doc': 'the shape of the new dataset, used only if data is None',
              'default': None},
             {'name': 'dtype',
              'type': (str, type, np.dtype),
-             'doc': 'the data type of the new dataset',
+             'doc': 'the data type of the new dataset, used only if data is None',
              'default': None}
             )
     def __init__(self, **kwargs):

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -475,11 +475,20 @@ class H5DataIO(DataIO):
             {'name': 'allow_plugin_filters',
              'type': bool,
              'doc': 'Enable passing dynamically loaded filters as compression parameter',
-             'default': False}
+             'default': False},
+            {'name': 'shape',
+             'type': tuple,
+             'doc': 'the shape of the new dataset',
+             'default': None},
+            {'name': 'dtype',
+             'type': (str, type, np.dtype),
+             'doc': 'the data type of the new dataset',
+             'default': None}
             )
     def __init__(self, **kwargs):
         # Get the list of I/O options that user has passed in
-        ioarg_names = [name for name in kwargs.keys() if name not in ['data', 'link_data', 'allow_plugin_filters']]
+        ioarg_names = [name for name in kwargs.keys() if name not in ['data', 'link_data', 'allow_plugin_filters',
+                                                                      'dtype', 'shape']]
         # Remove the ioargs from kwargs
         ioarg_values = [popargs(argname, kwargs) for argname in ioarg_names]
         # Consume link_data parameter
@@ -494,6 +503,9 @@ class H5DataIO(DataIO):
         call_docval_func(super().__init__, kwargs)
         # Construct the dict with the io args, ignoring all options that were set to None
         self.__iosettings = {k: v for k, v in zip(ioarg_names, ioarg_values) if v is not None}
+        if self.data is None:
+            self.__iosettings['dtype'] = self.dtype
+            self.__iosettings['shape'] = self.shape
         # Set io_properties for DataChunkIterators
         if isinstance(self.data, AbstractDataChunkIterator):
             # Define the chunking options if the user has not set them explicitly.
@@ -525,6 +537,18 @@ class H5DataIO(DataIO):
         if isinstance(self.data, Dataset):
             for k in self.__iosettings.keys():
                 warnings.warn("%s in H5DataIO will be ignored with H5DataIO.data being an HDF5 dataset" % k)
+
+        self.__dataset = None
+
+    @property
+    def dataset(self):
+        return self.__dataset
+
+    @dataset.setter
+    def dataset(self, val):
+        if self.__dataset is not None:
+            raise ValueError("Cannot overwrite H5DataIO.dataset")
+        self.__dataset = val
 
     def get_io_params(self):
         """

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -3,7 +3,7 @@ import os.path
 import warnings
 from collections import deque
 from functools import partial
-from pathlib import Path
+from pathlib import Path, PosixPath as pp
 
 import numpy as np
 import h5py
@@ -1342,9 +1342,9 @@ class HDF5IO(HDMFIO):
         """
         # Define the shape of the data if not provided by the user
         if 'shape' not in io_settings:
-            raise ValueError(f"Cannot setup empty dataset {parent.name}/{name} without shape")
+            raise ValueError(f"Cannot setup empty dataset {pp(parent.name, name)} without shape")
         if 'dtype' not in io_settings:
-            raise ValueError(f"Cannot setup empty dataset {parent.name}/{name} without dtype")
+            raise ValueError(f"Cannot setup empty dataset {pp(parent.name, name)} without dtype")
         if isinstance(io_settings['dtype'], str):
             # map to real dtype if we were given a string
             io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -3,7 +3,7 @@ import os.path
 import warnings
 from collections import deque
 from functools import partial
-from pathlib import Path, PosixPath as pp
+from pathlib import Path, PurePosixPath as pp
 
 import numpy as np
 import h5py

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -245,8 +245,6 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 ret_dtype = "ascii"
             else:
                 ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
-        elif isinstance(value, DataIO) and value.data is None:
-            ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
         else:
             if spec_dtype_type in (_unicode, _ascii):
                 ret_dtype = 'ascii'

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -907,10 +907,14 @@ class DataIO:
     used to pass dataset-specific I/O parameters to the particular HDMFIO backend.
     """
 
-    @docval({'name': 'data', 'type': 'array_data', 'doc': 'the data to be written', 'default': None})
+    @docval({'name': 'data', 'type': 'array_data', 'doc': 'the data to be written', 'default': None},
+            {'name': 'dtype', 'type': (type, np.dtype), 'doc': 'the data type of the dataset', 'default': None},
+            {'name': 'shape', 'type': tuple, 'doc': 'the shape of the dataset', 'default': None})
     def __init__(self, **kwargs):
-        data = popargs('data', kwargs)
+        data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)
         self.__data = data
+        self.__dtype = dtype
+        self.__shape = shape
 
     def get_io_params(self):
         """
@@ -929,6 +933,16 @@ class DataIO:
         if self.__data is not None:
             raise ValueError("cannot overwrite 'data' on DataIO")
         self.__data = val
+
+    @property
+    def dtype(self):
+        """Get the wrapped data object"""
+        return self.__dtype
+
+    @property
+    def shape(self):
+        """Get the wrapped data object"""
+        return self.__shape
 
     def __copy__(self):
         """

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -907,9 +907,18 @@ class DataIO:
     used to pass dataset-specific I/O parameters to the particular HDMFIO backend.
     """
 
-    @docval({'name': 'data', 'type': 'array_data', 'doc': 'the data to be written', 'default': None},
-            {'name': 'dtype', 'type': (type, np.dtype), 'doc': 'the data type of the dataset', 'default': None},
-            {'name': 'shape', 'type': tuple, 'doc': 'the shape of the dataset', 'default': None})
+    @docval({'name': 'data', 
+             'type': 'array_data', 
+             'doc': 'the data to be written', 
+             'default': None},
+            {'name': 'dtype', 
+             'type': (type, np.dtype), 
+             'doc': 'the data type of the dataset. Not used if data is specified.', 
+             'default': None},
+            {'name': 'shape', 
+             'type': tuple, 
+             'doc': 'the shape of the dataset. Not used if data is specified.', 
+             'default': None})
     def __init__(self, **kwargs):
         data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)
         if data is not None:

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -907,17 +907,17 @@ class DataIO:
     used to pass dataset-specific I/O parameters to the particular HDMFIO backend.
     """
 
-    @docval({'name': 'data', 
-             'type': 'array_data', 
-             'doc': 'the data to be written', 
+    @docval({'name': 'data',
+             'type': 'array_data',
+             'doc': 'the data to be written',
              'default': None},
-            {'name': 'dtype', 
-             'type': (type, np.dtype), 
-             'doc': 'the data type of the dataset. Not used if data is specified.', 
+            {'name': 'dtype',
+             'type': (type, np.dtype),
+             'doc': 'the data type of the dataset. Not used if data is specified.',
              'default': None},
-            {'name': 'shape', 
-             'type': tuple, 
-             'doc': 'the shape of the dataset. Not used if data is specified.', 
+            {'name': 'shape',
+             'type': tuple,
+             'doc': 'the shape of the dataset. Not used if data is specified.',
              'default': None})
     def __init__(self, **kwargs):
         data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -912,6 +912,11 @@ class DataIO:
             {'name': 'shape', 'type': tuple, 'doc': 'the shape of the dataset', 'default': None})
     def __init__(self, **kwargs):
         data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)
+        if data is not None:
+            if dtype is not None:
+                raise ValueError("Setting the dtype when data is not None is not supported")
+            if shape is not None:
+                raise ValueError("Setting the shape when data is not None is not supported")
         self.__data = data
         self.__dtype = dtype
         self.__shape = shape
@@ -932,6 +937,8 @@ class DataIO:
         """Set the wrapped data object"""
         if self.__data is not None:
             raise ValueError("cannot overwrite 'data' on DataIO")
+        if not (self.__dtype is None and self.__shape is None):
+            raise ValueError("Setting data when dtype and shape are not None is not supported")
         self.__data = val
 
     @property

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -937,12 +937,12 @@ class DataIO:
     @property
     def dtype(self):
         """Get the wrapped data object"""
-        return self.__dtype
+        return self.__dtype or self.__getattr__("dtype")
 
     @property
     def shape(self):
         """Get the wrapped data object"""
-        return self.__shape
+        return self.__shape or self.__getattr__("shape")
 
     def __copy__(self):
         """

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -826,7 +826,7 @@ def get_data_shape(data, strict_no_data_load=False):
     # NOTE: data.maxshape will fail on empty h5py.Dataset without shape or maxshape. this will be fixed in h5py 3.0
     if hasattr(data, 'maxshape'):
         return data.maxshape
-    if hasattr(data, 'shape'):
+    if hasattr(data, 'shape') and data.shape is not None:
         return data.shape
     if isinstance(data, dict):
         return None

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3066,6 +3066,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         self.assertEqual(dset.shuffle, True)
         self.assertEqual(dset.fletcher32, True)
 
+
 class HDF5IOEmptyDataset(TestCase):
     """ Test if file does not exist, write in mode (w, w-, x, a) is ok """
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3132,3 +3132,8 @@ class HDF5IOClassmethodTests(TestCase):
 
         with self.assertRaisesRegex(ValueError, 'Cannot setup empty dataset /foo without shape'):
             HDF5IO.__setup_empty_dset__(self.f, 'foo', {'dtype': np.float32})
+
+    def test_setup_empty_dset_create_exception(self):
+        HDF5IO.__setup_empty_dset__(self.f, 'foo', {'shape': (3, 3), 'dtype': 'float'})
+        with self.assertRaisesRegex(Exception, "Could not create dataset foo in /"):
+            HDF5IO.__setup_empty_dset__(self.f, 'foo', {'shape': (3, 3), 'dtype': 'float'})

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3084,10 +3084,10 @@ class HDF5IOEmptyDataset(TestCase):
         bucket = FooBucket('bucket1', [foo])
         foofile = FooFile(buckets=[bucket])
 
-        io = HDF5IO(self.path, manager=self.manager, mode='w')
-        io.write(foofile)
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            io.write(foofile)
 
-        self.assertIs(foo.my_data, dataio)
-        self.assertIsNotNone(foo.my_data.dataset)
-        self.assertIsInstance(foo.my_data.dataset, h5py.Dataset)
-        np.testing.assert_array_equal(foo.my_data.dataset, np.zeros(5, dtype=int))
+            self.assertIs(foo.my_data, dataio)
+            self.assertIsNotNone(foo.my_data.dataset)
+            self.assertIsInstance(foo.my_data.dataset, h5py.Dataset)
+            np.testing.assert_array_equal(foo.my_data.dataset, np.zeros(5, dtype=int))

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1577,7 +1577,7 @@ class H5DataIOValid(TestCase):
 
             self.assertTrue(self.foo2.my_data.valid)  # test valid
             self.assertEqual(len(self.foo2.my_data), 5)  # test len
-            self.assertEqual(self.foo2.my_data.size, (5,))  # test getattr with size
+            self.assertEqual(self.foo2.my_data.shape, (5,))  # test getattr with shape
             self.assertTrue(np.array_equal(np.array(self.foo2.my_data), [1, 2, 3, 4, 5]))  # test array conversion
 
             # test loop through iterable
@@ -1595,8 +1595,8 @@ class H5DataIOValid(TestCase):
         with self.assertRaisesWith(InvalidDataIOError, "Cannot get length of data. Data is not valid."):
             len(self.foo2.my_data)
 
-        with self.assertRaisesWith(InvalidDataIOError, "Cannot get attribute 'size' of data. Data is not valid."):
-            self.foo2.my_data.size
+        with self.assertRaisesWith(InvalidDataIOError, "Cannot get attribute 'shape' of data. Data is not valid."):
+            self.foo2.my_data.shape
 
         with self.assertRaisesWith(InvalidDataIOError, "Cannot convert data to array. Data is not valid."):
             np.array(self.foo2.my_data)

--- a/tests/unit/utils_test/test_core_DataIO.py
+++ b/tests/unit/utils_test/test_core_DataIO.py
@@ -55,3 +55,21 @@ class DataIOTests(TestCase):
         container = Data('wrapped_data', data)
         with self.assertRaisesWith(ValueError, "cannot overwrite 'data' on DataIO"):
             container.set_dataio(dataio)
+
+    def test_dataio_constructor(self):
+        """
+        Test that Data.set_dataio works as intended
+        """
+        with self.assertRaisesRegex(ValueError, "Setting the dtype when data is not None is not supported"):
+            DataIO(data=np.arange(5), dtype=int)
+        with self.assertRaisesRegex(ValueError, "Setting the shape when data is not None is not supported"):
+            DataIO(data=np.arange(5), shape=(3,))
+
+    def test_dataio_constructor(self):
+        """
+        Test that Data.set_dataio works as intended
+        """
+        dataio = DataIO(shape=(3,), dtype=int)
+        with self.assertRaisesRegex(ValueError, "Setting data when dtype and shape are not None is not supported"):
+            dataio.data = np.arange(5)
+

--- a/tests/unit/utils_test/test_core_DataIO.py
+++ b/tests/unit/utils_test/test_core_DataIO.py
@@ -56,20 +56,15 @@ class DataIOTests(TestCase):
         with self.assertRaisesWith(ValueError, "cannot overwrite 'data' on DataIO"):
             container.set_dataio(dataio)
 
-    def test_dataio_constructor(self):
+    def test_dataio_options(self):
         """
-        Test that Data.set_dataio works as intended
+        Test that either data or dtype+shape are specified exclusively
         """
         with self.assertRaisesRegex(ValueError, "Setting the dtype when data is not None is not supported"):
             DataIO(data=np.arange(5), dtype=int)
         with self.assertRaisesRegex(ValueError, "Setting the shape when data is not None is not supported"):
             DataIO(data=np.arange(5), shape=(3,))
 
-    def test_dataio_constructor(self):
-        """
-        Test that Data.set_dataio works as intended
-        """
         dataio = DataIO(shape=(3,), dtype=int)
         with self.assertRaisesRegex(ValueError, "Setting data when dtype and shape are not None is not supported"):
             dataio.data = np.arange(5)
-


### PR DESCRIPTION
## Motivation

Add the ability to create a dataset on disk and get access to the handle to the dataset _without_ having to close and repoen a file. 

## How to test the behavior?
```python
dataio = H5DataIO(shape=(5,), dtype=int)
foo = Foo('foo1', dataio, "I am foo1", 17, 3.14)
bucket = FooBucket('bucket1', [foo])
foofile = FooFile(buckets=[bucket])

io = HDF5IO(self.path, manager=self.manager, mode='w')
io.write(foofile)

foo.my_data.dataset[:] = [0, 1, 2, 3, 4]
io.close()
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
