### PR TITLE
Allow custom message as part of TestCase.assert... functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed an issue with the `tox` tool when upgrading to tox 4. @rly [#802](https://github.com/hdmf-dev/hdmf/pull/802)
 - Fixed export of newly added links to existing elements of the exported file. @rly [#808](https://github.com/hdmf-dev/hdmf/pull/808)
 
+### Minor improvements
+- Added `message` argument for assert methods defined by `hdmf.testing.TestCase` to allow developers to include custom error messages with asserts. @oruebel [#812](https://github.com/hdmf-dev/hdmf/pull/812)
+
+
 ## HDMF 3.4.7 (November 9, 2022)
 
 ### Minor improvements

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -123,7 +123,7 @@ class TestCase(unittest.TestCase):
                                     ignore_string_to_byte=ignore_string_to_byte,
                                     message=message)
         elif isinstance(f1, (float, np.floating)):
-            np.testing.assert_allclose(f1, f2)
+            np.testing.assert_allclose(f1, f2, err_msg=message)
         else:
             self.assertEqual(f1, f2, message)
 
@@ -185,7 +185,7 @@ class TestCase(unittest.TestCase):
             arr2 = arr2[()]
         if not isinstance(arr1, (tuple, list, np.ndarray)) and not isinstance(arr2, (tuple, list, np.ndarray)):
             if isinstance(arr1, (float, np.floating)):
-                np.testing.assert_allclose(arr1, arr2)
+                np.testing.assert_allclose(arr1, arr2, err_msg=message)
             else:
                 if ignore_string_to_byte:
                     if isinstance(arr1, bytes):
@@ -201,9 +201,9 @@ class TestCase(unittest.TestCase):
                 arr2 = arr2.tolist()
             if isinstance(arr1, np.ndarray) and isinstance(arr2, np.ndarray):
                 if np.issubdtype(arr1.dtype, np.number):
-                    np.testing.assert_allclose(arr1, arr2)
+                    np.testing.assert_allclose(arr1, arr2, err_msg=message)
                 else:
-                    np.testing.assert_array_equal(arr1, arr2)
+                    np.testing.assert_array_equal(arr1, arr2, err_msg=message)
             else:
                 for sub1, sub2 in zip(arr1, arr2):
                     if isinstance(sub1, Container):


### PR DESCRIPTION
## Motivation

Similar to standard assert functions of ``unittest.TestCase`` it will be useful to allow specification of a custom message to be added for asserts defined by HDMFs``hdmf.testing.testcase.TestCase`` class. This is useful, e.g., when tests are parametrized and we want to include test parameters as part of the error message from asserts when a test is failing. 

I came across this issue in hdmf_zarr where I need to run the same test with different backend parameters and it would be useful to include additional information in error messages when tests are failing.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
