### PR TITLE
Added error catcher for potentially unsafe memory operation (GenericDataChunkIterator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## Upcoming
+
+### Bug fixes
+- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by upcasting all shape attributes and operations to use the `uint64` data type. @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780))
+
+
 ## HDMF 3.4.7 (October 26, 2022)
 
 ### Bug fixes

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -153,7 +153,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             doc=(
                 "If chunk_shape is not specified, it will be inferred as the smallest chunk "
                 "below the chunk_mb threshold.",
-                "Defaults to 1MB."
+                "Defaults to 1MB.",
             ),
             default=None,
         ),
@@ -205,30 +205,16 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             chunk_shape is not None
         ), "Only one of 'chunk_mb' or 'chunk_shape' can be specified!"
 
-        self._maxshape = self._get_maxshape()
         self._dtype = self._get_dtype()
-        if chunk_shape is None:
-            self.chunk_shape = self._get_default_chunk_shape(chunk_mb=chunk_mb)
-        else:
-            self.chunk_shape = chunk_shape
-        if buffer_shape is None:
-            self.buffer_shape = self._get_default_buffer_shape(buffer_gb=buffer_gb)
-        else:
-            self.buffer_shape = buffer_shape
-            itemsize = np.dtype(self._dtype).itemsize
+        self._maxshape = tuple(np.array(self._get_maxshape(), dtype="uint64"))  # Upcast for safer numpy operations
 
-            filterwarnings(action="error")
-            try:
-                buffer_gb = np.prod(self.buffer_shape, dtype=np.int64) * itemsize / 1e9
-            except RuntimeWarning:  # buffer overflow, which can lead to an unintended memory leak
-                raise RuntimeError(
-                    "The GenericDataChunkIterator encountered a buffer overflow with values...\n\n"
-                    f"buffer_shape={buffer_shape}\nitemsize={itemsize}\n\n"
-                    "Please report this issue to https://github.com/hdmf-dev/hdmf/issues/new/choose "
-                    "and include these values in the ticket."
-                )
-            filterwarnings(action="default")  # Return to normal behavior
+        self.chunk_shape = chunk_shape or self._get_default_chunk_shape(chunk_mb=chunk_mb)
+        self.chunk_shape = tuple(np.asarray(self.chunk_shape, dtype="uint64"))  # Upcast for safer numpy operations
 
+        self.buffer_shape = buffer_shape or self._get_default_buffer_shape(buffer_gb=buffer_gb)
+        self.buffer_shape = tuple(np.asarray(self.chunk_shape, dtype="uint64"))  # Upcast for safer numpy operations
+
+        # Shape assertions
         array_chunk_shape = np.array(self.chunk_shape)
         array_buffer_shape = np.array(self.buffer_shape)
         array_maxshape = np.array(self.maxshape)
@@ -247,7 +233,9 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             f"evenly divide the buffer shape ({self.buffer_shape})!"
         )
 
