### PR TITLE
Fix testing of min requirements

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -217,8 +217,6 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-gallery-python3.11-ros3, python-ver: "3.11", os: windows-latest }
-          - { name: macos-gallery-python3.11-ros3  , python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # HDMF Changelog
 
-## HMDF 3.6.1 (May 18, 2023)
+## HDMF 3.6.1 (Upcoming)
+
+## Bug fixes
+- Fixed CI testing of minimum installation requirements, and removed some gallery tests run on each PR. @rly
+  [#877](https://github.com/hdmf-dev/hdmf/pull/877)
+
+## HDMF 3.6.1 (May 18, 2023)
 
 ### Bug fixes
-- Fix compatibility with hdmf_zarr for converting string arrays from Zarr to HDF5 by adding logic to determine the dtype for object arrays. @oruebel [#866](https://github.com/hdmf-dev/hdmf/pull/866)
+- Fixed compatibility with hdmf_zarr for converting string arrays from Zarr to HDF5 by adding logic to determine the dtype for object arrays. @oruebel [#866](https://github.com/hdmf-dev/hdmf/pull/866)
 
 ## HDMF 3.6.0 (May 12, 2023)
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ commands = {[testenv:build]commands}
 [testenv:build-py311-optional]
 basepython = python3.11
 deps =
-    {[testenv:build]deps}
+    {[testenv]deps}
     -rrequirements-opt.txt
 commands = {[testenv:build]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
   PYTHONDONTWRITEBYTECODE = 1
   VIRTUALENV_PIP = 22.3.1
 install_command =
-    python -m pip install -U {opts} {packages}
+    python -m pip install {opts} {packages}
 
 deps =
     -rrequirements-dev.txt
@@ -27,8 +27,6 @@ commands =
 # Test with python 3.11; pinned dev and optional reqs
 [testenv:py311-optional]
 basepython = python3.11
-install_command =
-    python -m pip install {opts} {packages}
 deps =
     -rrequirements-dev.txt
     -rrequirements-opt.txt
@@ -128,7 +126,7 @@ commands = python -c "import hdmf; import hdmf.common"
 # Envs that will execute gallery tests
 [testenv:gallery]
 install_command =
-    python -m pip install -U {opts} {packages}
+    python -m pip install {opts} {packages}
 
 deps =
     -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 [testenv:py311-optional]
 basepython = python3.11
 deps =
-    -rrequirements-dev.txt
+    {[testenv]deps}
     -rrequirements-opt.txt
 commands = {[testenv]commands}
 
@@ -89,7 +89,7 @@ commands = {[testenv:build]commands}
 [testenv:build-py311-optional]
 basepython = python3.11
 deps =
-    -rrequirements-dev.txt
+    {[testenv:build]deps}
     -rrequirements-opt.txt
 commands = {[testenv:build]commands}
 


### PR DESCRIPTION
## Motivation

Fix #876 

Also fix a related issue with testing optional requirements where the upgraded requirements using the flexible requirements in `pyproject.toml` were used.

Also reduce the number of ROS3 tests run on each PR

## How to test the behavior?
```
Run tests
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
