### PR TITLE
ExternalResources I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `ExternalResources` to have EntityKeyTable with updated tests/documentation and minor bug fix to ObjectKeyTable. @mavaylon1 [#872](https://github.com/hdmf-dev/hdmf/pull/872)
 - Added warning for DynamicTableRegion links that are not added to the same parent as the original container object. @mavaylon1 [#891](https://github.com/hdmf-dev/hdmf/pull/891)
 - Added the `TermSet` class along with integrated validation methods for any child of `AbstractContainer`, e.g., `VectorData`, `Data`, `DynamicTable`. @mavaylon1 [#880](https://github.com/hdmf-dev/hdmf/pull/880)
+- Updated `HDMFIO` and `HDF5IO` to support `ExternalResources`. @mavaylon1 [#895](https://github.com/hdmf-dev/hdmf/pull/895)
 
 ### Documentation and tutorial enhancements:
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -48,15 +48,15 @@ class HDF5IO(HDMFIO):
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
             {'name': 'file', 'type': [File, "S3File"], 'doc': 'a pre-existing h5py.File object', 'default': None},
             {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None},
-            {'name': 'external_resources', 'type': str,
+            {'name': 'external_resources_path', 'type': str,
              'doc': 'The path to the ExternalResources', 'default': None},)
     def __init__(self, **kwargs):
         """Open an HDF5 file for IO.
         """
         self.logger = logging.getLogger('%s.%s' % (self.__class__.__module__, self.__class__.__qualname__))
-        path, manager, mode, comm, file_obj, driver, external_resources = popargs('path', 'manager', 'mode',
-                                                                                  'comm', 'file', 'driver',
-                                                                                  'external_resources', kwargs)
+        path, manager, mode, comm, file_obj, driver, external_resources_path = popargs('path', 'manager', 'mode',
+                                                                                       'comm', 'file', 'driver',
+                                                                                       'external_resources_path', kwargs)
 
         self.__open_links = []  # keep track of other files opened from links in this file
         self.__file = None  # This will be set below, but set to None first in case an error occurs and we need to close
@@ -79,7 +79,7 @@ class HDF5IO(HDMFIO):
         self.__comm = comm
         self.__mode = mode
         self.__file = file_obj
-        super().__init__(manager, source=path, external_resources=external_resources)
+        super().__init__(manager, source=path, external_resources_path=external_resources_path)
         # NOTE: source is not set if path is None and file_obj is passed
         self.__built = dict()       # keep track of each builder for each dataset/group/link for each file
         self.__read = dict()        # keep track of which files have been read. Key is the filename value is the builder

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -54,9 +54,9 @@ class HDF5IO(HDMFIO):
         """Open an HDF5 file for IO.
         """
         self.logger = logging.getLogger('%s.%s' % (self.__class__.__module__, self.__class__.__qualname__))
-        path, manager, mode, comm, file_obj, driver, external_resources = popargs('path', 'manager', 'mode', 'comm',
-                                                                                  'file', 'driver', 'external_resources',
-                                                                                  kwargs)
+        path, manager, mode, comm, file_obj, driver, external_resources = popargs('path', 'manager', 'mode',
+                                                                                  'comm', 'file', 'driver',
+                                                                                  'external_resources', kwargs)
 
         self.__open_links = []  # keep track of other files opened from links in this file
         self.__file = None  # This will be set below, but set to None first in case an error occurs and we need to close
@@ -79,7 +79,8 @@ class HDF5IO(HDMFIO):
         self.__comm = comm
         self.__mode = mode
         self.__file = file_obj
-        super().__init__(manager, source=path, external_resources=external_resources)  # NOTE: source is not set if path is None and file_obj is passed
+        super().__init__(manager, source=path, external_resources=external_resources)
+        # NOTE: source is not set if path is None and file_obj is passed
         self.__built = dict()       # keep track of each builder for each dataset/group/link for each file
         self.__read = dict()        # keep track of which files have been read. Key is the filename value is the builder
         self.__ref_queue = deque()  # a queue of the references that need to be added

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -56,7 +56,8 @@ class HDF5IO(HDMFIO):
         self.logger = logging.getLogger('%s.%s' % (self.__class__.__module__, self.__class__.__qualname__))
         path, manager, mode, comm, file_obj, driver, external_resources_path = popargs('path', 'manager', 'mode',
                                                                                        'comm', 'file', 'driver',
-                                                                                       'external_resources_path', kwargs)
+                                                                                       'external_resources_path',
+                                                                                       kwargs)
 
         self.__open_links = []  # keep track of other files opened from links in this file
         self.__file = None  # This will be set below, but set to None first in case an error occurs and we need to close

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -47,13 +47,16 @@ class HDF5IO(HDMFIO):
             {'name': 'comm', 'type': 'Intracomm',
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
             {'name': 'file', 'type': [File, "S3File"], 'doc': 'a pre-existing h5py.File object', 'default': None},
-            {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None})
+            {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None},
+            {'name': 'external_resources', 'type': str,
+             'doc': 'The path to the ExternalResources', 'default': None},)
     def __init__(self, **kwargs):
         """Open an HDF5 file for IO.
         """
         self.logger = logging.getLogger('%s.%s' % (self.__class__.__module__, self.__class__.__qualname__))
-        path, manager, mode, comm, file_obj, driver = popargs('path', 'manager', 'mode', 'comm', 'file', 'driver',
-                                                              kwargs)
+        path, manager, mode, comm, file_obj, driver, external_resources = popargs('path', 'manager', 'mode', 'comm',
+                                                                                  'file', 'driver', 'external_resources',
+                                                                                  kwargs)
 
         self.__open_links = []  # keep track of other files opened from links in this file
         self.__file = None  # This will be set below, but set to None first in case an error occurs and we need to close
@@ -76,7 +79,7 @@ class HDF5IO(HDMFIO):
         self.__comm = comm
         self.__mode = mode
         self.__file = file_obj
-        super().__init__(manager, source=path)  # NOTE: source is not set if path is None and file_obj is passed
+        super().__init__(manager, source=path, external_resources=external_resources)  # NOTE: source is not set if path is None and file_obj is passed
         self.__built = dict()       # keep track of each builder for each dataset/group/link for each file
         self.__read = dict()        # keep track of which files have been read. Key is the filename value is the builder
         self.__ref_queue = deque()  # a queue of the references that need to be added

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -12,9 +12,11 @@ class HDMFIO(metaclass=ABCMeta):
     @docval({'name': 'manager', 'type': BuildManager,
              'doc': 'the BuildManager to use for I/O', 'default': None},
             {"name": "source", "type": (str, Path),
-             "doc": "the source of container being built i.e. file path", 'default': None})
+             "doc": "the source of container being built i.e. file path", 'default': None},
+            {'name': 'external_resources', 'type': str,
+             'doc': 'The path to the ExternalResources', 'default': None},)
     def __init__(self, **kwargs):
