### PR TITLE
Convert object arrays to string dtype by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HMDF 3.6.1 (upcoming)
 
 ### Bug fixes
-- Fix compatability with hdmf_zarr for converting string arrays from Zarr to HDF5 by adding logic to determine the dtype for object arrays. @oruebel [#866](https://github.com/hdmf-dev/hdmf/pull/866)
+- Fix compatibility with hdmf_zarr for converting string arrays from Zarr to HDF5 by adding logic to determine the dtype for object arrays. @oruebel [#866](https://github.com/hdmf-dev/hdmf/pull/866)
 
 ## HDMF 3.6.0 (May 12, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HMDF 3.6.1 (upcoming)
+
+### Bug fixes
+- Fix compatability with hdmf_zarr for converting string arrays from Zarr to HDF5 by adding logic to determine the dtype for object arrays. @oruebel [#866](https://github.com/hdmf-dev/hdmf/pull/866)
+
 ## HDMF 3.6.0 (May 12, 2023)
 
 ### New features and minor improvements


### PR DESCRIPTION
## Motivation

This is related to https://github.com/hdmf-dev/hdmf-zarr/issues/79 when we want to convert a file from Zarr to HDF5 using the export function. This leads to errors for datasets of variable-length strings.

## Problem 

As far as I can tell the progression of the error is as follows:

* https://github.com/hdmf-dev/hdmf/pull/848 added a call to `clear_cache` before export. This means that existing builders are discarded and rebuild from containers
* Without `clear_cache` the dtype is determined from the Builder `builder.dtype` which is set correctly when reading from Zarr. However, with `clear_cache` the builders are being recreated, so that the `dtype` needs to be determined from the array directly
* For variable-length strings, hdmf_zarr uses the the convenience method to set  `dtype=str`, which is a short-hand for dtype=object, object_codec=numcodecs.VLenUTF8().  This means, variable length strings are stored as object and are being resolved via the object_coded
* Currently, the `ObjectMapper` does not consider this case, so that `numpy._object` is being returned as the dtype in this case
* This in turn leads to an error in `HDF5IO` because `h5py` does not know how to store generic Python objects. 

## Approach

This PR addresses this problem by setting the `dtype` for all arrays that have an object dtype to be a unicode string. In principle this should be safe (at least right now), because we should never have generic objects as data. However, it seems a more elegant solution would be if we could use the dtype from the original builder. 

@rly what do you think: 1) is the approach in this PR appropriate, 2) is there a better way to determine whether an object array stores strings, instead of just assuming objects are unicode, 3) is the `clear_cache` really necessary or is there an alternate approach.


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
