### PR TITLE
Ensure slices of GenericDataChunkIterator have consistent data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,11 @@
 # HDMF Changelog
 
-## Upcoming
-
-### Bug fixes
-- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by dropping all `numpy` operations (which forced casting within the passed data type) in favor of the unlimited precision of Python builtin integer types @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780)) ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
-
-
-## HDMF 3.4.7 (October 26, 2022)
+## HDMF 3.4.7 (November 9, 2022)
 
 ### Bug fixes
 - Fix an issue where not providing an optional argument to `__init__` of an auto-generated `MultiContainerInterface`
   class raised an error. @rly ([#779](https://github.com/hdmf-dev/hdmf/pull/779))
+- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by dropping all `numpy` operations (which forced casting within the passed data type) in favor of the unlimited precision of Python builtin integer types @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780)) ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
 
 ## HDMF 3.4.6 (October 4, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Upcoming
 
 ### Bug fixes
-- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by upcasting all shape attributes and operations to use the `uint64` data type. @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780))
-- Fixed issue following #780 where not all of the data types of the `selection` ranges for each DataChunk were consistent, leading to unexpected casting issues when attempting operations between endpoints (such as `selection.stop - selection.start` returning `float64` because one was a `uint64` and the other was a `int32`). @codycbakerphd ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
+- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by upcasting all shape attributes and operations to use the `uint64` data type. The `selection` ranges are also cast as `int32` for downstream compatability @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780)) ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
 
 
 ## HDMF 3.4.7 (October 26, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 ### Bug fixes
-- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by upcasting all shape attributes and operations to use the `uint64` data type. The `selection` ranges are also cast as `int32` for downstream compatability @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780)) ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
+- Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by dropping all `numpy` operations (which forced casting within the passed data type) in favor of the unlimited precision of Python builtin integer types @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780)) ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
 
 
 ## HDMF 3.4.7 (October 26, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 - Fixed an issue with the `data_utils.GenericDataChunkIterator` where if the underlying dataset was such that the `numpy.product` of the `maxshape` exceeded the range of the default `int32`, buffer overflow would occur and cause the true buffer shape to exceed available memory. This has been resolved by upcasting all shape attributes and operations to use the `uint64` data type. @codycbakerphd ([#780](https://github.com/hdmf-dev/hdmf/pull/780))
+- Fixed issue following #780 where not all of the data types of the `selection` ranges for each DataChunk were consistent, leading to unexpected casting issues when attempting operations between endpoints (such as `selection.stop - selection.start` returning `float64` because one was a `uint64` and the other was a `int32`). @codycbakerphd ([#781](https://github.com/hdmf-dev/hdmf/pull/781))
 
 
 ## HDMF 3.4.7 (October 26, 2022)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -345,8 +345,9 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             f"Some dimensions of chunk_shape ({self.chunk_shape}) are less than zero!"
         )
 