-        self.num_buffers = np.prod(np.ceil(array_maxshape / array_buffer_shape))
+        self.num_buffers = np.prod(
+            np.ceil(array_maxshape / array_buffer_shape).astype("uint64")  # np.ceil casts as float
+        )
         self.buffer_selection_generator = (
             tuple([slice(lower_bound, upper_bound) for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)])
             for lower_bounds, upper_bounds in zip(
@@ -298,28 +286,28 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
 
         Keeps the dimensional ratios of the original data.
         """
-        chunk_mb = getargs('chunk_mb', kwargs)
+        chunk_mb = getargs("chunk_mb", kwargs)
         assert chunk_mb > 0, f"chunk_mb ({chunk_mb}) must be greater than zero!"
 
         n_dims = len(self.maxshape)
         itemsize = self.dtype.itemsize
         chunk_bytes = chunk_mb * 1e6
-        v = np.floor(np.array(self.maxshape) / np.min(self.maxshape))
+        v = np.floor(np.array(self.maxshape) / np.min(self.maxshape)).astype("uint64")  # np.floor casts to float
         prod_v = np.prod(v)
         while prod_v * itemsize > chunk_bytes and prod_v != 1:
             v_ind = v != 1
             next_v = v[v_ind]
             v[v_ind] = np.floor(next_v / np.min(next_v))
             prod_v = np.prod(v)
-        k = np.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims))
-        return tuple([min(int(x), self.maxshape[dim]) for dim, x in enumerate(k * v)])
+        k = np.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims)).astype("uint64")  # np.floor casts to float
+        return tuple([min(x, self.maxshape[dim]) for dim, x in enumerate(k * v)])
 
     @docval(
         dict(
-           name="buffer_gb",
-           type=(float, int),
-           doc="Size of the data buffer in gigabytes. Recommended to be as much free RAM as safely available.",
-           default=None,
+            name="buffer_gb",
+            type=(float, int),
+            doc="Size of the data buffer in gigabytes. Recommended to be as much free RAM as safely available.",
+            default=None,
         )
     )
     def _get_default_buffer_shape(self, **kwargs):
@@ -329,19 +317,21 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         Keeps the dimensional ratios of the original data.
         Assumes the chunk_shape has already been set.
         """
-        buffer_gb = getargs('buffer_gb', kwargs)
+        buffer_gb = getargs("buffer_gb", kwargs)
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
-        assert all(np.array(self.chunk_shape) > 0), (
-            f"Some dimensions of chunk_shape ({self.chunk_shape}) are less than zero!"
-        )
+        assert all(
+            np.array(self.chunk_shape) > 0
+        ), f"Some dimensions of chunk_shape ({self.chunk_shape}) are less than zero!"
 
         k = np.floor(
             (buffer_gb * 1e9 / (np.prod(self.chunk_shape) * self.dtype.itemsize)) ** (1 / len(self.chunk_shape))
+        ).astype("uint64")  # np.floor casts to float
+        return tuple(
+            [
+                min(max(x, self.chunk_shape[j]), self.maxshape[j])
+                for j, x in enumerate(k * np.array(self.chunk_shape))
+            ]
         )
-        return tuple([
-            min(max(int(x), self.chunk_shape[j]), self.maxshape[j])
-            for j, x in enumerate(k * np.array(self.chunk_shape))
-        ])
 
     def recommended_chunk_shape(self) -> tuple:
         return self.chunk_shape

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1,7 +1,7 @@
 import copy
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
-from warnings import warn, filterwarnings
+from warnings import warn
 from typing import Tuple
 from itertools import product, chain
 

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -161,13 +161,28 @@ class GenericDataChunkIteratorTests(TestCase):
             )
 
     def test_maxshape_attribute_uint64_type(self):
-        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape])
+        assert all(
+            [
+                x.dtype is np.dtype("uint64")
+                for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape
+            ]
+        )
 
     def test_chunk_shape_attribute_automated_uint64_type(self):
-        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape])
+        assert all(
+            [
+                x.dtype is np.dtype("uint64")
+                for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape
+            ]
+        )
 
     def test_buffer_shape_attribute_automated_uint64_type(self):
-        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape])
+        assert all(
+            [
+                x.dtype is np.dtype("uint64")
+                for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape
+            ]
+        )
 
     def test_chunk_shape_attribute_manual_uint64_type(self):
         assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -174,6 +174,28 @@ class GenericDataChunkIteratorTests(TestCase):
                 progress_bar_options=dict(total=5),
             )
 
+    def test_maxshape_attribute_uint64_type(self):
+        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape.dtype is np.dtype("uint64")
+
+    def test_chunk_shape_attribute_automated_uint64_type(self):
+        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape.dtype is np.dtype("uint64")
+
+    def test_buffer_shape_attribute_automated_uint64_type(self):
+        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape.dtype is np.dtype("uint64")
+
+    def test_chunk_shape_attribute_manual_uint64_type(self):
+        assert self.TestNumpyArrayDataChunkIterator(
+            array=self.test_array,
+            chunk_shape=(100, 2)
+        ).chunk_shape.dtype is np.dtype("uint64")
+
+    def test_buffer_shape_attribute_manual_uint64_type(self):
+        assert self.TestNumpyArrayDataChunkIterator(
+            array=self.test_array,
+            chunk_shape=(100, 2),
+            buffer_shape=(200, 4),
+        ).buffer_shape.dtype is np.dtype("uint64")
+
     def test_num_buffers(self):
         buffer_shape = (950, 190)
         chunk_shape = (50, 38)

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -175,26 +175,26 @@ class GenericDataChunkIteratorTests(TestCase):
             )
 
     def test_maxshape_attribute_uint64_type(self):
