### PR TITLE
Fix get_hdf5io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.5.0 (Upcoming)
+## HDMF 3.4.3 (September 14, 2022)
 
 ### Minor improvements
 - Began to deprecate the use of the testing script `test.py` in favor of `pytest` and `test_gallery.py`.
@@ -10,6 +10,7 @@
 ### Bug fixes
 - Fixed CI and flake8 issues. @rly ([#760](https://github.com/hdmf-dev/hdmf/pull/760))
 - Updated uses of pandas.DataFrame.set_index to avoid FutureWarnings for pandas >=1.5.x @oruebel ([#762](https://github.com/hdmf-dev/hdmf/pull/762))
+- Fixed broken `hdmf.common.get_hdf5io` function. @rly ([#765](https://github.com/hdmf-dev/hdmf/pull/765))
 
 ## HDMF 3.4.2 (August 26, 2022)
 

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -181,12 +181,12 @@ def validate(**kwargs):
 @docval(*get_docval(HDF5IO.__init__), is_method=False)
 def get_hdf5io(**kwargs):
     """
-    A convenience method for getting an HDF5IO object
+    A convenience method for getting an HDF5IO object using an HDMF-common build manager if none is provided.
     """
     manager = getargs('manager', kwargs)
     if manager is None:
         kwargs['manager'] = get_manager()
-    return HDF5IO.__init__(**kwargs)
+    return HDF5IO(**kwargs)
 
 
 # load the hdmf-common namespace

--- a/tests/unit/common/test_common_io.py
+++ b/tests/unit/common/test_common_io.py
@@ -87,4 +87,3 @@ class TestGetHdf5IO(TestCase):
         manager = get_manager()
         with get_hdf5io(self.path, "w", manager=manager) as io:
             self.assertIs(io.manager, manager)
-

--- a/tests/unit/common/test_common_io.py
+++ b/tests/unit/common/test_common_io.py
@@ -1,7 +1,7 @@
 from h5py import File
 
 from hdmf.backends.hdf5 import HDF5IO
-from hdmf.common import Container, get_manager
+from hdmf.common import Container, get_manager, get_hdf5io
 from hdmf.spec import NamespaceCatalog
 from hdmf.testing import TestCase, remove_test_file
 
@@ -67,3 +67,24 @@ class TestCacheSpec(TestCase):
                             self.assertIsNotNone(cached_spec)
                         with self.subTest('Cached spec matches original spec'):
                             self.assertDictEqual(original_spec, cached_spec)
+
+
+class TestGetHdf5IO(TestCase):
+
+    def setUp(self):
+        self.path = get_temp_filepath()
+
+    def tearDown(self):
+        remove_test_file(self.path)
+
+    def test_gethdf5io(self):
+        """Test the get_hdf5io convenience method with manager=None."""
+        with get_hdf5io(self.path, "w") as io:
+            self.assertIsNotNone(io.manager)
+
+    def test_gethdf5io_manager(self):
+        """Test the get_hdf5io convenience method with manager set."""
+        manager = get_manager()
+        with get_hdf5io(self.path, "w", manager=manager) as io:
+            self.assertIs(io.manager, manager)
+


### PR DESCRIPTION
## Motivation

Fixed broken `hdmf.common.get_hdf5io` function. Fix #764.

## How to test the behavior?
```
with get_hdf5io(self.path, "w") as io:
    pass
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
