### PR TITLE
Support "allow_none=True" in docval for args with non-None default

### DIFF
--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -644,6 +644,61 @@ class TestDocValidator(TestCase):
         with self.assertRaisesWith(SyntaxError, msg):
             method(self, True)
 
+    def test_allow_none_false(self):
+        """Test that docval with allow_none=True and non-None default value works"""
+        @docval({'name': 'arg1', 'type': bool, 'doc': 'this is a bool or None with a default', 'default': True,
+                 'allow_none': False})
+        def method(self, **kwargs):
+            return popargs('arg1', kwargs)
+
+        # if provided, None is not allowed
+        msg = ("TestDocValidator.test_allow_none_false.<locals>.method: incorrect type for 'arg1' "
+               "(got 'NoneType', expected 'bool')")
+        with self.assertRaisesWith(TypeError, msg):
+            res = method(self, arg1=None)
+
+        # if not provided, the default value is used
+        res = method(self)
+        self.assertTrue(res)
+
+    def test_allow_none(self):
+        """Test that docval with allow_none=True and non-None default value works"""
+        @docval({'name': 'arg1', 'type': bool, 'doc': 'this is a bool or None with a default', 'default': True,
+                 'allow_none': True})
+        def method(self, **kwargs):
+            return popargs('arg1', kwargs)
+
+        # if provided, None is allowed
+        res = method(self, arg1=None)
+        self.assertIsNone(res)
+
+        # if not provided, the default value is used
+        res = method(self)
+        self.assertTrue(res)
+
+    def test_allow_none_redundant(self):
+        """Test that docval with allow_none=True and default=None works"""
+        @docval({'name': 'arg1', 'type': bool, 'doc': 'this is a bool or None with a default', 'default': None,
+                 'allow_none': True})
+        def method(self, **kwargs):
+            return popargs('arg1', kwargs)
+
+        # if provided, None is allowed
+        res = method(self, arg1=None)
+        self.assertIsNone(res)
+
+        # if not provided, the default value is used
+        res = method(self)
+        self.assertIsNone(res)
+
+    def test_allow_none_no_default(self):
+        """Test that docval with allow_none=True and no default raises an error"""
+        msg = ("docval for arg1: allow_none=True can only be set if a default value is provided.")
+        with self.assertRaisesWith(Exception, msg):
+            @docval({'name': 'arg1', 'type': bool, 'doc': 'this is a bool or None with a default', 'allow_none': True})
+            def method(self, **kwargs):
+                return popargs('arg1', kwargs)
+
     def test_enum_str(self):
         """Test that the basic usage of an enum check on strings works"""
         @docval({'name': 'arg1', 'type': str, 'doc': 'an arg', 'enum': ['a', 'b']})  # also use enum: list


### PR DESCRIPTION
## Motivation

Addressing issue raised in https://github.com/NeurodataWithoutBorders/pynwb/pull/1540#issuecomment-1224053092

## How to test the behavior?
```python
@docval({'name': 'arg1', 'type': bool, 'doc': 'this is a bool or None with a default', 'default': True,
                 'allow_none': True})
    def method(self, **kwargs):
        return popargs('arg1', kwargs)

    # if provided, None is allowed
    res = method(self, arg1=None)
    self.assertIsNone(res)

    # if not provided, the default value is used
    res = method(self)
    self.assertTrue(res)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