-        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape.dtype is np.dtype("uint64")
+        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape])
 
     def test_chunk_shape_attribute_automated_uint64_type(self):
-        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape.dtype is np.dtype("uint64")
+        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape])
 
     def test_buffer_shape_attribute_automated_uint64_type(self):
-        assert self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape.dtype is np.dtype("uint64")
+        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape])
 
     def test_chunk_shape_attribute_manual_uint64_type(self):
-        assert self.TestNumpyArrayDataChunkIterator(
+        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(
             array=self.test_array,
             chunk_shape=(100, 2)
-        ).chunk_shape.dtype is np.dtype("uint64")
+        ).chunk_shape])
 
     def test_buffer_shape_attribute_manual_uint64_type(self):
-        assert self.TestNumpyArrayDataChunkIterator(
+        assert all([x.dtype is np.dtype("uint64") for x in self.TestNumpyArrayDataChunkIterator(
             array=self.test_array,
             chunk_shape=(100, 2),
             buffer_shape=(200, 4),
-        ).buffer_shape.dtype is np.dtype("uint64")
+        ).buffer_shape])
 
     def test_num_buffers(self):
         buffer_shape = (950, 190)

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -34,7 +34,7 @@ class GenericDataChunkIteratorTests(TestCase):
     def setUp(self):
         np.random.seed(seed=0)
         self.test_dir = Path(mkdtemp())
-        self.test_array = np.random.randint(low=-(2 ** 15), high=2 ** 15 - 1, size=(2000, 384), dtype="int16")
+        self.test_array = np.empty(shape=(2000, 384), dtype="int16")
 
     def tearDown(self):
         rmtree(self.test_dir)
@@ -130,13 +130,6 @@ class GenericDataChunkIteratorTests(TestCase):
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, buffer_gb=buffer_gb)
 
-        buffer_shape = (-1, 384)
-        with self.assertRaisesWith(
-            exc_type=AssertionError,
-            exc_msg=f"Some dimensions of buffer_shape ({buffer_shape}) are less than zero!"
-        ):
-            self.TestNumpyArrayDataChunkIterator(array=self.test_array, buffer_shape=buffer_shape)
-
         buffer_shape = (2001, 384)
         with self.assertRaisesWith(
             exc_type=AssertionError,
@@ -154,13 +147,6 @@ class GenericDataChunkIteratorTests(TestCase):
             exc_msg=f"chunk_mb ({chunk_mb}) must be greater than zero!"
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, chunk_mb=chunk_mb)
-
-        chunk_shape = (-1, 384)
-        with self.assertRaisesWith(
-            exc_type=AssertionError,
-            exc_msg=f"Some dimensions of chunk_shape ({chunk_shape}) are less than zero!"
-        ):
-            self.TestNumpyArrayDataChunkIterator(array=self.test_array, chunk_shape=chunk_shape)
 
     @unittest.skipIf(not TQDM_INSTALLED, "optional tqdm module is not installed")
     def test_progress_bar_assertion(self):


### PR DESCRIPTION
Related to a memory leak detected in https://github.com/catalystneuro/neuroconv/pull/194

Basic explanation is, when the `GenericDataChunkIterator` was initially developed and tested in real-world situations, the data types and scales at that time weren't large enough to cause this problem. What happens is `np.prod(some_iterable_of_ints)` uses `int32` in its product operation (max value of only 2,147,483,648 on the positive end), whereas Python uses `int64` for `*` operations (max value of  9,223,372,036,854,775,808) .

So if we had recursively used `*` like

```python
val=1
for x in some_iterable_of_ints:
    val *= x
```
the data type would have been large enough to avoid the problem.

Anyhow, this was detected initially via the warnings numpy throws when it first happens in the operation, but given that this value determines how much data to load into RAM it's a bit more important of a problem than a warning (it actually killed my entire system, lol...) so I'm catching it here and upgrading to an informative warning that will also let us know in the future if we ever need to push it further than this.

Message appears like

![image](https://user-images.githubusercontent.com/51133164/198500151-c3c335b4-462b-49a7-8581-9853988b3997.png)
