### PR TITLE
Add html repr

### DIFF
--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -504,8 +504,10 @@ class Container(AbstractContainer):
                     or isinstance(value, list)
                     or hasattr(value, "fields")
                 ):
-                    html_repr += f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields ' \
-                                 f'field-key" title="{current_access_code}"><b>{key}</b></summary>'
+                    html_repr += (
+                        f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields '
+                        f'field-key" title="{current_access_code}"><b>{key}</b></summary>'
+                    )
                     if hasattr(value, "fields"):
                         value = value.fields
                         current_access_code = current_access_code + ".fields"
@@ -514,11 +516,17 @@ class Container(AbstractContainer):
                     )
                     html_repr += "</details>"
                 else:
-                    html_repr += f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-key" title="{current_access_code}">{key}:</span> <span class="field-value">{value}</span></div>'
+                    html_repr += (
+                        f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-key"'
+                        f' title="{current_access_code}">{key}:</span> <span class="field-value">{value}</span></div>'
+                    )
         elif isinstance(fields, list):
             for index, item in enumerate(fields):
                 current_access_code = f"{access_code}[{index}]"
-                html_repr += f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-value" title="{current_access_code}">{str(item)}</span></div>'
+                html_repr += (
+                    f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-value"'
+                    f' title="{current_access_code}">{str(item)}</span></div>'
+                )
         else:
             pass
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -455,10 +455,10 @@ class Container(AbstractContainer):
     def _repr_html_(self):
         CSS_STYLE = """
         <style>
-            .nwb-fields { font-family: "Open Sans", Arial, sans-serif; }
-            .nwb-fields .field-value { color: #00788E; }
-            .nwb-fields details > summary { cursor: pointer; }
-            .nwb-fields details > summary:hover { color: #0A6EAA; }
+            .container-fields { font-family: "Open Sans", Arial, sans-serif; }
+            .container-fields .field-value { color: #00788E; }
+            .container-fields details > summary { cursor: pointer; }
+            .container-fields details > summary:hover { color: #0A6EAA; }
         </style>
         """
 
