### PR TITLE
Remove broken conda install line in developer docs

### DIFF
--- a/docs/source/install_developers.rst
+++ b/docs/source/install_developers.rst
@@ -94,12 +94,7 @@ package requirements using the pip_ Python package manager, and install HDMF in 
 .. note::
 
    When using ``conda``, you may use ``pip install`` to install dependencies as shown above; however, it is generally
-   recommended that dependencies should be installed via ``conda install``, e.g.,
-
-   .. code:: bash
-
-      conda install --file=requirements.txt --file=requirements-dev.txt --file=requirements-doc.txt \
-      --file=requirements-opt.txt
+   recommended that dependencies should be installed via ``conda install``.
 
 
 Run tests


### PR DESCRIPTION
## Motivation

conda install with the requirements files is not working. This removes the broken command from the docs. 

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
