### PR TITLE
Fix deploy release workflow

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py310-upgraded
+          tox -e py311-upgraded
 
       - name: Build wheel and source distribution
         run: |
-          tox -e build-py310-upgraded
+          tox -e build-py311-upgraded
           ls -1 dist
 
       - name: Test installation from a wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # HDMF Changelog
 
-## HDMF 3.5.3 (April 4, 2023)
+## HDMF 3.5.4 (April 7, 2023)
+
+### Bug fixes
+- Fixed typo in deploy release workflow. @rly [#845](https://github.com/hdmf-dev/hdmf/pull/845)
+
+## HDMF 3.5.3 (April 7, 2023)
 
 ### Bug fixes
 - Fixed search bar and missing jquery in ReadTheDocs documentation. @rly


### PR DESCRIPTION
## Motivation

The deploy release workflow failed because I forgot to update it when I increased the max python version to 3.11.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