@@ -473,7 +473,7 @@ class Container(AbstractContainer):
             }
 
             document.addEventListener('DOMContentLoaded', function() {
-                let fieldKeys = document.querySelectorAll('.nwb-fields .field-key');
+                let fieldKeys = document.querySelectorAll('.container-fields .field-key');
                 fieldKeys.forEach(function(fieldKey) {
                     fieldKey.addEventListener('click', function() {
                         let accessCode = fieldKey.getAttribute('title').replace('Access code: ', '');
@@ -483,17 +483,15 @@ class Container(AbstractContainer):
             });
         </script>
         """
-        if self.__class__.__name__ == "NWBFile":
-            nwb_header_text = "NWBFile"
-        elif self.name == self.__class__.__name__:
-            nwb_header_text = self.name
+        if self.name == self.__class__.__name__:
+            header_text = self.name
         else:
-            nwb_header_text = f"{self.name} ({self.__class__.__name__})"
+            header_text = f"{self.name} ({self.__class__.__name__})"
         html_repr = CSS_STYLE
         html_repr += JS_SCRIPT
-        html_repr += "<div class='nwb-wrap'>"
+        html_repr += "<div class='container-wrap'>"
         html_repr += (
-            f"<div class='nwb-header'><div class='xr-obj-type'>{nwb_header_text}</div></div>"
+            f"<div class='container-header'><div class='xr-obj-type'>{header_text}</div></div>"
         )
         html_repr += self._generate_html_repr(self.fields)
         html_repr += "</div>"
@@ -511,7 +509,7 @@ class Container(AbstractContainer):
                     or hasattr(value, "fields")
                 ):
                     html_repr += (
-                        f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields '
+                        f'<details><summary style="margin-left: {level * 20}px;" class="container-fields '
                         f'field-key" title="{current_access_code}"><b>{key}</b></summary>'
                     )
                     if hasattr(value, "fields"):
@@ -523,14 +521,14 @@ class Container(AbstractContainer):
                     html_repr += "</details>"
                 else:
                     html_repr += (
-                        f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-key"'
+                        f'<div style="margin-left: {level * 20}px;" class="container-fields"><span class="field-key"'
                         f' title="{current_access_code}">{key}:</span> <span class="field-value">{value}</span></div>'
                     )
         elif isinstance(fields, list):
             for index, item in enumerate(fields):
                 current_access_code = f"{access_code}[{index}]"
                 html_repr += (
-                    f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-value"'
+                    f'<div style="margin-left: {level * 20}px;" class="container-fields"><span class="field-value"'
                     f' title="{current_access_code}">{str(item)}</span></div>'
                 )
         else:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -509,8 +509,8 @@ class Container(AbstractContainer):
                     or hasattr(value, "fields")
                 ):
                     html_repr += (
-                        f'<details><summary style="margin-left: {level * 20}px;" class="container-fields '
-                        f'field-key" title="{current_access_code}"><b>{key}</b></summary>'
+                        f'<details><summary style="display: list-item; margin-left: {level * 20}px;" '
+                        f'class="container-fields field-key" title="{current_access_code}"><b>{key}</b></summary>'
                     )
                     if hasattr(value, "fields"):
                         value = value.fields

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -455,7 +455,7 @@ class Container(AbstractContainer):
     def _repr_html_(self):
         CSS_STYLE = """
         <style>
-            .nwb-fields { font-family: "Segoe UI", Roboto, sans-serif; }
+            .nwb-fields { font-family: "Open Sans", Arial, sans-serif; }
             .nwb-fields .field-value { color: #00788E; }
             .nwb-fields details > summary { cursor: pointer; }
             .nwb-fields details > summary:hover { color: #0A6EAA; }

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -455,10 +455,19 @@ class Container(AbstractContainer):
     def _repr_html_(self):
         CSS_STYLE = """
         <style>
-            .container-fields { font-family: "Open Sans", Arial, sans-serif; }
-            .container-fields .field-value { color: #00788E; }
-            .container-fields details > summary { cursor: pointer; }
-            .container-fields details > summary:hover { color: #0A6EAA; }
+            .container-fields {
+                font-family: "Open Sans", Arial, sans-serif;
+            }
+            .container-fields .field-value {
+                color: #00788E;
+            }
+            .container-fields details > summary {
+                cursor: pointer;
+                display: list-item;
+            }
+            .container-fields details > summary:hover {
+                color: #0A6EAA;
+            }
         </style>
         """
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -456,7 +456,6 @@ class Container(AbstractContainer):
         CSS_STYLE = """
         <style>
             .nwb-fields { font-family: "Segoe UI", Roboto, sans-serif; }
-            .nwb-fields .field-key { font-weight: bold; }
             .nwb-fields .field-value { color: #00788E; }
             .nwb-fields details > summary { cursor: pointer; }
             .nwb-fields details > summary:hover { color: #0A6EAA; }
@@ -490,7 +489,7 @@ class Container(AbstractContainer):
         html_repr += (
             "<div class='nwb-header'><div class='xr-obj-type'>NWB File</div></div>"
         )
-        html_repr += self.generate_html_repr(self.fields)
+        html_repr += self._generate_html_repr(self.fields)
         html_repr += "</div>"
         return html_repr
 
@@ -505,11 +504,12 @@ class Container(AbstractContainer):
                     or isinstance(value, list)
                     or hasattr(value, "fields")
                 ):
-                    html_repr += f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields field-key" title="{current_access_code}">{key}</summary>'
+                    html_repr += f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields ' \
+                                 f'field-key" title="{current_access_code}"><b>{key}</b></summary>'
                     if hasattr(value, "fields"):
                         value = value.fields
                         current_access_code = current_access_code + ".fields"
-                    html_repr += self.generate_html_repr(
+                    html_repr += self._generate_html_repr(
                         value, level + 1, current_access_code
                     )
                     html_repr += "</details>"

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -483,11 +483,17 @@ class Container(AbstractContainer):
             });
         </script>
         """
+        if self.__class__.__name__ == "NWBFile":
+            nwb_header_text = "NWBFile"
+        elif self.name == self.__class__.__name__:
+            nwb_header_text = self.name
+        else:
+            nwb_header_text = f"{self.name} ({self.__class__.__name__})"
         html_repr = CSS_STYLE
         html_repr += JS_SCRIPT
         html_repr += "<div class='nwb-wrap'>"
         html_repr += (
-            "<div class='nwb-header'><div class='xr-obj-type'>NWB File</div></div>"
+            f"<div class='nwb-header'><div class='xr-obj-type'>{nwb_header_text}</div></div>"
         )
         html_repr += self._generate_html_repr(self.fields)
         html_repr += "</div>"

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -500,7 +500,7 @@ class Container(AbstractContainer):
         html_repr += JS_SCRIPT
         html_repr += "<div class='container-wrap'>"
         html_repr += (
-            f"<div class='container-header'><div class='xr-obj-type'>{header_text}</div></div>"
+            f"<div class='container-header'><div class='xr-obj-type'><h3>{header_text}</h3></div></div>"
         )
         html_repr += self._generate_html_repr(self.fields)
         html_repr += "</div>"
@@ -513,8 +513,7 @@ class Container(AbstractContainer):
             for key, value in fields.items():
                 current_access_code = f"{access_code}['{key}']"
                 if (
-                    isinstance(value, dict)
-                    or isinstance(value, list)
+                    isinstance(value, (list, dict, np.ndarray))
                     or hasattr(value, "fields")
                 ):
                     html_repr += (
@@ -540,6 +539,11 @@ class Container(AbstractContainer):
                     f'<div style="margin-left: {level * 20}px;" class="container-fields"><span class="field-value"'
                     f' title="{current_access_code}">{str(item)}</span></div>'
                 )
+        elif isinstance(fields, np.ndarray):
+            str_ = str(fields).replace("\n", "</br>")
+            html_repr += (
+                f'<div style="margin-left: {level * 20}px;" class="container-fields">{str_}</div>'
+            )
         else:
             pass
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -11,6 +11,15 @@ class Subcontainer(Container):
     pass
 
 
+class ContainerWithChild(Container):
+    __fields__ = ({'name': 'field1', 'child': True}, )
+
+    @docval({'name': 'field1', 'doc': 'field1 doc', 'type': None, 'default': None})
+    def __init__(self, **kwargs):
+        super().__init__('test name')
+        self.field1 = kwargs['field1']
+
+
 class TestExternalResourcesManager(TestCase):
     def test_link_and_get_resources(self):
         em = ExternalResourcesManager()
@@ -262,8 +271,56 @@ class TestContainer(TestCase):
         obj.reset_parent()
         self.assertIsNone(obj.parent)
 
+
+class TestHTMLRepr(TestCase):
+
+    class ContainerWithChildAndData(Container):
+        __fields__ = (
+            {'name': 'child', 'child': True},
+            "data",
+            "str"
+        )
+
+        @docval(
+            {'name': 'child', 'doc': 'field1 doc', 'type': Container},
+            {'name': "data", "doc": 'data', 'type': list, "default": None},
+            {'name': "str", "doc": 'str', 'type': str, "default": None},
+
+        )
+        def __init__(self, **kwargs):
+            super().__init__('test name')
+            self.child = kwargs['child']
+            self.data = kwargs['data']
+            self.str = kwargs['str']
+
     def test_repr_html_(self):
-        assert isinstance(Container('obj1')._repr_html_(), str)
+        child_obj1 = Container('test child 1')
+        obj1 = self.ContainerWithChildAndData(child=child_obj1, data=[1, 2, 3], str="hello")
+        assert obj1._repr_html_() == (
+            '\n        <style>\n            .container-fields {\n                font-family: "Open Sans", Arial, sans-'
+            'serif;\n            }\n            .container-fields .field-value {\n                color: #00788E;\n    '
+            '        }\n            .container-fields details > summary {\n                cursor: pointer;\n          '
+            '      display: list-item;\n            }\n            .container-fields details > summary:hover {\n       '
+            '         color: #0A6EAA;\n            }\n        </style>\n        \n        <script>\n            functio'
+            'n copyToClipboard(text) {\n                navigator.clipboard.writeText(text).then(function() {\n        '
+            '            console.log(\'Copied to clipboard: \' + text);\n                }, function(err) {\n          '
+            '          console.error(\'Could not copy text: \', err);\n                });\n            }\n\n          '
+            '  document.addEventListener(\'DOMContentLoaded\', function() {\n                let fieldKeys = document.q'
+            'uerySelectorAll(\'.container-fields .field-key\');\n                fieldKeys.forEach(function(fieldKey) {'
+            '\n                    fieldKey.addEventListener(\'click\', function() {\n                        let acces'
+            'sCode = fieldKey.getAttribute(\'title\').replace(\'Access code: \', \'\');\n                        copyTo'
+            'Clipboard(accessCode);\n                    });\n                });\n            });\n        </script>\n'
+            '        <div class=\'container-wrap\'><div class=\'container-header\'><div class=\'xr-obj-type\'><h3>test '
+            'name (ContainerWithChildAndData)</h3></div></div><details><summary style="display: list-item; margin-left:'
+            ' 0px;" class="container-fields field-key" title=".fields[\'child\']"><b>child</b></summary></details><deta'
+            'ils><summary style="display: list-item; margin-left: 0px;" class="container-fields field-key" title=".fiel'
+            'ds[\'data\']"><b>data</b></summary><div style="margin-left: 20px;" class="container-fields"><span class="f'
+            'ield-value" title=".fields[\'data\'][0]">1</span></div><div style="margin-left: 20px;" class="container-fi'
+            'elds"><span class="field-value" title=".fields[\'data\'][1]">2</span></div><div style="margin-left: 20px;"'
+            ' class="container-fields"><span class="field-value" title=".fields[\'data\'][2]">3</span></div></details><'
+            'div style="margin-left: 0px;" class="container-fields"><span class="field-key" title=".fields[\'str\']">st'
+            'r:</span> <span class="field-value">hello</span></div></div>'
+        )
 
 
 class TestData(TestCase):
@@ -510,14 +567,6 @@ class TestContainerFieldsConf(TestCase):
         self.assertIsNone(obj4.field1)
 
     def test_child(self):
-        class ContainerWithChild(Container):
-            __fields__ = ({'name': 'field1', 'child': True}, )
-
-            @docval({'name': 'field1', 'doc': 'field1 doc', 'type': None, 'default': None})
-            def __init__(self, **kwargs):
-                super().__init__('test name')
-                self.field1 = kwargs['field1']
-
         child_obj1 = Container('test child 1')
         obj1 = ContainerWithChild(child_obj1)
         self.assertIs(child_obj1.parent, obj1)
@@ -535,13 +584,6 @@ class TestContainerFieldsConf(TestCase):
         self.assertIsNone(obj2.field1)
 
     def test_setter_set_modified(self):
-        class ContainerWithChild(Container):
-            __fields__ = ({'name': 'field1', 'child': True}, )
-
-            @docval({'name': 'field1', 'doc': 'field1 doc', 'type': None, 'default': None})
-            def __init__(self, **kwargs):
-                super().__init__('test name')
-                self.field1 = kwargs['field1']
 
         child_obj1 = Container('test child 1')
         obj1 = ContainerWithChild()

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -262,6 +262,9 @@ class TestContainer(TestCase):
         obj.reset_parent()
         self.assertIsNone(obj.parent)
 
+    def test_repr_html_(self):
+        assert isinstance(Container('obj1')._repr_html_(), str)
+
 
 class TestData(TestCase):
 


### PR DESCRIPTION
## Motivation

Inspired by the handy html reprs provided by dask, xarray, and pandas (see [this blog post](https://matthewrocklin.com/blog/2019/07/04/html-repr) for some examples), I wanted to create an easy visual representation of the pynwb file that allows users to:
1. Easily navigate the structure of the nwb file.
2. Display how to navigate to nwb objects via tooltip (e.g. `nwb_file.fields["processing"]["behavior"].fields["data_interfaces"][
    "finger_pos"
].fields["starting_time"]`)
3. Allow the user to easily copy this code.

This visualization only displays when using a jupyter notebook, but I believe enough users use these tools for it to be of use. While this does overlap with some of the functionality of NWB Widgets, it is lighter-weight, requires no additional installation, and does no plotting. The goal is for the user to figure out what is in the contents of the nwb file and access the data quickly.

The code below should show off the functionality for an arbitrary NWB file, although the copying of the tooltip is still a work in progress.

## How to test the behavior?
```python
import pynwb


class NWBDisplay:
    CSS_STYLE = """
    <style>
        .nwb-fields { font-family: "Segoe UI", Roboto, sans-serif; }
        .nwb-fields .field-key { font-weight: bold; }
        .nwb-fields .field-value { color: #00788E; }
        .nwb-fields details > summary { cursor: pointer; }
        .nwb-fields details > summary:hover { color: #0A6EAA; }
    </style>
    """

    JS_SCRIPT = """
    <script>
        function copyToClipboard(text) {
            navigator.clipboard.writeText(text).then(function() {
                console.log('Copied to clipboard: ' + text);
            }, function(err) {
                console.error('Could not copy text: ', err);
            });
        }
        
        document.addEventListener('DOMContentLoaded', function() {
            let fieldKeys = document.querySelectorAll('.nwb-fields .field-key');
            fieldKeys.forEach(function(fieldKey) {
                fieldKey.addEventListener('click', function() {
                    let accessCode = fieldKey.getAttribute('title').replace('Access code: ', '');
                    copyToClipboard(accessCode);
                });
            });
        });
    </script>
    """

    def __init__(self, nwb_obj):
        self.nwb_obj = nwb_obj
        self.fields = nwb_obj.fields

    def _repr_html_(self):
        html_repr = self.CSS_STYLE
        html_repr += self.JS_SCRIPT
        html_repr += "<div class='nwb-wrap'>"
        html_repr += (
            "<div class='nwb-header'><div class='xr-obj-type'>NWB File</div></div>"
        )
        html_repr += self.generate_html_repr(self.fields)
        html_repr += "</div>"
        return html_repr

    def generate_html_repr(self, fields, level=0, access_code=".fields"):
        html_repr = ""

        if isinstance(fields, dict):
            for key, value in fields.items():
                current_access_code = f"{access_code}['{key}']"
                if (
                    isinstance(value, dict)
                    or isinstance(value, list)
                    or hasattr(value, "fields")
                ):
                    html_repr += f'<details><summary style="margin-left: {level * 20}px;" class="nwb-fields field-key" title="{current_access_code}">{key}</summary>'
                    if hasattr(value, "fields"):
                        value = value.fields
                        current_access_code = current_access_code + ".fields"
                    html_repr += self.generate_html_repr(
                        value, level + 1, current_access_code
                    )
                    html_repr += "</details>"
                else:
                    html_repr += f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-key" title="{current_access_code}">{key}:</span> <span class="field-value">{value}</span></div>'
        elif isinstance(fields, list):
            for index, item in enumerate(fields):
                current_access_code = f"{access_code}[{index}]"
                html_repr += f'<div style="margin-left: {level * 20}px;" class="nwb-fields"><span class="field-value" title="{current_access_code}">{str(item)}</span></div>'
        else:
            pass

        return html_repr


nwb_file = pynwb.NWBHDF5IO(
    "test.nwb", mode="r"
).read()

NWBDisplay(nwb_file)
```

### Example display
<img width="1073" alt="image" src="https://github.com/hdmf-dev/hdmf/assets/8053989/bfa40a25-6e5e-40a3-aefe-bf8aa720e37a">
