### PR TITLE
assign a filler to __version__ if it cannot be imported

### DIFF
--- a/src/hdmf/__init__.py
+++ b/src/hdmf/__init__.py
@@ -31,7 +31,11 @@ try:
     # see https://effigies.gitlab.io/posts/python-packaging-2023/
     from ._version import __version__
 except ImportError:  # pragma: no cover
-    __version__ = "unknown"
+    # this is a relatively slower method for getting the version string
+    from importlib.metadata import version  # noqa: E402
+    
+    __version__ = version("hdmf")
+    del version
 
 
 from ._due import BibTeX, due  # noqa: E402

--- a/src/hdmf/__init__.py
+++ b/src/hdmf/__init__.py
@@ -33,7 +33,7 @@ try:
 except ImportError:  # pragma: no cover
     # this is a relatively slower method for getting the version string
     from importlib.metadata import version  # noqa: E402
-    
+
     __version__ = version("hdmf")
     del version
 

--- a/src/hdmf/__init__.py
+++ b/src/hdmf/__init__.py
@@ -31,7 +31,7 @@ try:
     # see https://effigies.gitlab.io/posts/python-packaging-2023/
     from ._version import __version__
 except ImportError:  # pragma: no cover
-    pass
+    __version__ = "unknown"
 
 
 from ._due import BibTeX, due  # noqa: E402


### PR DESCRIPTION
## Motivation

fix #905
