### PR TITLE
Fix GenericDataChunkIteratorTests.test_abstract_assertions for Python 3.12

### DIFF
--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from shutil import rmtree
 from typing import Tuple, Iterable
+from sys import version_info
 
 import h5py
 
@@ -90,6 +91,9 @@ class GenericDataChunkIteratorTests(TestCase):
             exc_msg=(
                 "Can't instantiate abstract class TestGenericDataChunkIterator with abstract methods "
                 "_get_data, _get_dtype, _get_maxshape"
+            ) if version_info < (3, 12) else (
+                "Can't instantiate abstract class TestGenericDataChunkIterator without an "
+                "implementation for abstract methods '_get_data', '_get_dtype', '_get_maxshape'"
             ),
         ):
             TestGenericDataChunkIterator()


### PR DESCRIPTION
The exception message has changed slightly.

## Motivation

Fix a test failure in hdmf 3.6.1 [in Fedora Linux Rawhide](https://bugzilla.redhat.com/show_bug.cgi?id=2220270) (development version) with Python 3.12.0b3.

```
=================================== FAILURES ===================================
____________ GenericDataChunkIteratorTests.test_abstract_assertions ____________
TypeError: Can't instantiate abstract class TestGenericDataChunkIterator without an implementation for abstract methods '_get_data', '_get_dtype', '_get_maxshape'
During handling of the above exception, another exception occurred:
self = <tests.unit.utils_test.test_core_GenericDataChunkIterator.GenericDataChunkIteratorTests testMethod=test_abstract_assertions>
    def test_abstract_assertions(self):
        class TestGenericDataChunkIterator(GenericDataChunkIterator):
            pass
    
>       with self.assertRaisesWith(
            exc_type=TypeError,
            exc_msg=(
                "Can't instantiate abstract class TestGenericDataChunkIterator with abstract methods "
                "_get_data, _get_dtype, _get_maxshape"
            ),
        ):
E       AssertionError: "^Can't\ instantiate\ abstract\ class\ TestGenericDataChunkIterator\ with\ abstract\ methods\ _get_data,\ _get_dtype,\ _get_maxshape$" does not match "Can't instantiate abstract class TestGenericDataChunkIterator without an implementation for abstract methods '_get_data', '_get_dtype', '_get_maxshape'"
tests/unit/utils_test/test_core_GenericDataChunkIterator.py:88: AssertionError
```

## How to test the behavior?

This is tricky since the `tox` machinery isn’t set up for Python 3.12 yet. I can vouch that it fixes the test failure in the Fedora build infrastructure.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes? **No, this is a trivial test fix that might not belong in the changelog.**
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged. **N/A, I did not file an issue**
