### PR TITLE
Update deploy CI to use latest githubrelease

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -48,12 +48,7 @@ jobs:
 
       - name: Publish wheel and source distributions as a GitHub release
         run: |
-          # use click<8 until https://github.com/j0057/github-release/issues/62 is resolved
-          python -m pip install "click<8" githubrelease
+          python -m pip install "githubrelease>=1.5.9"
           githubrelease --github-token ${{ secrets.BOT_GITHUB_TOKEN }} release hdmf-dev/hdmf \
             create ${{ github.ref_name }} --name ${{ github.ref_name }} \
-            --publish
-          # upload assets in a separate command until https://github.com/j0057/github-release/issues/67 is resolved
-          githubrelease --github-token ${{ secrets.BOT_GITHUB_TOKEN }} asset hdmf-dev/hdmf \
-            upload ${{ github.ref_name }} \
             --publish dist/*

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -138,7 +138,7 @@ jobs:
         with:
           auto-update-conda: true
           auto-activate-base: true
-          activate-environment: ""
+          activate-environment: true
           python-version: ${{ matrix.python-ver }}
 
       - name: Install build dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -120,8 +120,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: linux-python3.10-upgraded  , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: conda-linux-python3.10-upgraded  , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
     steps:
       - name: Cancel any previous incomplete runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -139,13 +139,12 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
+          python-version: ${{ matrix.python-ver }}
 
       - name: Install build dependencies
         run: |
-          conda update -n base -c defaults conda
           conda config --set always_yes yes --set changeps1 no
-          conda config --add channels conda-forge
-          conda install python=${{ matrix.python-ver }}
+          conda info
           conda install tox
           conda list
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          conda install tox
+          conda install -c conda-forge tox
           conda list
 
       - name: Run tox tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HDMF Changelog
 
+## HDMF 3.4.2 (August 26, 2022)
+- Support "allow_none=True" in docval for args with non-None default. @rly ([#757](https://github.com/hdmf-dev/hdmf/pull/757))
+- Fixed deploy release CI. @rly ([#759](https://github.com/hdmf-dev/hdmf/pull/759))
+
 ## HDMF 3.4.1 (August 8, 2022)
 
 ### Bug fixes


### PR DESCRIPTION
## Motivation

Hopefully this works after the release today of https://github.com/j0057/github-release

## How to test the behavior?
Deploy a release

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
