### PR TITLE
Fix autogeneration of class that extends class with fixed init values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # HDMF Changelog
 
-## HDMF 3.4.6 (September 22, 2022)
+## HDMF 3.4.6 (October 4, 2022)
 
+### Minor improvements
 - When data is not specified in DataIO, 1) require dtype and shape both be specified and 2) determine length from shape. @ajtritt ([#771](https://github.com/hdmf-dev/hdmf/pull/771))
+
+### Bug fixes
+- Fix an issue when autogenerating a class that extends a class where the constructor docval does not include all of
+the fields (i.e., when the constructor sets some fields to fixed values). @rly
+([#773](https://github.com/hdmf-dev/hdmf/pull/773))
 
 ## HDMF 3.4.5 (September 22, 2022)
 

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -292,7 +292,8 @@ class CustomClassGenerator:
         parent_docval_args = set(arg['name'] for arg in get_docval(base.__init__))
         new_args = list()
         for attr_name, field_spec in not_inherited_fields.items():
-            # auto-initialize arguments not found in superclass
+            # store arguments for fields that are not in the superclass and not in the superclass __init__ docval
+            # so that they are set after calling base.__init__
             if attr_name not in parent_docval_args:
                 new_args.append(attr_name)
 
@@ -300,13 +301,24 @@ class CustomClassGenerator:
         def __init__(self, **kwargs):
             if name is not None:  # force container name to be the fixed name in the spec
                 kwargs.update(name=name)
+
+            # remove arguments from kwargs that correspond to fields that are new (not inherited)
+            # set these arguments after calling base.__init__
             new_kwargs = dict()
             for f in new_args:
                 new_kwargs[f] = popargs(f, kwargs) if f in kwargs else None
-            base.__init__(self, **kwargs)  # special case: need to pass self to __init__
+
+            # NOTE: the docval of some constructors do not include all of the fields. the constructor may set
+            # some fields to fixed values. so only keep the kwargs that are used in the constructor docval
+            kwargs_to_pass = {k:v for k, v in kwargs.items() if k in parent_docval_args}
+
+            base.__init__(self, **kwargs_to_pass)  # special case: need to pass self to __init__
             # TODO should super() be used above instead of base?
+
+            # set the fields that are new to this class (not inherited)
             for f, arg_val in new_kwargs.items():
                 setattr(self, f, arg_val)
+
         classdict['__init__'] = __init__
 
 

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -310,7 +310,7 @@ class CustomClassGenerator:
 
             # NOTE: the docval of some constructors do not include all of the fields. the constructor may set
             # some fields to fixed values. so only keep the kwargs that are used in the constructor docval
-            kwargs_to_pass = {k:v for k, v in kwargs.items() if k in parent_docval_args}
+            kwargs_to_pass = {k: v for k, v in kwargs.items() if k in parent_docval_args}
 
             base.__init__(self, **kwargs_to_pass)  # special case: need to pass self to __init__
             # TODO should super() be used above instead of base?

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -8,7 +8,7 @@ from hdmf.build.classgenerator import ClassGenerator, MCIClassGenerator
 from hdmf.container import Container, Data, MultiContainerInterface, AbstractContainer
 from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, LinkSpec
 from hdmf.testing import TestCase
-from hdmf.utils import get_docval, docval, getargs
+from hdmf.utils import get_docval, docval
 
 from .test_io_map import Bar
 from tests.unit.utils import CORE_NAMESPACE, create_test_type_map, create_load_namespace_yaml
@@ -296,7 +296,6 @@ class TestDynamicContainer(TestCase):
         self.assertTrue(issubclass(cls, FixedAttrBar))
         inst = cls(name="My Baz", data=[1, 2, 3, 4], attr2=1000, attr3=98.6, attr4=1.0)
         self.assertEqual(inst.attr1, "fixed_attr1")
-
 
     def test_multi_container_spec(self):
         multi_spec = GroupSpec(

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -8,7 +8,7 @@ from hdmf.build.classgenerator import ClassGenerator, MCIClassGenerator
 from hdmf.container import Container, Data, MultiContainerInterface, AbstractContainer
 from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, LinkSpec
 from hdmf.testing import TestCase
-from hdmf.utils import get_docval
+from hdmf.utils import get_docval, docval, getargs
 
 from .test_io_map import Bar
 from tests.unit.utils import CORE_NAMESPACE, create_test_type_map, create_load_namespace_yaml
@@ -262,6 +262,41 @@ class TestDynamicContainer(TestCase):
         Baz = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
         obj = Baz(data=[1, 2, 3, 4], attr1='string attribute', attr2=1000)
         self.assertEqual(obj.name, 'Baz')
+
+    def test_dynamic_container_super_init_fixed_value(self):
+        """Test that dynamic class generation when the superclass init does not include all fields works"""
+
+        class FixedAttrBar(Bar):
+            @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
+                    {'name': 'data', 'type': ('data', 'array_data'), 'doc': 'some data'},
+                    {'name': 'attr2', 'type': int, 'doc': 'another attribute'},
+                    {'name': 'attr3', 'type': float, 'doc': 'a third attribute', 'default': 3.14},
+                    {'name': 'foo', 'type': 'Foo', 'doc': 'a group', 'default': None})
+            def __init__(self, **kwargs):
+                kwargs["attr1"] = "fixed_attr1"
+                super().__init__(**kwargs)
+
+        # overwrite the "Bar" to Bar class mapping from setUp()
+        self.type_map.register_container_type(CORE_NAMESPACE, "Bar", FixedAttrBar)
+
+        baz_spec = GroupSpec('A test extension with no Container class',
+                             data_type_def='Baz', data_type_inc=self.bar_spec,
+                             attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
+                                         AttributeSpec('attr4', 'another float attribute', 'float')])
+        self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
+        cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
+        expected_args = {'name', 'data', 'attr2', 'attr3', 'attr4'}
+        received_args = set()
+        for x in get_docval(cls.__init__):
+            if x['name'] != 'foo':
+                received_args.add(x['name'])
+                with self.subTest(name=x['name']):
+                    self.assertNotIn('default', x)
+        self.assertSetEqual(expected_args, received_args)
+        self.assertTrue(issubclass(cls, FixedAttrBar))
+        inst = cls(name="My Baz", data=[1, 2, 3, 4], attr2=1000, attr3=98.6, attr4=1.0)
+        self.assertEqual(inst.attr1, "fixed_attr1")
+
 
     def test_multi_container_spec(self):
         multi_spec = GroupSpec(


### PR DESCRIPTION
## Motivation

Fix #772 

## How to test the behavior?
```
Run tests
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
