### PR TITLE
Fix pynwb test failing due to coverage not finding sources

### DIFF
--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -32,9 +32,10 @@ jobs:
           git clone https://github.com/NeurodataWithoutBorders/pynwb.git --recurse-submodules
           cd pynwb
           python -m pip install -r requirements-dev.txt -r requirements.txt
-          python -m pip install .  # this will install a particular version of hdmf instead of the current one
+          # must install in editable mode for coverage to find sources
+          python -m pip install -e .  # this will install a pinned version of hdmf instead of the current one
           cd ..
-          python -m pip uninstall -y hdmf
+          python -m pip uninstall -y hdmf  # uninstall the pinned version of hdmf
           python -m pip install .  # reinstall current branch of hdmf
           python -m pip list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # HDMF Changelog
 
 ## HDMF 3.3.3 (Upcoming)
+
+### Minor improvements
 - Relax input validation of `HDF5IO` to allow for s3fs support. Existing arguments of `HDF5IO` are modified as follows: i) `mode` was given a default value of "r", ii) `path` was given a default value of `None`, and iii) `file` can now accept an `S3File` type argument. @bendichter ([#746](https://github.com/hdmf-dev/hdmf/pull/746))
+
+### Bug fixes
+- Fixed PyNWB dev CI. @rly ([#749](https://github.com/hdmf-dev/hdmf/pull/749))
 
 ## HDMF 3.3.2 (June 27, 2022)
 


### PR DESCRIPTION
## Motivation

The PyNWB CI test is failing due to a change in PyNWB dev on testing code coverage. PyNWB needs to be installed in editable mode for coverage to correctly find the sources.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
