### PR TITLE
Fix broken link to requires.io and update docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -3,7 +3,6 @@ Prepare for release of HDMF [version]
 ### Before merging:
 - [ ] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,
   `requirements-doc.txt`, `requirements-min.txt`, `requirements-opt.txt`, `setup.py` as needed
-  See https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `setup.py` as needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 3.5.6 (April 28, 2023)
+
+### Bug fixes
+- Remove references to discontinued `requires.io` service in documentation. @rly
+  [#854](https://github.com/hdmf-dev/hdmf/pull/854)
+
 ## HDMF 3.5.5 (April 13, 2023)
 
 ### Bug fixes

--- a/README.rst
+++ b/README.rst
@@ -45,10 +45,6 @@ Overall Health
 .. image:: https://codecov.io/gh/hdmf-dev/hdmf/branch/dev/graph/badge.svg
     :target: https://codecov.io/gh/hdmf-dev/hdmf
 
-.. image:: https://requires.io/github/hdmf-dev/hdmf/requirements.svg?branch=dev
-     :target: https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
-     :alt: Requirements Status
-
 .. image:: https://readthedocs.org/projects/hdmf/badge/?version=stable
      :target: https://hdmf.readthedocs.io/en/stable/?badge=stable
      :alt: Documentation Status

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -37,12 +37,24 @@ codecov_, which shows line by line which lines are covered by the tests.
 
 ..  _software_process_requirement_specifications:
 
+-------------------------
+Installation Requirements
+-------------------------
 
---------------------------
-Requirement Specifications
---------------------------
+setup.py_ contains a list of package dependencies and their version ranges allowed for
+running HDMF. As a library, upper bound version constraints create more harm than good in the long term (see this
+`blog post`_) so we avoid setting upper bounds on requirements.
 
-There are 6 kinds of requirements specification in HDMF.
+If some of the packages are outdated, see :ref:`update_requirements_files`.
+
+.. _setup.py: https://github.com/hdmf-dev/hdmf/blob/dev/setup.py
+.. _blog post: https://iscinumpy.dev/post/bound-version-constraints/
+
+--------------------
+Testing Requirements
+--------------------
+
+There are several kinds of requirements files used for testing PyNWB.
 
 The first one is requirements-min.txt_, which lists the package dependencies and their minimum versions for
 installing HDMF.
@@ -57,26 +69,20 @@ environments.
 The fourth one is requirements-opt.txt_, which lists the pinned (concrete) optional dependencies to use all
 available features in HDMF.
 
-The fifth one is requirements-doc.txt_, which lists the dependencies to generate the documentation for HDMF.
-Both this file and `requirements.txt` are used by ReadTheDocs_ to initialize the local environment for Sphinx to run.
-
-The final one is within setup.py_, which contains a list of package dependencies and their version ranges allowed for
-running HDMF.
-
-In order to check the status of the required packages, requires.io_ is used to create a badge on the project
-README_. If all the required packages are up to date, a green badge appears.
-
-If some of the packages are outdated, see :ref:`update_requirements_files`.
-
 .. _requirements-min.txt: https://github.com/hdmf-dev/hdmf/blob/dev/requirements-min.txt
-.. _setup.py: https://github.com/hdmf-dev/hdmf/blob/dev/setup.py
 .. _requirements.txt: https://github.com/hdmf-dev/hdmf/blob/dev/requirements.txt
 .. _requirements-dev.txt: https://github.com/hdmf-dev/hdmf/blob/dev/requirements-dev.txt
 .. _requirements-opt.txt: https://github.com/hdmf-dev/hdmf/blob/dev/requirements-opt.txt
+
+--------------------------
+Documentation Requirements
+--------------------------
+
+requirements-doc.txt_ lists the dependencies to generate the documentation for HDMF.
+Both this file and `requirements.txt` are used by ReadTheDocs_ to initialize the local environment for Sphinx to run.
+
 .. _requirements-doc.txt: https://github.com/hdmf-dev/hdmf/blob/dev/requirements-doc.txt
 .. _ReadTheDocs: https://readthedocs.org/projects/hdmf/
-.. _requires.io: https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev
-
 
 -------------------------
 Versioning and Releasing


### PR DESCRIPTION
## Motivation

Fix broken link caught by Sphinx checks:
```
(software_process: line   66) broken    https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev - HTTPSConnectionPool(host='requires.io', port=443): Max retries exceeded with url: /github/hdmf-dev/hdmf/requirements/?branch=dev (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7feb49abbc50>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
