### PR TITLE
Remove unused codecov dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 3.5.5 (Upcoming)
+
+### Bug fixes
+- Remove unused, deprecated `codecov` package from dev installation requirements. @rly
+  [#849](https://github.com/hdmf-dev/hdmf/pull/849)
+
 ## HDMF 3.5.4 (April 7, 2023)
 
 ### Bug fixes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF, run HDMF tests, check code style,
 # compute coverage, and create test environments
-codecov==2.1.12
 coverage==6.4.2
 flake8==5.0.4
 flake8-debugger==4.1.2


### PR DESCRIPTION
## Motivation

The `codecov` package on PyPI was deprecated and suddenly deleted today. See https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259 and https://about.codecov.io/blog/message-regarding-the-pypi-package/

We no longer use the CLI for codecov so we can safely remove it as a dependency in `requirements-dev.txt`
 
## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