-        manager, source = getargs('manager', 'source', kwargs)
+        manager, source, external_resources = getargs('manager', 'source', 'external_resources', kwargs)
         if isinstance(source, Path):
             source = source.resolve()
         elif (isinstance(source, str) and
@@ -26,6 +28,7 @@ class HDMFIO(metaclass=ABCMeta):
         self.__manager = manager
         self.__built = dict()
         self.__source = source
+        self.external_resources = external_resources
         self.open()
 
     @property

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -53,6 +53,8 @@ class HDMFIO(metaclass=ABCMeta):
         if self.external_resources_path is not None:
             from hdmf.common import ExternalResources
             self.external_resources = ExternalResources.from_norm_tsv(path=self.external_resources_path)
+            if isinstance(container, ExternalResourcesManager):
+                container.link_resources(external_resources=self.external_resources)
         return container
 
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -13,10 +13,10 @@ class HDMFIO(metaclass=ABCMeta):
              'doc': 'the BuildManager to use for I/O', 'default': None},
             {"name": "source", "type": (str, Path),
              "doc": "the source of container being built i.e. file path", 'default': None},
-            {'name': 'external_resources', 'type': str,
+            {'name': 'external_resources_path', 'type': str,
              'doc': 'The path to the ExternalResources', 'default': None},)
     def __init__(self, **kwargs):
-        manager, source, external_resources = getargs('manager', 'source', 'external_resources', kwargs)
+        manager, source, external_resources_path = getargs('manager', 'source', 'external_resources_path', kwargs)
         if isinstance(source, Path):
             source = source.resolve()
         elif (isinstance(source, str) and
@@ -28,7 +28,8 @@ class HDMFIO(metaclass=ABCMeta):
         self.__manager = manager
         self.__built = dict()
         self.__source = source
-        self.external_resources = external_resources
+        self.external_resources_path = external_resources_path
+        self.external_resources = None
         self.open()
 
     @property
@@ -49,6 +50,9 @@ class HDMFIO(metaclass=ABCMeta):
             # TODO also check that the keys are appropriate. print a better error message
             raise UnsupportedOperation('Cannot build data. There are no values.')
         container = self.__manager.construct(f_builder)
+        if self.external_resources_path is not None:
+            from hdmf.common import ExternalResources
+            self.external_resources = ExternalResources.from_norm_tsv(path=self.external_resources_path)
         return container
 
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -3,7 +3,7 @@ import tempfile
 from copy import copy, deepcopy
 
 from hdmf.build import BuildManager, ObjectMapper, TypeMap
-from hdmf.container import Container, Data
+from hdmf.container import Container, ExternalResourcesManager, Data
 from hdmf.spec import (
     AttributeSpec,
     DatasetSpec,
@@ -117,7 +117,7 @@ class FooBucket(Container):
         return foo
 
 
-class FooFile(Container):
+class FooFile(Container, ExternalResourcesManager):
     """
     NOTE: if the ROOT_NAME for the backend is not 'root' then we must set FooFile.ROOT_NAME before use
           and should be reset to 'root' when use is finished to avoid potential cross-talk between tests.


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

This is to add logic to support ExternalResources on HDMFIO and HDF5IO. This was set up due to pynwb (https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/5488375497?pr=1684). The update simply sets up external resources in the corresponding init methods.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
