### PR TITLE
allow passing through additional arguments for col_cls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # HDMF Changelog
 
+## HDMF 3.4.5 (September 22, 2022)
+
+### Minor improvements
+- Allow passing arguments through to column class constructur (argument `col_cls`) when calling `DynamicTable.add_column`. @ajtritt ([#769](https://github.com/hdmf-dev/hdmf/pull/769))
+
 ## HDMF 3.4.4 (September 20, 2022)
 
 ### Bug fixes
-- Allow passing arguments through to column class constructur (argument `col_cls`) when calling `DynamicTable.add_column`. @ajtritt ([#769](https://github.com/hdmf-dev/hdmf/pull/769))
 - Fixed missing dependency "packaging" introduced in 3.4.3. The code has been updated to avoid the dependency. @rly @oruebel ([#770](https://github.com/hdmf-dev/hdmf/pull/770))
 
 ## HDMF 3.4.3 (September 14, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HDMF 3.4.4 (September 20, 2022)
 
 ### Bug fixes
+- Allow passing arguments through to column class constructur (argument `col_cls`) when calling `DynamicTable.add_column`. @ajtritt ([#769](https://github.com/hdmf-dev/hdmf/pull/769))
 - Fixed missing dependency "packaging" introduced in 3.4.3. The code has been updated to avoid the dependency. @rly @oruebel ([#770](https://github.com/hdmf-dev/hdmf/pull/770))
 
 ## HDMF 3.4.3 (September 14, 2022)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -654,7 +654,8 @@ class DynamicTable(Container):
             {'name': 'col_cls', 'type': type, 'default': VectorData,
              'doc': ('class to use to represent the column data. If table=True, this field is ignored and a '
                      'DynamicTableRegion object is used. If enum=True, this field is ignored and a EnumData '
-                     'object is used.')}, )
+                     'object is used.')},
+             allow_extra=True)
     def add_column(self, **kwargs):  # noqa: C901
         """
         Add a column to this table.

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -661,6 +661,8 @@ class DynamicTable(Container):
         Add a column to this table.
 
         If data is provided, it must contain the same number of rows as the current state of the table.
+        
+        Extra keyword arguments will be passed to the constructor of the column class ("col_cls"). 
 
         :raises ValueError: if the column has already been added to the table
         """

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -662,7 +662,7 @@ class DynamicTable(Container):
 
         If data is provided, it must contain the same number of rows as the current state of the table.
         
-        Extra keyword arguments will be passed to the constructor of the column class ("col_cls"). 
+        Extra keyword arguments will be passed to the constructor of the column class ("col_cls").
 
         :raises ValueError: if the column has already been added to the table
         """

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -655,7 +655,7 @@ class DynamicTable(Container):
              'doc': ('class to use to represent the column data. If table=True, this field is ignored and a '
                      'DynamicTableRegion object is used. If enum=True, this field is ignored and a EnumData '
                      'object is used.')},
-             allow_extra=True)
+            allow_extra=True)
     def add_column(self, **kwargs):  # noqa: C901
         """
         Add a column to this table.

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -661,7 +661,7 @@ class DynamicTable(Container):
         Add a column to this table.
 
         If data is provided, it must contain the same number of rows as the current state of the table.
-        
+
         Extra keyword arguments will be passed to the constructor of the column class ("col_cls").
 
         :raises ValueError: if the column has already been added to the table


### PR DESCRIPTION
## Motivation

To make the `col_cls` argument to `DynamicTable.add_column` more usable. Now, additional arguments will get passed through to the `col_cls` constructor call.

## How to test the behavior?
```python
class FooColumn(VectorData):
    def __init__(self, ..., foo_arg=None)
        ...
    ....
table = DynamicTable(...)
table.add_column(name='foo_col', ..., foo_arg='bar')
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
