### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,7 +62,6 @@ body:
     attributes:
       label: Python Version
       options:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -22,24 +22,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: linux-python3.8              , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
           - { name: linux-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.11-optional    , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.11-prerelease  , test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }
-          - { name: windows-python3.8            , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: windows-latest }
           - { name: windows-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.11-optional  , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.11-prerelease, test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: windows-latest }
-          - { name: macos-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: macos-latest }
-          - { name: macos-python3.8              , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: macos-latest }
           - { name: macos-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: macos-latest }
           - { name: macos-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: macos-latest }
@@ -92,13 +89,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.7-minimum      , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: linux-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-gallery-python3.7-minimum    , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: windows-latest }
+          - { name: windows-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: windows-latest }
           - { name: windows-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: windows-latest }
           - { name: windows-gallery-python3.11-prerelease, test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: windows-latest }
-          - { name: macos-gallery-python3.7-minimum      , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: macos-latest }
+          - { name: macos-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: macos-latest }
           - { name: macos-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: macos-latest }
           - { name: macos-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: macos-latest }
     steps:
@@ -138,8 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: conda-linux-python3.8            , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: conda-linux-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
           - { name: conda-linux-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
@@ -168,8 +164,7 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          # the conda dependency resolution for tox under python 3.7 can install the wrong importlib_metadata
-          conda install -c conda-forge tox "importlib_metadata>4"
+          conda install -c conda-forge tox
 
       - name: Conda reporting
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: linux-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
-          - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }
+          - { name: windows-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: windows-latest }
           - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
-          - { name: macos-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: macos-latest }
+          - { name: macos-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: macos-latest }
           - { name: macos-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
@@ -80,9 +80,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.7-minimum    , test-tox-env: gallery-py37-minimum  , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: linux-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum  , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-gallery-python3.7-minimum  , test-tox-env: gallery-py37-minimum  , python-ver: "3.7" , os: windows-latest }
+          - { name: windows-gallery-python3.8-minimum  , test-tox-env: gallery-py38-minimum  , python-ver: "3.8" , os: windows-latest }
           - { name: windows-gallery-python3.11-upgraded, test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: windows-latest }
     steps:
       - name: Cancel non-latest runs
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
@@ -144,8 +144,7 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          # the conda dependency resolution for tox under python 3.7 can install the wrong importlib_metadata
-          conda install -c conda-forge tox "importlib_metadata>4"
+          conda install -c conda-forge tox
 
       - name: Conda reporting
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # HDMF Changelog
 
