### PR TITLE
TermSet get attribute replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.7.1 (Upcoming)
+
+### Bug fixes
+- Fixed bug on `add_ref_term_set` in which attributes that were not subscribtable returned an error. @mavaylon1 [#909](https://github.com/hdmf-dev/hdmf/pull/909)
+
 ## HDMF 3.7.0 (July 10, 2023)
 
 ### New features and minor improvements
@@ -17,7 +22,7 @@
 ### Documentation and tutorial enhancements:
 - Added tutorial for the new `TermSet` class @mavaylon1 [#880](https://github.com/hdmf-dev/hdmf/pull/880)
 
-## Bug fixes
+### Bug fixes
 - Fixed CI testing of minimum installation requirements, and removed some gallery tests run on each PR. @rly
   [#877](https://github.com/hdmf-dev/hdmf/pull/877)
 - Fixed reporting of version when installed using conda. @rly [#890](https://github.com/hdmf-dev/hdmf/pull/890)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -453,7 +453,7 @@ class ExternalResources(Container):
             if attribute is None:
                 data_object = container
             else:
-                data_object = container[attribute]
+                data_object = getattr(container, attribute)
             if isinstance(data_object, (Data, DataIO)):
                 data = data_object.data
             elif isinstance(data_object, (list, np.ndarray)):


### PR DESCRIPTION
## Motivation

The add_ref_term_set optional attribute was being subscripted and would throw an error if it wasn't subscriptable. Replaced with getattr() like the original add_ref
## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
Tox Tests

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
