### PR TITLE
Update CHANGELOG to fix link to PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Removed unused, deprecated `codecov` package from dev installation requirements. @rly
   [#849](https://github.com/hdmf-dev/hdmf/pull/849)
 - Fixed export with `'link_data': False'` not copying datasets in some situations. @rly
-  [#842](https://github.com/hdmf-dev/hdmf/pull/842)
+  [#848](https://github.com/hdmf-dev/hdmf/pull/848)
 
 ## HDMF 3.5.4 (April 7, 2023)
 


### PR DESCRIPTION
## Motivation

An entry in the changelog was linking to the issue instead of the PR related to the change.


## Checklist

- [N/A] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) foX the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
