### PR TITLE
Fix/pdsetindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 - Fixed CI and flake8 issues. @rly ([#760](https://github.com/hdmf-dev/hdmf/pull/760))
+- Updated uses of pandas.DataFrame.set_index to avoid FutureWarnings for pandas >=1.5.x @oruebel ([#762](https://github.com/hdmf-dev/hdmf/pull/762))
 
 ## HDMF 3.4.2 (August 26, 2022)
 

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -503,7 +503,7 @@ with closing(sqlite3.connect(db_file)) as db:
     for table_name in tables:
         table_name = table_name[0]
         table = pd.read_sql_query("SELECT * from %s" % table_name, db)
-        table.set_index('id', inplace=True)
+        table = table.set_index('id')
         ref_table = getattr(er, table_name).to_dataframe()
         assert np.all(np.array(table.index) == np.array(ref_table.index) + 1)
         for c in table.columns:

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,7 +2,7 @@
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
 jsonschema==2.6.0
 numpy==1.16
-pandas==1.0.5
+pandas==1.0.5. # when this is increased >= 1.5.0, see TODO items referenced in #762
 ruamel.yaml==0.16
 scipy==1.1
 setuptools

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,7 +2,7 @@
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
 jsonschema==2.6.0
 numpy==1.16
-pandas==1.0.5. # when this is increased >= 1.5.0, see TODO items referenced in #762
+pandas==1.0.5  # when this is changed to >=1.5.0, see TODO items referenced in #762
 ruamel.yaml==0.16
 scipy==1.1
 setuptools

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
+from packaging import version
 
 from . import register_class
 from .table import DynamicTable
@@ -247,7 +248,11 @@ class AlignedDynamicTable(DynamicTable):
             dfs += [category.to_dataframe().reset_index() for category in self.category_tables.values()]
         names = [self.name, ] + list(self.category_tables.keys())
         res = pd.concat(dfs, axis=1, keys=names)
-        res.set_index((self.name, 'id'), drop=True, inplace=True)
+        # TODO: Once Pandas minimum version has increased to 1.5 drop the if/else and just use the 1.5 approach
+        if version.parse(pd.__version__) >= version.parse("1.5.0"):
+            res = res.set_index((self.name, 'id'), drop=True, copy=False)
+        else:
+            res.set_index((self.name, 'id'), drop=True, inplace=True)
         return res
 
     def __getitem__(self, item):
@@ -311,7 +316,11 @@ class AlignedDynamicTable(DynamicTable):
                    [category[item].reset_index() for category in self.category_tables.values()])
             names = [self.name, ] + list(self.category_tables.keys())
             res = pd.concat(dfs, axis=1, keys=names)
-            res.set_index((self.name, 'id'), drop=True, inplace=True)
+            # TODO: Once Pandas minimum version has increased to 1.5 drop the if/else and just use the 1.5 approach
+            if version.parse(pd.__version__) >= version.parse("1.5.0"):
+                res = res.set_index((self.name, 'id'), drop=True, copy=False)
+            else:
+                res.set_index((self.name, 'id'), drop=True, inplace=True)
             return res
         elif isinstance(item, str) or item is None:
             if item in self.colnames:

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -250,7 +250,7 @@ class AlignedDynamicTable(DynamicTable):
         res = pd.concat(dfs, axis=1, keys=names)
         # TODO: Once Pandas minimum version has increased to 1.5 drop the if/else and just use the 1.5 approach
         if version.parse(pd.__version__) >= version.parse("1.5.0"):
-            res = res.set_index((self.name, 'id'), drop=True, copy=False)
+            res = res.set_index((self.name, 'id'), drop=True, copy=False)   # pragma: no cover
         else:
             res.set_index((self.name, 'id'), drop=True, inplace=True)
         return res
@@ -318,7 +318,7 @@ class AlignedDynamicTable(DynamicTable):
             res = pd.concat(dfs, axis=1, keys=names)
             # TODO: Once Pandas minimum version has increased to 1.5 drop the if/else and just use the 1.5 approach
             if version.parse(pd.__version__) >= version.parse("1.5.0"):
-                res = res.set_index((self.name, 'id'), drop=True, copy=False)
+                res = res.set_index((self.name, 'id'), drop=True, copy=False)  # pragma: no cover
             else:
                 res.set_index((self.name, 'id'), drop=True, inplace=True)
             return res


### PR DESCRIPTION
## Motivation

Fix #761 [pandas.DataFrame.set_index](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.set_index.html) functions signature is changing in 1.5 to deprecate the ``inplace`` argument and add the ``copy`` argument instead. 

For the galleries we can just ignore those arguments, which results in making copies of the tables, but allows us to avoid having to check for pandas versions. 

In ``AlignedDynamicTable`` we want to avoid making data copies if possible, so we need to check for the pandas version and use the appropriate variant of ``set_index`` based on the version 


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
