### PR TITLE
Minor refactor, fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Bug fixes
 - Fixed issue with conda CI. @rly [#823](https://github.com/hdmf-dev/hdmf/pull/823)
-- Fixed issue with deprecated `pkg_resources`. @mavaylon [822](https://github.com/hdmf-dev/hdmf/pull/822)
-- Fixed `hdmf.common` deprecation warning. @mavaylon [826]((https://github.com/hdmf-dev/hdmf/pull/826)
+- Fixed issue with deprecated `pkg_resources`. @mavaylon [#822](https://github.com/hdmf-dev/hdmf/pull/822)
+- Fixed `hdmf.common` deprecation warning. @mavaylon [#826]((https://github.com/hdmf-dev/hdmf/pull/826)
 
 ### Internal improvements
 - A number of typos fixed and Github action running codespell to ensure that no typo sneaks in [#825](https://github.com/hdmf-dev/hdmf/pull/825) was added.

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -73,21 +73,16 @@ def register_map(**kwargs):
 def __get_resources():
     try:
         from importlib.resources import files
-
-        def resource_filename(package_or_requirement, resource_name):
-            return str(files(package_or_requirement) / resource_name)
     except ImportError:
         # TODO: Remove when python 3.9 becomes the new minimum
         from importlib_resources import files
 
-        def resource_filename(package_or_requirement, resource_name):
-            return str(files(package_or_requirement) / resource_name)
-
-    from os.path import join
+    __location_of_this_file = files(__name__)
     __core_ns_file_name = 'namespace.yaml'
+    __schema_dir = 'hdmf-common-schema/common'
 
     ret = dict()
-    ret['namespace_path'] = join(resource_filename(__name__, 'hdmf-common-schema/common'), __core_ns_file_name)
+    ret['namespace_path'] = str(__location_of_this_file / __schema_dir / __core_ns_file_name)
     return ret
 
 

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -155,13 +155,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
         pd.testing.assert_frame_equal(result_df, expected_df)
 
     def test_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
             entity_id="id11", entity_uri='url11')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
@@ -171,13 +171,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
                                                                           er_right))
 
     def test_invalid_keys_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
             entity_id="id11", entity_uri='url11')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right.add_ref(
             container='invalid', key='invalid',
             resource_name='resource11', resource_uri='resource_uri11',
@@ -188,13 +188,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
                                                               er_right)
 
     def test_invalid_objects_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='invalid', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
             entity_id="id11", entity_uri='url11')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
@@ -205,13 +205,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
                                                               er_right)
 
     def test_invalid_resources_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='uuid1', key='key1',
             resource_name='invalid', resource_uri='invalid',
             entity_id="id11", entity_uri='url11')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
@@ -222,13 +222,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
                                                               er_right)
 
     def test_invalid_entity_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
             entity_id="invalid", entity_uri='invalid')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right.add_ref(
             container='uuid1', key='key1',
             resource_name='resource11', resource_uri='resource_uri11',
@@ -239,13 +239,13 @@ class TestExternalResources(H5RoundTripMixin, TestCase):
                                                               er_right)
 
     def test_invalid_object_keys_assert_external_resources_equal(self):
-        er_left = ExternalResources('terms')
+        er_left = ExternalResources(name='terms')
         er_left.add_ref(
             container='invalid', key='invalid',
             resource_name='resource11', resource_uri='resource_uri11',
             entity_id="id11", entity_uri='url11')
 
-        er_right = ExternalResources('terms')
+        er_right = ExternalResources(name='terms')
         er_right._add_key('key')
         er_right.add_ref(
             container='uuid1', key='key1',

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -85,11 +85,11 @@ class H5IOTest(TestCase):
             for iter_axis in iter_axis_opts:
                 for buffer_size in buffer_size_opts:
                     with self.subTest(data_type=data_type, iter_axis=iter_axis, buffer_size=buffer_size):
-                        with warnings.catch_warnings(record=True) as w:
+                        with warnings.catch_warnings(record=True):
                             # init may throw UserWarning for iterating over not-first dim of a list. ignore here
                             msg = ("Iterating over an axis other than the first dimension of list or tuple data "
-                               "involves converting the data object to a numpy ndarray, which may incur a "
-                               "computational cost.")
+                                   "involves converting the data object to a numpy ndarray, which may incur a "
+                                   "computational cost.")
                             warnings.filterwarnings("ignore", message=msg, category=UserWarning)
                             dci = DataChunkIterator(data=data, buffer_size=buffer_size, iter_axis=iter_axis)
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -86,10 +86,12 @@ class H5IOTest(TestCase):
                 for buffer_size in buffer_size_opts:
                     with self.subTest(data_type=data_type, iter_axis=iter_axis, buffer_size=buffer_size):
                         with warnings.catch_warnings(record=True) as w:
