### PR TITLE
Warning for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features and minor improvements
 - Updated `ExternalResources` to have EntityKeyTable with updated tests/documentation and minor bug fix to ObjectKeyTable. @mavaylon1 [#872](https://github.com/hdmf-dev/hdmf/pull/872)
-- Added warning for links that are not added to the same parent as the host object. @mavaylon1 [#891](https://github.com/hdmf-dev/hdmf/pull/891)
+- Added warning for DynamicTableRegion links that are not added to the same parent as the original container object. @mavaylon1 [#891](https://github.com/hdmf-dev/hdmf/pull/891)
 
 ## HMDF 3.6.1 (May 18, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features and minor improvements
 - Updated `ExternalResources` to have EntityKeyTable with updated tests/documentation and minor bug fix to ObjectKeyTable. @mavaylon1 [#872](https://github.com/hdmf-dev/hdmf/pull/872)
+- Added warning for links that are not added to the same parent as the host object. @mavaylon1 [#891](https://github.com/hdmf-dev/hdmf/pull/891)
 
 ## HMDF 3.6.1 (May 18, 2023)
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -331,7 +331,6 @@ class AbstractContainer(metaclass=ExtenderMeta):
 
     @parent.setter
     def parent(self, parent_container):
-        # breakpoint()
         if self.parent is parent_container:
             return
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -331,6 +331,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
 
     @parent.setter
     def parent(self, parent_container):
+        # breakpoint()
         if self.parent is parent_container:
             return
 
@@ -354,6 +355,13 @@ class AbstractContainer(metaclass=ExtenderMeta):
             if isinstance(parent_container, Container):
                 parent_container.__children.append(self)
                 parent_container.set_modified()
+            for child in self.children:
+                if type(child).__name__ == "DynamicTableRegion":
+                    if child.table.parent is None:
+                        msg = "The table for this DynamicTableRegion has not been added to the parent."
+                        warn(msg)
+                    else:
+                        continue
 
     def _remove_child(self, child):
         """Remove a child Container. Intended for use in subclasses that allow dynamic addition of child Containers."""

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -5,6 +5,7 @@ from hdmf.container import AbstractContainer, Container, Data, ExternalResources
 from hdmf.common.resources import ExternalResources
 from hdmf.testing import TestCase
 from hdmf.utils import docval
+from hdmf.common import (DynamicTable, VectorData, DynamicTableRegion)
 
 
 class Subcontainer(Container):
@@ -135,6 +136,47 @@ class TestContainer(TestCase):
         self.assertIs(child_obj.parent, parent_obj)
         self.assertTrue(parent_obj.modified)
         self.assertIs(parent_obj.children[0], child_obj)
+
+    def test_parent_set_link_warning(self):
+        col1 = VectorData(
+            name='col1',
+            description='column #1',
+            data=[1, 2],
+        )
+        col2 = VectorData(
+            name='col2',
+            description='column #2',
+            data=['a', 'b'],
+        )
+
+        # this table will have two rows with ids 0 and 1
+        table = DynamicTable(
+            name='my table',
+            description='an example table',
+            columns=[col1, col2],
+        )
+
+        dtr_col = DynamicTableRegion(
+            name='table1_ref',
+            description='references rows of earlier table',
+            data=[0, 1, 0, 0],  # refers to row indices of the 'table' variable
+            table=table
+        )
+
+        data_col = VectorData(
+            name='col2',
+            description='column #2',
+            data=['a', 'a', 'a', 'b'],
+        )
+
+        table2 = DynamicTable(
+            name='my_table',
+            description='an example table',
+            columns=[dtr_col, data_col],
+        )
+
+        with self.assertWarns(Warning):
+            table2.parent=ContainerWithChild()
 
     def test_set_parent_exists(self):
         """Test that setting a parent a second time does nothing


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Create a warning if linked objects are not already present in a parent when the original container's parent is set, stemming from the fact when objects that have links are added to containers (NWBFiles), the links are not added.

The Fix: Add a warning in the parent setter to search through the children of the original object for DynamicTableRegion and check the target table for a parent. If the parent is not set, raise a warning.

Original issue: https://github.com/NeurodataWithoutBorders/pynwb/issues/1701 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
Run tests for container.py
## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
