### PR TITLE
improve html output

### DIFF
--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -512,9 +512,10 @@ class Container(AbstractContainer):
         if isinstance(fields, dict):
             for key, value in fields.items():
                 current_access_code = f"{access_code}['{key}']"
+                if isinstance(value, (list, dict)) and not value:
+                    continue
                 if (
-                    isinstance(value, np.ndarray)
-                    or isinstance(value, (list, dict, np.ndarray))
+                    isinstance(value, (list, dict, np.ndarray))
                     or hasattr(value, "fields")
                 ):
                     html_repr += (

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -513,7 +513,8 @@ class Container(AbstractContainer):
             for key, value in fields.items():
                 current_access_code = f"{access_code}['{key}']"
                 if (
-                    isinstance(value, (list, dict, np.ndarray))
+                    isinstance(value, np.ndarray)
+                    or isinstance(value, (list, dict, np.ndarray))
                     or hasattr(value, "fields")
                 ):
                     html_repr += (


### PR DESCRIPTION
@edeno 

current:

Summary expandable is rendered for fields that are empty. See the expanded groups at the bottom that are empty:

![image](https://github.com/hdmf-dev/hdmf/assets/844306/4d4c0b4e-c602-4337-bf1f-a23c098a9e6d)


option 1: render them as empty

![image](https://github.com/hdmf-dev/hdmf/assets/844306/c1b4269a-ba28-450d-ae8e-eb653a66c353)

option 2: don't render them

![image](https://github.com/hdmf-dev/hdmf/assets/844306/ec93465d-7c32-4d52-bf16-980104379139)


I have a slight preference for  option 2, but I think option 1 would be fine and would be an improvement.
