### PR TITLE
Update make_a_release.rst to fix broken sphinx links

### DIFF
--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -221,8 +221,8 @@ In order to release a new version on conda-forge manually, follow the steps belo
 
 6. Modify ``meta.yaml``.
 
-   Update the `version string <https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml#L2>`_ and
-   `sha256 <https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml#L3>`_.
+   Update the `version string (line 2) <https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml>`_ and
+   `sha256 (line 3) <https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml>`_.
 
    We have to modify the sha and the version string in the ``meta.yaml`` file.
 


### PR DESCRIPTION
## Motivation

For some reason, Sphinx no longer recognizes https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml#L2 as a valid anchor. See
https://github.com/hdmf-dev/hdmf/actions/runs/5498163184/jobs/10019445276

```
(  make_a_release: line  224) broken    https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml#L2 - Anchor 'L2' not found
(  make_a_release: line  224) broken    https://github.com/conda-forge/hdmf-feedstock/blob/main/recipe/meta.yaml#L3 - Anchor 'L3' not found
```

It could have been due to changes to the github website

Solution: no longer use those anchors.


## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
