### PR TITLE
Use shape for DataIO length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HDMF Changelog
 
+## HDMF 3.4.6 (September 22, 2022)
+
+- When data is not specified in DataIO, 1) require dtype and shape both be specified and 2) determine length from shape. @ajtritt ([#771](https://github.com/hdmf-dev/hdmf/pull/771))
+
 ## HDMF 3.4.5 (September 22, 2022)
 
 ### Minor improvements

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -489,6 +489,10 @@ class H5DataIO(DataIO):
         # Get the list of I/O options that user has passed in
         ioarg_names = [name for name in kwargs.keys() if name not in ['data', 'link_data', 'allow_plugin_filters',
                                                                       'dtype', 'shape']]
+
+        if kwargs['data'] is None:
+            if kwargs['shape'] is None or kwargs['dtype'] is None:
+                raise ValueError("Must specify 'dtype' and 'shape' if not specifying 'data'")
         # Remove the ioargs from kwargs
         ioarg_values = [popargs(argname, kwargs) for argname in ioarg_names]
         # Consume link_data parameter

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -637,9 +637,3 @@ class H5DataIO(DataIO):
         if isinstance(self.data, Dataset) and not self.data.id.valid:
             return False
         return super().valid
-
-    def __len__(self):
-        maxshape = self.__iosettings.get('maxshape', None)
-        if maxshape is not None and maxshape[0] is not None:
-            return maxshape[0]
-        return super().__len__()

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -633,3 +633,9 @@ class H5DataIO(DataIO):
         if isinstance(self.data, Dataset) and not self.data.id.valid:
             return False
         return super().valid
+
+    def __len__(self):
+        maxshape = self.__iosettings.get('maxshape', None)
+        if maxshape is not None and maxshape[0] is not None:
+            return maxshape[0]
+        return super().__len__()

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -490,9 +490,6 @@ class H5DataIO(DataIO):
         ioarg_names = [name for name in kwargs.keys() if name not in ['data', 'link_data', 'allow_plugin_filters',
                                                                       'dtype', 'shape']]
 
-        if kwargs['data'] is None:
-            if kwargs['shape'] is None or kwargs['dtype'] is None:
-                raise ValueError("Must specify 'dtype' and 'shape' if not specifying 'data'")
         # Remove the ioargs from kwargs
         ioarg_values = [popargs(argname, kwargs) for argname in ioarg_names]
         # Consume link_data parameter

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -82,6 +82,8 @@ class DynamicTableGenerator(CustomClassGenerator):
             # the spec does not know which table this DTR points to
             # the user must specify the table attribute on the DTR after it is generated
             column_conf['table'] = True
+        else:
+            column_conf['class'] = dtype
 
         index_counter = 0
         index_name = attr_name

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -995,6 +995,8 @@ class DataIO:
 
     def __len__(self):
         """Number of values in self.data"""
+        if self.__shape is not None:
+            return self.__shape[0]
         if not self.valid:
             raise InvalidDataIOError("Cannot get length of data. Data is not valid.")
         return len(self.data)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -922,7 +922,7 @@ class DataIO:
     def __init__(self, **kwargs):
         data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)
         if data is None:
-            if dtype is None or shape is None:
+            if (dtype is None) ^ (shape is None):
                 raise ValueError("Must specify 'dtype' and 'shape' if not specifying 'data'")
         else:
             if dtype is not None:

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -921,11 +921,16 @@ class DataIO:
              'default': None})
     def __init__(self, **kwargs):
         data, dtype, shape = popargs('data', 'dtype', 'shape', kwargs)
-        if data is not None:
+        if data is None:
+            if dtype is None or shape is None:
+                raise ValueError("Must specify 'dtype' and 'shape' if not specifying 'data'")
+        else:
             if dtype is not None:
-                raise ValueError("Setting the dtype when data is not None is not supported")
+                warn("Argument 'dtype' is ignored when 'data' is specified")
+                dtype = None
             if shape is not None:
-                raise ValueError("Setting the shape when data is not None is not supported")
+                warn("Argument 'shape' is ignored when 'data' is specified")
+                shape = None
         self.__data = data
         self.__dtype = dtype
         self.__shape = shape

--- a/tests/unit/common/test_generate_table.py
+++ b/tests/unit/common/test_generate_table.py
@@ -5,7 +5,7 @@ import tempfile
 
 from hdmf.backends.hdf5 import HDF5IO
 from hdmf.build import BuildManager, TypeMap
