### PR TITLE
Clarify tutorial to indicate that EnumData is experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.5.1 (Upcoming)
+
+### Documentation and tutorial enhancements:
+- Updated `DynamicTable` how to tutorial to clarify the status of `EnumData`. @oruebel [#819](https://github.com/hdmf-dev/hdmf/pull/819)
+
 ## HDMF 3.5.0 (January 17, 2023)
 
 ### Bug fixes

--- a/docs/gallery/plot_dynamictable_howto.py
+++ b/docs/gallery/plot_dynamictable_howto.py
@@ -142,8 +142,16 @@ table.add_column(
 # references those values by index. Using this method is more efficient than storing
 # a single value many times, and has the advantage of communicating to downstream
 # tools that the data is categorical in nature.
+#
+# .. warning::
+#
+#    :py:class:`~hdmf.common.table.EnumData` is currently an experimental
+#    feature and as such should not be used for production use.
+#
 
 from hdmf.common.table import EnumData
+import warnings
+warnings.filterwarnings(action="ignore", message="EnumData is experimental")
 
 # this column has a length of 5, not 3. the first row has value "aa"
 enum_col = EnumData(


### PR DESCRIPTION
## Motivation

Fix #755

* Update tutorial to filter warning and add note to explain in the tutorial itself that EnumData is an experimental feature

What was the reasoning behind this change? Please explain the changes briefly.


## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