-## HMDF 3.6.2 (Upcoming)
+## HMDF 3.7.0 (Upcoming)
 
 ### New features and minor improvements
 - Updated `ExternalResources` to have EntityKeyTable with updated tests/documentation and minor bug fix to ObjectKeyTable. @mavaylon1 [#872](https://github.com/hdmf-dev/hdmf/pull/872)
 - Added warning for DynamicTableRegion links that are not added to the same parent as the original container object. @mavaylon1 [#891](https://github.com/hdmf-dev/hdmf/pull/891)
 - Added the `TermSet` class along with integrated validation methods for any child of `AbstractContainer`, e.g., `VectorData`, `Data`, `DynamicTable`. @mavaylon1 [#880](https://github.com/hdmf-dev/hdmf/pull/880)
 - Updated `HDMFIO` and `HDF5IO` to support `ExternalResources`. @mavaylon1 [#895](https://github.com/hdmf-dev/hdmf/pull/895)
+- Dropped Python 3.7 support. @rly [#897](https://github.com/hdmf-dev/hdmf/pull/897)
 
 ### Documentation and tutorial enhancements:
 

--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -4,7 +4,7 @@
 Installing HDMF
 ---------------
 
-HDMF requires having Python 3.7, 3.8, 3.9, 3.10, or 3.11 installed. If you don't have Python installed and want the simplest way to
+HDMF requires having Python 3.8, 3.9, 3.10, or 3.11 installed. If you don't have Python installed and want the simplest way to
 get started, we recommend you install and use the `Anaconda Distribution`_. It includes Python, NumPy, and many other
 commonly used packages for scientific computing and data science.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,10 @@ authors = [
 ]
 description = "A hierarchical data modeling framework for modern science data standards"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -32,11 +31,10 @@ classifiers = [
 dependencies = [
     "h5py>=2.10",
     "jsonschema>=2.6.0",
-    "numpy>=1.16",
+    "numpy>=1.18",
     "pandas>=1.0.5",
     "ruamel.yaml>=0.16",
-    "scipy>=1.1",
-    "importlib-metadata<4.3; python_version < '3.8'",  # TODO: remove when minimum python version is 3.8
+    "scipy>=1.4",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
 ]
 dynamic = ["version"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,11 +5,9 @@
 black==23.3.0
 codespell==2.2.4
 coverage==7.2.5
-pre-commit==3.3.1; python_version >= "3.8"
-pre-commit==2.21.0; python_version < "3.8"  # pre-commit 3 dropped python 3.7 support
+pre-commit==3.3.1
 pytest==7.3.1
 pytest-cov==4.0.0
 python-dateutil==2.8.2
 ruff==0.0.265
-tox==4.5.1; python_version >= "3.8"
-tox==3.28.0; python_version < "3.8"  # tox 4+ has virtualenv requirements that are incompatible with other pkgs
+tox==4.5.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,12 +1,11 @@
 # minimum versions of package dependencies for installing HDMF
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-importlib-metadata==4.2.0; python_version < "3.8"  # TODO: remove when minimum python version is 3.8
 importlib-resources==5.12.0; python_version < "3.9"  # TODO: remove when when minimum python version is 3.9
 jsonschema==3.2.0
-numpy==1.16  # numpy>=1.16,<1.18 does not provide wheels for python 3.8 and does not build well on windows
+numpy==1.18
 pandas==1.0.5  # when this is changed to >=1.5.0, see TODO items referenced in #762
 ruamel.yaml==0.16
-scipy==1.1  # scipy>=1.1,<1.4 does not provide wheels for python 3.8 and building scipy can fail due to incompatibilities with numpy
+scipy==1.4
 linkml-runtime==1.5.0
 tqdm==4.41.0
 zarr==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF
-# note that python 3.7 end of life is 27 Jun 2023
 h5py==3.8.0
-importlib-metadata==4.2.0; python_version < "3.8"  # TODO: remove when minimum python version is 3.8
 importlib-resources==5.12.0; python_version < "3.9"  # TODO: remove when when minimum python version is 3.9
 jsonschema==4.17.3
-numpy==1.24.3; python_version >= "3.8"
-numpy==1.21.5; python_version < "3.8"  # numpy 1.22 dropped python 3.7 support
-pandas==2.0.1; python_version >= "3.8"
-pandas==1.3.5; python_version < "3.8"  # pandas 1.4 dropped python 3.7 support
+numpy==1.24.3
+pandas==2.0.1
 ruamel.yaml==0.17.24
-scipy==1.10.1; python_version >= "3.8"
-scipy==1.7.3; python_version < "3.8"   # scipy 1.8 dropped python 3.7 support
+scipy==1.10.1

--- a/src/hdmf/__init__.py
+++ b/src/hdmf/__init__.py
@@ -27,11 +27,7 @@ def get_region_slicer(**kwargs):
     return None
 
 
-try:
-    from importlib.metadata import version  # noqa: E402
-except ImportError:
-    # TODO: Remove when python 3.8 becomes the new minimum
-    from importlib_metadata import version  # noqa: E402
+from importlib.metadata import version  # noqa: E402
 
 __version__ = version(__package__)
 del version

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1,7 +1,5 @@
 import copy
 import math
-import functools  # TODO: remove when Python 3.7 support is dropped - see #785
-import operator  # TODO: remove when Python 3.7 support is dropped
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from warnings import warn
@@ -237,15 +235,11 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             f"evenly divide the buffer shape ({self.buffer_shape})!"
         )
 
-        # TODO: replace with below when Python 3.7 support is dropped
-        # self.num_buffers = math.prod(
-        self.num_buffers = functools.reduce(
-            operator.mul,
+        self.num_buffers = math.prod(
             [
                 math.ceil(maxshape_axis / buffer_axis)
                 for buffer_axis, maxshape_axis in zip(self.buffer_shape, self.maxshape)
             ],
-            1,
         )
         self.buffer_selection_generator = (
             tuple(
@@ -311,15 +305,11 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
 
         min_maxshape = min(self.maxshape)
         v = tuple(math.floor(maxshape_axis / min_maxshape) for maxshape_axis in self.maxshape)
-        # TODO: replace with below when Python 3.7 support is dropped
-        # prod_v = math.prod(v)
-        prod_v = functools.reduce(operator.mul, v, 1)
+        prod_v = math.prod(v)
         while prod_v * itemsize > chunk_bytes and prod_v != 1:
             non_unit_min_v = min(x for x in v if x != 1)
             v = tuple(math.floor(x / non_unit_min_v) if x != 1 else x for x in v)
-            # TODO: replace with below when Python 3.7 support is dropped
-            # prod_v = math.prod(v)
-            prod_v = functools.reduce(operator.mul, v, 1)
+            prod_v = math.prod(v)
         k = math.floor((chunk_bytes / (prod_v * itemsize)) ** (1 / n_dims))
         return tuple([min(k * x, self.maxshape[dim]) for dim, x in enumerate(v)])
 
@@ -346,9 +336,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
 
         k = math.floor(
             (
-                # TODO: replace with below when Python 3.7 support is dropped
-                # buffer_gb * 1e9 / (math.prod(self.chunk_shape) * self.dtype.itemsize)
-                buffer_gb * 1e9 / (functools.reduce(operator.mul, self.chunk_shape, 1) * self.dtype.itemsize)
+                buffer_gb * 1e9 / (math.prod(self.chunk_shape) * self.dtype.itemsize)
             ) ** (1 / len(self.chunk_shape))
         )
         return tuple(

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311
 requires = pip >= 22.0
 
 [testenv]
@@ -52,9 +52,9 @@ deps =
     -rrequirements-opt.txt
 commands = {[testenv]commands}
 
-# Test with python 3.7; pinned dev reqs; minimum run reqs
-[testenv:py37-minimum]
-basepython = python3.7
+# Test with python 3.8; pinned dev reqs; minimum run reqs
+[testenv:py38-minimum]
+basepython = python3.8
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -65,10 +65,6 @@ commands = {[testenv]commands}
 commands =
     python -m pip install --upgrade build
     python -m build
-
-[testenv:build-py37]
-basepython = python3.7
-commands = {[testenv:build]commands}
 
 [testenv:build-py38]
 basepython = python3.8
@@ -111,8 +107,8 @@ deps =
     -rrequirements-opt.txt
 commands = {[testenv:build]commands}
 
-[testenv:build-py37-minimum]
-basepython = python3.7
+[testenv:build-py38-minimum]
+basepython = python3.8
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -178,9 +174,9 @@ deps =
     -rrequirements-opt.txt
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.7; pinned dev and doc reqs; minimum run reqs
-[testenv:gallery-py37-minimum]
-basepython = python3.7
+# Test with python 3.8; pinned dev and doc reqs; minimum run reqs
+[testenv:gallery-py38-minimum]
+basepython = python3.8
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt


### PR DESCRIPTION
## Motivation

Python 3.7 has reached official end of life support. Most packages in the scientific python ecosystem have dropped support for Python 3.7 in new releases months ago. Maintaining Python 3.7 support means:
1) having to debug CI workflows that fail due to an issue with 3.7 compatibility in dependencies (this has happened with `importlib_metadata` and `zipp` already)
2) waiting longer for CI to complete / using more CI computational resources
3) adding try/excepts and other workarounds in order to use python features and features from our dependencies that exist only in python 3.8+. 

... at the benefit of continuing to support systems that cannot upgrade to Python 3.8+, a use case which we have not heard from.

As a result, I suggest we drop support for Python 3.7. 

Also fix #785.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