-from hdmf.common import get_type_map, DynamicTable
+from hdmf.common import get_type_map, DynamicTable, VectorData
 from hdmf.spec import GroupSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog
 from hdmf.testing import TestCase
 from hdmf.validate import ValidatorMap
@@ -142,11 +142,12 @@ class TestDynamicDynamicTable(TestCase):
     def test_dynamic_table(self):
         assert issubclass(self.TestTable, DynamicTable)
 
-        assert self.TestTable.__columns__[0] == dict(
-            name='my_col',
-            description='a test column',
-            required=True
-        )
+        assert self.TestTable.__columns__[0] == {
+                'name': 'my_col',
+                'description': 'a test column',
+                'class': VectorData,
+                'required': True
+            }
 
     def test_forbids_incorrect_col(self):
         test_table = self.TestTable(name='test_table', description='my test table')

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3137,3 +3137,20 @@ class HDF5IOClassmethodTests(TestCase):
         HDF5IO.__setup_empty_dset__(self.f, 'foo', {'shape': (3, 3), 'dtype': 'float'})
         with self.assertRaisesRegex(Exception, "Could not create dataset foo in /"):
             HDF5IO.__setup_empty_dset__(self.f, 'foo', {'shape': (3, 3), 'dtype': 'float'})
+
+
+class H5DataIOTests(TestCase):
+
+    def _bad_arg_cm(self):
+        return self.assertRaisesRegex(ValueError, "Must specify 'dtype' and 'shape' "
+                                                  "if not specifying 'data'")
+
+    def test_dataio_bad_args(self):
+        with self._bad_arg_cm():
+            H5DataIO(shape=(10, 10))
+        with self._bad_arg_cm():
+            H5DataIO(dtype=int)
+
+    def test_dataio_len(self):
+        dataio = H5DataIO(shape=(10, 10), dtype=int)
+        self.assertEqual(len(dataio), 10)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3150,6 +3150,10 @@ class H5DataIOTests(TestCase):
             H5DataIO(shape=(10, 10))
         with self._bad_arg_cm():
             H5DataIO(dtype=int)
+        with self.assertWarnsRegex(UserWarning, "Argument 'dtype' is ignored when 'data' is specified"):
+            H5DataIO(data=np.zeros((10, 10)), dtype=int)
+        with self.assertWarnsRegex(UserWarning, "Argument 'shape' is ignored when 'data' is specified"):
+            H5DataIO(data=np.zeros((10, 10)), shape=(10, 10))
 
     def test_dataio_len(self):
         dataio = H5DataIO(shape=(10, 10), dtype=int)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3154,3 +3154,8 @@ class H5DataIOTests(TestCase):
     def test_dataio_len(self):
         dataio = H5DataIO(shape=(10, 10), dtype=int)
         self.assertEqual(len(dataio), 10)
+
+    def test_dataio_shape_then_data(self):
+        dataio = H5DataIO(shape=(10, 10), dtype=int)
+        with self.assertRaisesRegex(ValueError, "Setting data when dtype and shape are not None is not supported"):
+            dataio.data = list()

--- a/tests/unit/utils_test/test_core_DataIO.py
+++ b/tests/unit/utils_test/test_core_DataIO.py
@@ -60,9 +60,9 @@ class DataIOTests(TestCase):
         """
         Test that either data or dtype+shape are specified exclusively
         """
-        with self.assertRaisesRegex(ValueError, "Setting the dtype when data is not None is not supported"):
+        with self.assertWarnsRegex(UserWarning, "Argument 'dtype' is ignored when 'data' is specified"):
             DataIO(data=np.arange(5), dtype=int)
-        with self.assertRaisesRegex(ValueError, "Setting the shape when data is not None is not supported"):
+        with self.assertWarnsRegex(UserWarning, "Argument 'shape' is ignored when 'data' is specified"):
             DataIO(data=np.arange(5), shape=(3,))
 
         dataio = DataIO(shape=(3,), dtype=int)


### PR DESCRIPTION
## Motivation

When shape is specified in DataIO, length should be obtainable. However, because `data` was not being set, DataIO was declaring itself not valid and raising an error.

This also adds the requirement in H5DataIO that `dtype` and `shape` are specified together. [h5py's `create_dataset`](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) sets `dtype` to 32-bit float by default. I opted to not rely on this default behavior out of concern of creating unintended behavior in hdmf. 

## How to test the behavior?
```python
dataio = H5DataIO(dtype=int, shape=(10, 10))
assert len(dataio) == 10
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
