### PR TITLE
Use pytest command instead of test.py

### DIFF
--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -26,7 +26,7 @@ jobs:
           - { os: ubuntu-latest , opt_req: false }
           - { os: windows-latest, opt_req: false }
           - { os: macos-latest  , opt_req: false }
-    env:
+    env:  # used by codecov-action
       OS: ${{ matrix.os }}
       PYTHON: '3.10'
     steps:

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -13,7 +13,7 @@ jobs:
   run-coverage:
     name: ${{ matrix.os }}, opt reqs ${{ matrix.opt_req }}
     runs-on: ${{ matrix.os }}
-    # TODO
+    # TODO handle forks
     # run pipeline on either a push event or a PR event on a fork
     # if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     defaults:

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run tests and generate coverage report
         run: |
-          python -m coverage run test.py -u
+          pytest --cov
           python -m coverage xml  # codecov uploader requires xml format
           python -m coverage report -m
 


### PR DESCRIPTION
The code coverage workflow still uses `python test.py` but that command will be deprecated soon (see #760)

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