+                            # init may throw UserWarning for iterating over not-first dim of a list. ignore here
+                            msg = ("Iterating over an axis other than the first dimension of list or tuple data "
+                               "involves converting the data object to a numpy ndarray, which may incur a "
+                               "computational cost.")
+                            warnings.filterwarnings("ignore", message=msg, category=UserWarning)
                             dci = DataChunkIterator(data=data, buffer_size=buffer_size, iter_axis=iter_axis)
-                            if len(w) <= 1:
-                                # init may throw UserWarning for iterating over not-first dim of a list. ignore here
-                                pass
 
                         dset_name = '%s, %d, %d' % (data_type, iter_axis, buffer_size)
                         my_dset = HDF5IO.__chunked_iter_fill__(self.f, dset_name, dci)
@@ -211,13 +213,14 @@ class H5IOTest(TestCase):
         self.assertEqual(dset.compression, 'gzip')
 
     def test_write_dataset_list_disable_default_compress(self):
-        with warnings.catch_warnings(record=True) as w:
+        msg = ("Compression disabled by compression=False setting. compression_opts parameter will, therefore, "
+               "be ignored.")
+        with self.assertWarnsWith(UserWarning, msg):
             a = H5DataIO(np.arange(30).reshape(5, 2, 3),
                          compression=False,
                          compression_opts=5)
-            self.assertEqual(len(w), 1)  # We expect a warning that compression options are being ignored
-            self.assertFalse('compression_ops' in a.io_settings)
-            self.assertFalse('compression' in a.io_settings)
+        self.assertFalse('compression_ops' in a.io_settings)
+        self.assertFalse('compression' in a.io_settings)
 
         self.io.write_dataset(self.f, DatasetBuilder('test_dataset', a, attributes={}))
         dset = self.f['test_dataset']
@@ -638,15 +641,16 @@ class H5IOTest(TestCase):
             H5DataIO(np.arange(30), compression='szip', compression_opts=('bad_method', 16))
 
     def test_warning_on_linking_of_regular_array(self):
-        with warnings.catch_warnings(record=True) as w:
+        msg = "link_data parameter in H5DataIO will be ignored"
+        with self.assertWarnsWith(UserWarning, msg):
             dset = H5DataIO(np.arange(30),
                             link_data=True)
-            self.assertEqual(len(w), 1)
             self.assertEqual(dset.link_data, False)
 
     def test_warning_on_setting_io_options_on_h5dataset_input(self):
         self.io.write_dataset(self.f, DatasetBuilder('test_dataset', np.arange(10), attributes={}))
-        with warnings.catch_warnings(record=True) as w:
+        msg = "maxshape in H5DataIO will be ignored with H5DataIO.data being an HDF5 dataset"
+        with self.assertWarnsWith(UserWarning, msg):
             H5DataIO(self.f['test_dataset'],
                      compression='gzip',
                      compression_opts=4,
@@ -655,7 +659,7 @@ class H5IOTest(TestCase):
                      maxshape=(10, 20),
                      chunks=(10,),
                      fillvalue=100)
-            self.assertEqual(len(w), 7)
+            # self.assertEqual(len(w), 7)
 
     def test_h5dataio_array_conversion_numpy(self):
         # Test that H5DataIO.__array__ is working when wrapping an ndarray

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -659,7 +659,6 @@ class H5IOTest(TestCase):
                      maxshape=(10, 20),
                      chunks=(10,),
                      fillvalue=100)
-            # self.assertEqual(len(w), 7)
 
     def test_h5dataio_array_conversion_numpy(self):
         # Test that H5DataIO.__array__ is working when wrapping an ndarray


### PR DESCRIPTION
## Motivation

1. Minor code refactor from #830 to improve readability
2. Fix docval FutureWarning in external resources tests
3. Change how warnings are caught in tests so that they are not raised when running `pytest -Werror`

## How to test the behavior?
```
pytest -Werror
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