+        # TODO: replace with math.prod when Python 3.7 is dropped
         k = math.floor(
-            (  # TODO: replace with math.prod when Python 3.7 is dropped
+            (
                 buffer_gb * 1e9 / ( _temporary_prod(self.chunk_shape) * self.dtype.itemsize)
             ) ** (1 / len(self.chunk_shape))
         )

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -348,7 +348,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         # TODO: replace with math.prod when Python 3.7 is dropped
         k = math.floor(
             (
-                buffer_gb * 1e9 / ( _temporary_prod(self.chunk_shape) * self.dtype.itemsize)
+                buffer_gb * 1e9 / (_temporary_prod(self.chunk_shape) * self.dtype.itemsize)
             ) ** (1 / len(self.chunk_shape))
         )
         return tuple(

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -238,7 +238,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         self.buffer_selection_generator = (
             tuple(
                 [
-                    slice(np.uint64(lower_bound), np.uint64(upper_bound))
+                    slice(int(lower_bound), int(upper_bound))
                     for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)
                 ]
             )

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -207,9 +207,9 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         ), "Only one of 'chunk_mb' or 'chunk_shape' can be specified!"
 
         self._dtype = self._get_dtype()
-        self._maxshape = self._get_maxshape()
-        self.chunk_shape = chunk_shape or self._get_default_chunk_shape(chunk_mb=chunk_mb)
-        self.buffer_shape = buffer_shape or self._get_default_buffer_shape(buffer_gb=buffer_gb)
+        self._maxshape = tuple(int(x) for x in self._get_maxshape())
+        self.chunk_shape = tuple(int(x) for x in chunk_shape) or self._get_default_chunk_shape(chunk_mb=chunk_mb)
+        self.buffer_shape = tuple(int(x) for x in buffer_shape) or self._get_default_buffer_shape(buffer_gb=buffer_gb)
 
         # Shape assertions
         assert all(

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -313,7 +313,8 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         while prod_v * itemsize > chunk_bytes and prod_v != 1:
             non_unit_min_v = min(x for x in v if x != 1)
             v = tuple(math.floor(x / non_unit_min_v) if x != 1 else x for x in v)
-            prod_v = functools.reduce(operator.mul, v, 1)  # TODO: replace with math.prod when Python 3.7 support is dropped
+            # TODO: replace with math.prod when Python 3.7 support is dropped
+            prod_v = functools.reduce(operator.mul, v, 1)
         k = math.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims))
         return tuple([min(k * x, self.maxshape[dim]) for dim, x in enumerate(v)])
 

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -236,7 +236,12 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             np.ceil(array_maxshape / array_buffer_shape).astype("uint64")  # np.ceil casts as float
         )
         self.buffer_selection_generator = (
-            tuple([slice(lower_bound, upper_bound) for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)])
+            tuple(
+                [
+                    slice(np.uint64(lower_bound), np.uint64(upper_bound))
+                    for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)
+                ]
+            )
             for lower_bounds, upper_bounds in zip(
                 product(
                     *[

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1,4 +1,5 @@
 import copy
+import math
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from warnings import warn
@@ -206,39 +207,40 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         ), "Only one of 'chunk_mb' or 'chunk_shape' can be specified!"
 
         self._dtype = self._get_dtype()
-        self._maxshape = tuple(np.array(self._get_maxshape(), dtype="uint64"))  # Upcast for safer numpy operations
-        self.chunk_shape = tuple(
-            np.asarray(chunk_shape or self._get_default_chunk_shape(chunk_mb=chunk_mb), dtype="uint64")
-        )  # Upcast for safer numpy operations
-        self.buffer_shape = tuple(
-            np.asarray(buffer_shape or self._get_default_buffer_shape(buffer_gb=buffer_gb), dtype="uint64")
-        )  # Upcast for safer numpy operations
+        self._maxshape = self._get_maxshape()
+        self.chunk_shape = chunk_shape or self._get_default_chunk_shape(chunk_mb=chunk_mb)
+        self.buffer_shape = buffer_shape or self._get_default_buffer_shape(buffer_gb=buffer_gb)
 
         # Shape assertions
-        array_chunk_shape = np.array(self.chunk_shape)
-        array_buffer_shape = np.array(self.buffer_shape)
-        array_maxshape = np.array(self.maxshape)
         assert all(
-            array_chunk_shape <= array_maxshape
+            buffer_axis > 0 for buffer_axis in self.buffer_shape
+        ), f"Some dimensions of buffer_shape ({self.buffer_shape}) are less than zero!"
+        assert all(
+            chunk_axis <= maxshape_axis for chunk_axis, maxshape_axis in zip(self.chunk_shape, self.maxshape)
         ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the data dimensions ({self.maxshape})!"
         assert all(
-            array_buffer_shape <= array_maxshape
+            buffer_axis <= maxshape_axis for buffer_axis, maxshape_axis in zip(self.buffer_shape, self.maxshape)
         ), f"Some dimensions of buffer_shape ({self.buffer_shape}) exceed the data dimensions ({self.maxshape})!"
         assert all(
-            array_chunk_shape <= array_buffer_shape
+            (chunk_axis <= buffer_axis for chunk_axis, buffer_axis in zip(self.chunk_shape, self.buffer_shape))
         ), f"Some dimensions of chunk_shape ({self.chunk_shape}) exceed the buffer shape ({self.buffer_shape})!"
-        assert all((array_buffer_shape % array_chunk_shape == 0)[array_buffer_shape != array_maxshape]), (
+        assert all(
+            chunk_axis % buffer_axis
+            for chunk_axis, buffer_axis, maxshape_axis in zip(self.chunk_shape, self.buffer_shape, self.maxshape)
+            if buffer_axis != maxshape_axis
+        ), (
             f"Some dimensions of chunk_shape ({self.chunk_shape}) do not "
             f"evenly divide the buffer shape ({self.buffer_shape})!"
         )
 
-        self.num_buffers = np.prod(
-            np.ceil(array_maxshape / array_buffer_shape).astype("uint64")  # np.ceil casts as float
+        self.num_buffers = math.prod(
+            math.ceil(maxshape_axis / buffer_axis)
+            for buffer_axis, maxshape_axis in zip(self.buffer_shape, self.maxshape)
         )
         self.buffer_selection_generator = (
             tuple(
                 [
-                    slice(int(lower_bound), int(upper_bound))
+                    slice(lower_bound, upper_bound)
                     for lower_bound, upper_bound in zip(lower_bounds, upper_bounds)
                 ]
             )
@@ -284,7 +286,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             default=None,
         )
     )
-    def _get_default_chunk_shape(self, **kwargs):
+    def _get_default_chunk_shape(self, **kwargs) -> Tuple[int, ...]:
         """
         Select chunk shape with size in MB less than the threshold of chunk_mb.
 
@@ -296,15 +298,17 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         n_dims = len(self.maxshape)
         itemsize = self.dtype.itemsize
         chunk_bytes = chunk_mb * 1e6
-        v = np.floor(np.array(self.maxshape) / np.min(self.maxshape)).astype("uint64")  # np.floor casts to float
-        prod_v = np.prod(v)
+
+        min_maxshape = min(self.maxshape)
+        v = tuple(math.floor(maxshape_axis / min_maxshape) for maxshape_axis in self.maxshape)
+        prod_v = math.prod(v)
         while prod_v * itemsize > chunk_bytes and prod_v != 1:
-            v_ind = v != 1
-            next_v = v[v_ind]
-            v[v_ind] = np.floor(next_v / np.min(next_v)).astype("uint64")  # np.floor casts to float
-            prod_v = np.prod(v)
-        k = np.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims)).astype("uint64")  # np.floor casts to float
-        return tuple([min(x, self.maxshape[dim]) for dim, x in enumerate(k * v)])
+            next_v = tuple(x for x in v if x != 1)
+            min_next_v = min(next_v)
+            v = tuple(math.floor(x / min_next_v) for x in next_v)
+            prod_v = math.prod(v)
+        k = math.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims))
+        return tuple([min(k * x, self.maxshape[dim]) for dim, x in enumerate(v)])
 
     @docval(
         dict(
@@ -314,7 +318,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             default=None,
         )
     )
-    def _get_default_buffer_shape(self, **kwargs):
+    def _get_default_buffer_shape(self, **kwargs) -> Tuple[int, ...]:
         """
         Select buffer shape with size in GB less than the threshold of buffer_gb.
 
@@ -323,21 +327,24 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         """
         buffer_gb = getargs("buffer_gb", kwargs)
         assert buffer_gb > 0, f"buffer_gb ({buffer_gb}) must be greater than zero!"
+        assert all(chunk_axis > 0 for chunk_axis in self.chunk_shape), (
+            f"Some dimensions of chunk_shape ({self.chunk_shape}) are less than zero!"
+        )
 
-        k = np.floor(
-            (buffer_gb * 1e9 / (np.prod(self.chunk_shape) * self.dtype.itemsize)) ** (1 / len(self.chunk_shape))
-        ).astype("uint64")  # np.floor casts to float
+        k = math.floor(
+            (buffer_gb * 1e9 / (math.prod(self.chunk_shape) * self.dtype.itemsize)) ** (1 / len(self.chunk_shape))
+        )
         return tuple(
             [
-                min(max(x, self.chunk_shape[j]), self.maxshape[j])
-                for j, x in enumerate(k * np.array(self.chunk_shape))
+                min(max(k * x, self.chunk_shape[j]), self.maxshape[j])
+                for j, x in enumerate(self.chunk_shape)
             ]
         )
 
-    def recommended_chunk_shape(self) -> tuple:
+    def recommended_chunk_shape(self) -> Tuple[int, ...]:
         return self.chunk_shape
 
-    def recommended_data_shape(self) -> tuple:
+    def recommended_data_shape(self) -> Tuple[int, ...]:
         return self.maxshape
 
     def __iter__(self):
@@ -381,16 +388,16 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         raise NotImplementedError("The data fetching method has not been built for this DataChunkIterator!")
 
     @property
-    def maxshape(self):
+    def maxshape(self) -> Tuple[int, ...]:
         return self._maxshape
 
     @abstractmethod
-    def _get_maxshape(self) -> tuple:
+    def _get_maxshape(self) -> Tuple[int, ...]:
         """Retrieve the maximum bounds of the data shape using minimal I/O."""
         raise NotImplementedError("The setter for the maxshape property has not been built for this DataChunkIterator!")
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         return self._dtype
 
     @abstractmethod

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -80,7 +80,7 @@ class GenericDataChunkIteratorTests(TestCase):
                 isinstance(x, int) for x in iterable
             )
         )
-            
+
     def test_abstract_assertions(self):
         class TestGenericDataChunkIterator(GenericDataChunkIterator):
             pass
@@ -202,15 +202,21 @@ class GenericDataChunkIteratorTests(TestCase):
 
     def test_maxshape_attribute_contains_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
-        self.check_all_of_iterable_is_python_int(iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape)
+        self.check_all_of_iterable_is_python_int(
+            iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).maxshape
+        )
 
     def test_automated_buffer_shape_attribute_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
-        self.check_all_of_iterable_is_python_int(iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape)
+        self.check_all_of_iterable_is_python_int(
+            iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).buffer_shape
+        )
 
     def test_automated_chunk_shape_attribute_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
-        self.check_all_of_iterable_is_python_int(iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape)
+        self.check_all_of_iterable_is_python_int(
+            iterable=self.TestNumpyArrayDataChunkIterator(array=self.test_array).chunk_shape
+        )
 
     def test_np_dtype_maxshape_attribute_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
@@ -227,7 +233,7 @@ class GenericDataChunkIteratorTests(TestCase):
                 buffer_shape=(np.uint64(200), np.uint64(4)),
             ).buffer_shape
         )
-        
+
     def test_manual_chunk_shape_attribute_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
         self.check_all_of_iterable_is_python_int(
@@ -252,7 +258,7 @@ class GenericDataChunkIteratorTests(TestCase):
         buffer_shape = (950, 190)
         chunk_shape = (50, 38)
         expected_num_buffers = 9
-        
+
         test = self.TestNumpyArrayDataChunkIterator(
             array=self.test_array, buffer_shape=buffer_shape, chunk_shape=chunk_shape
         )
@@ -333,7 +339,7 @@ class GenericDataChunkIteratorTests(TestCase):
         special_array = np.random.randint(low=-(2 ** 15), high=2 ** 15 - 1, size=(1, 2000, 2000), dtype="int16")
         iterator = self.TestNumpyArrayDataChunkIterator(array=special_array)
         self.assertEqual(iterator.chunk_shape, expected_chunk_shape)
-        
+
     @unittest.skipIf(not TQDM_INSTALLED, "optional tqdm module is not installed")
     def test_progress_bar(self):
         out_text_file = self.test_dir / "test_progress_bar.txt"

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -205,10 +205,10 @@ class GenericDataChunkIteratorTests(TestCase):
         stop_1 = first_chunk.selection[1].stop
         start_1 = first_chunk.selection[1].start
 
-        assert stop_0.dtype is np.dtype("uint64")
-        assert start_0.dtype is np.dtype("uint64")
-        assert stop_1.dtype is np.dtype("uint64")
-        assert start_1.dtype is np.dtype("uint64")
+        assert isinstance(stop_0, int)
+        assert isinstance(start_0, int)
+        assert isinstance(stop_1, int)
+        assert isinstance(start_1, int)
 
     def test_num_buffers(self):
         buffer_shape = (950, 190)

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -122,7 +122,7 @@ class GenericDataChunkIteratorTests(TestCase):
                 array=self.test_array, buffer_shape=buffer_shape, chunk_shape=chunk_shape
             )
 
-    def test_buffer_option_assertions(self):
+    def test_buffer_option_assertion_negative_buffer_gb(self):
         buffer_gb = -1
         with self.assertRaisesWith(
             exc_type=AssertionError,
@@ -130,6 +130,7 @@ class GenericDataChunkIteratorTests(TestCase):
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, buffer_gb=buffer_gb)
 
+    def test_buffer_option_assertion_exceed_maxshape(self):
         buffer_shape = (2001, 384)
         with self.assertRaisesWith(
             exc_type=AssertionError,
@@ -140,13 +141,29 @@ class GenericDataChunkIteratorTests(TestCase):
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, buffer_shape=buffer_shape)
 
-    def test_chunk_option_assertions(self):
+    def test_buffer_option_assertion_negative_shape(self):
+        buffer_shape = (-1, 384)
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg=f"Some dimensions of buffer_shape ({buffer_shape}) are less than zero!"
+        ):
+            self.TestNumpyArrayDataChunkIterator(array=self.test_array, buffer_shape=buffer_shape)
+
+    def test_chunk_option_assertion_negative_chunk_mb(self):
         chunk_mb = -1
         with self.assertRaisesWith(
             exc_type=AssertionError,
             exc_msg=f"chunk_mb ({chunk_mb}) must be greater than zero!"
         ):
             self.TestNumpyArrayDataChunkIterator(array=self.test_array, chunk_mb=chunk_mb)
+
+    def test_chunk_option_assertion_negative_shape(self):
+        chunk_shape = (-1, 384)
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg=f"Some dimensions of chunk_shape ({chunk_shape}) are less than zero!"
+        ):
+            self.TestNumpyArrayDataChunkIterator(array=self.test_array, chunk_shape=chunk_shape)
 
     @unittest.skipIf(not TQDM_INSTALLED, "optional tqdm module is not installed")
     def test_progress_bar_assertion(self):

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -197,6 +197,19 @@ class GenericDataChunkIteratorTests(TestCase):
             buffer_shape=(200, 4),
         ).buffer_shape])
 
+    def test_selection_uint64_type(self):
+        iterator = self.TestNumpyArrayDataChunkIterator(array=self.test_array)
+        first_chunk = next(iterator)
+        stop_0 = first_chunk.selection[0].stop
+        start_0 = first_chunk.selection[0].start
+        stop_1 = first_chunk.selection[1].stop
+        start_1 = first_chunk.selection[1].start
+
+        assert stop_0.dtype is np.dtype("uint64")
+        assert start_0.dtype is np.dtype("uint64")
+        assert stop_1.dtype is np.dtype("uint64")
+        assert start_1.dtype is np.dtype("uint64")
+
     def test_num_buffers(self):
         buffer_shape = (950, 190)
         chunk_shape = (50, 38)


### PR DESCRIPTION
A follow-up to #780 lead to some issues in our dev branch testing suite on NeuroConv (https://github.com/catalystneuro/neuroconv/actions/runs/3379295582/jobs/5610660624); as explained in the `CHANGELOG.md`, the issue occurs because the `np.uint64` upcasting from #780 was indeed propagating down to the level of the `selection` ranges (tuple of slices of integers) of each `DataChunk` on the call to `next(some_iterator)`. However, not all ranges had consistent data types which lead to a strange interaction when you tried to do otherwise self-consistent operations with those slice values, such as `selection.stop - selection.start` returning as a `float` because the `stop` was a `uint64` and the `start` was a `int32`. While this isn't a really big problem since the actual value of the operation is unaffected, some downstream code relied on the output of such things having a consistent data type so I think we might as well ensure that as upstream as possible.