### PR TITLE
Add _in_construct_mode to differentiate container init vs construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - Relax input validation of `HDF5IO` to allow for s3fs support. Existing arguments of `HDF5IO` are modified as follows: i) `mode` was given a default value of "r", ii) `path` was given a default value of `None`, and iii) `file` can now accept an `S3File` type argument. @bendichter ([#746](https://github.com/hdmf-dev/hdmf/pull/746))
 - Added ability to create and get back handle to empty HDF5 dataset. @ajtritt (#747)
 - Added `AbstractContainer._in_construct_mode` that is set and modified only by the ObjectMapper when constructing an
-  object from a builder read from a file. Subclasses of `AbstractContainer` can check `_in_construct_mode` to
-  determine whether to raise a warning or error when encountering invalid data (we want to be able to read and
-  fix data that is invalid but not create new data that is invalid). @rly (#751)
+  object from a builder read from a file. Subclasses of `AbstractContainer` can check `_in_construct_mode` 
+  during the initialization phase as part of ``__init__`` to distinguish between actions during construction
+  (i.e., read from disk) vs. creation by the user, e.g., to determine whether to raise a warning or error when
+  encountering invalid data to support reading and correcting data that is invalid while preventing creation
+  of new data that is invalid. @rly (#751)
 
 ### Bug fixes
 - Fixed PyNWB dev CI. @rly ([#749](https://github.com/hdmf-dev/hdmf/pull/749))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Allow manual triggering of some GitHub Actions. @rly ([#744](https://github.com/hdmf-dev/hdmf/pull/744))
 - Relax input validation of `HDF5IO` to allow for s3fs support. Existing arguments of `HDF5IO` are modified as follows: i) `mode` was given a default value of "r", ii) `path` was given a default value of `None`, and iii) `file` can now accept an `S3File` type argument. @bendichter ([#746](https://github.com/hdmf-dev/hdmf/pull/746))
 - Added ability to create and get back handle to empty HDF5 dataset. @ajtritt (#747)
+- Added `AbstractContainer._in_construct_mode` that is set and modified only by the ObjectMapper when constructing an
+  object from a builder read from a file. Subclasses of `AbstractContainer` can check `_in_construct_mode` to
+  determine whether to raise a warning or error when encountering invalid data (we want to be able to read and
+  fix data that is invalid but not create new data that is invalid). @rly (#751)
 
 ### Bug fixes
 - Fixed PyNWB dev CI. @rly ([#749](https://github.com/hdmf-dev/hdmf/pull/749))

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -505,13 +505,13 @@ with closing(sqlite3.connect(db_file)) as db:
         table = pd.read_sql_query("SELECT * from %s" % table_name, db)
         table.set_index('id', inplace=True)
         ref_table = getattr(er, table_name).to_dataframe()
-        assert(np.all(np.array(table.index) == np.array(ref_table.index) + 1))
+        assert np.all(np.array(table.index) == np.array(ref_table.index) + 1)
         for c in table.columns:
             # NOTE: SQLite uses 1-based row-indices so we need adjust for that
             if np.issubdtype(table[c].dtype, np.integer):
-                assert(np.all(np.array(table[c]) == np.array(ref_table[c]) + 1))
+                assert np.all(np.array(table[c]) == np.array(ref_table[c]) + 1)
             else:
-                assert(np.all(np.array(table[c]) == np.array(ref_table[c])))
+                assert np.all(np.array(table[c]) == np.array(ref_table[c]))
     cursor.close()
 
 ###############################################################################

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,10 @@ exclude =
   versioneer.py
   src/hdmf/_version.py
   src/hdmf/_due.py
+  docs/source/tutorials/
+  docs/_build/
 per-file-ignores =
   docs/gallery/*:E402,T001
-  docs/source/tutorials/*:E402,T001
   src/hdmf/__init__.py:F401
   src/hdmf/backends/__init__.py:F401
   src/hdmf/backends/hdf5/__init__.py:F401

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1256,6 +1256,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
         """A wrapper function for ensuring a container gets everything set appropriately"""
         obj = cls.__new__(cls, container_source=container_source, parent=parent, object_id=object_id,
                           in_construct_mode=True)
+        # obj has been created and is in construction mode, indicating that the object is being constructed by
+        # the automatic construct process during read, rather than by the user
         obj.__init__(**kwargs)
         obj._in_construct_mode = False  # reset to False to indicate that the construction of the object is complete
         return obj

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1254,8 +1254,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
 
     def __new_container__(self, cls, container_source, parent, object_id, **kwargs):
         """A wrapper function for ensuring a container gets everything set appropriately"""
-        obj = cls.__new__(cls, container_source=container_source, parent=parent, object_id=object_id)
+        obj = cls.__new__(cls, container_source=container_source, parent=parent, object_id=object_id,
+                          in_construct_mode=True)
         obj.__init__(**kwargs)
+        obj._in_construct_mode = False  # reset to False after object construction
         return obj
 
     @docval({'name': 'container', 'type': AbstractContainer,

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1257,7 +1257,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
         obj = cls.__new__(cls, container_source=container_source, parent=parent, object_id=object_id,
                           in_construct_mode=True)
         obj.__init__(**kwargs)
-        obj._in_construct_mode = False  # reset to False after object construction
+        obj._in_construct_mode = False  # reset to False to indicate that the construction of the object is complete
         return obj
 
     @docval({'name': 'container', 'type': AbstractContainer,

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -179,7 +179,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         """
         Static method of the object class called by Python to create the object first and then
          __init__() is called to initialize the object's attributes.
-        
+
         NOTE: this method is called directly from ObjectMapper.__new_container__ during the process of
         constructing the object from builders that are read from a file.
         """
@@ -191,7 +191,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         inst.__children = list()
         inst.__modified = True
         inst.__object_id = kwargs.pop('object_id', str(uuid4()))
-        # this variable is being passed in from ObjectMapper.__new_container__ and is 
+        # this variable is being passed in from ObjectMapper.__new_container__ and is
         # reset to False in that method after the object has been initialized by __init__
         inst._in_construct_mode = kwargs.pop('in_construct_mode', False)
         inst.parent = kwargs.pop('parent', None)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -176,8 +176,13 @@ class AbstractContainer(metaclass=ExtenderMeta):
         cls.__fieldsconf = tuple(all_fields_conf)
 
     def __new__(cls, *args, **kwargs):
-        # NOTE: this method is called directly from ObjectMapper.__new_container__ during the process of
-        # constructing the object from builders that are read from a file
+        """
+        Static method of the object class called by Python to create the object first and then
+         __init__() is called to initialize the object's attributes.
+        
+        NOTE: this method is called directly from ObjectMapper.__new_container__ during the process of
+        constructing the object from builders that are read from a file.
+        """
         inst = super().__new__(cls)
         if cls._experimental:
             warn(_exp_warn_msg(cls))

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -191,8 +191,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
         inst.__children = list()
         inst.__modified = True
         inst.__object_id = kwargs.pop('object_id', str(uuid4()))
-        # this variable is being passed in from ObjectMapper.__new_container__ and is reset to False in that method
-        # after the object is initialized
+        # this variable is being passed in from ObjectMapper.__new_container__ and is 
+        # reset to False in that method after the object has been initialized by __init__
         inst._in_construct_mode = kwargs.pop('in_construct_mode', False)
         inst.parent = kwargs.pop('parent', None)
         return inst

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -176,6 +176,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
         cls.__fieldsconf = tuple(all_fields_conf)
 
     def __new__(cls, *args, **kwargs):
+        # NOTE: this method is called directly from ObjectMapper.__new_container__ during the process of
+        # constructing the object from builders that are read from a file
         inst = super().__new__(cls)
         if cls._experimental:
             warn(_exp_warn_msg(cls))
@@ -184,6 +186,9 @@ class AbstractContainer(metaclass=ExtenderMeta):
         inst.__children = list()
         inst.__modified = True
         inst.__object_id = kwargs.pop('object_id', str(uuid4()))
+        # this variable is being passed in from ObjectMapper.__new_container__ and is reset to False in that method
+        # after the object is initialized
+        inst._in_construct_mode = kwargs.pop('in_construct_mode', False)
         inst.parent = kwargs.pop('parent', None)
         return inst
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1053,7 +1053,7 @@ class HDF5IOMultiFileTest(TestCase):
         # Close all the files
         for i in self.io:
             i.close()
-            del(i)
+            del i
         self.io = None
         self.f = None
         # Make sure the files have been deleted
@@ -1282,7 +1282,7 @@ class HDF5IOInitFileExistsTest(TestCase):
     def tearDown(self):
         if self.io is not None:
             self.io.close()
-            del(self.io)
+            del self.io
         if os.path.exists(self.path):
             os.remove(self.path)
 
@@ -1316,7 +1316,7 @@ class HDF5IOReadNoDataTest(TestCase):
     def tearDown(self):
         if self.io is not None:
             self.io.close()
-            del(self.io)
+            del self.io
 
         if os.path.exists(self.path):
             os.remove(self.path)
@@ -1358,7 +1358,7 @@ class HDF5IOReadData(TestCase):
     def tearDown(self):
         if self.io is not None:
             self.io.close()
-            del(self.io)
+            del self.io
         if os.path.exists(self.path):
             os.remove(self.path)
 
@@ -1390,7 +1390,7 @@ class HDF5IOReadBuilderClosed(TestCase):
     def tearDown(self):
         if self.io is not None:
             self.io.close()
-            del(self.io)
+            del self.io
 
         if os.path.exists(self.path):
             os.remove(self.path)
@@ -1459,7 +1459,7 @@ class HDF5IOWriteFileExists(TestCase):
     def tearDown(self):
         if self.io is not None:
             self.io.close()
-            del(self.io)
+            del self.io
         if os.path.exists(self.path):
             os.remove(self.path)
 


### PR DESCRIPTION
## Motivation

Fix #750. This PR adds a new single-underscore-protected field in `AbstractContainer` called `_in_construct_mode` that is set to True if the object is being created by the ObjectMapper when constructing the object from builders read from a file and then reset to False after the object is done being created. Users creating the object will not interact with this field.

Subclasses of AbstractContainer can check `_in_construct_mode` to determine whether to raise a warning or error when encountering invalid data (we want to be able to read and fix data that is invalid but not create new data that is invalid).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
