### PR TITLE
Fix error with setting read_io to same obj twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # HDMF Changelog
 
-## HDMF 3.8.0 (July 21,2023)
+## HDMF 3.8.1 (July 25, 2023)
+
+### Bug fixes
+- Fixed error when calling `HDF5IO.read` twice. @rly [#915](https://github.com/hdmf-dev/hdmf/pull/915)
+
+## HDMF 3.8.0 (July 21, 2023)
 
 ### New features and minor improvements
 - Added the ability to write ExternalResources if the path is provided and the container has a linked instance of ExternalResources. @mavaylon1 [#910](https://github.com/hdmf-dev/hdmf/pull/910)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -253,7 +253,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         from hdmf.backends.io import HDMFIO
         if not isinstance(value, HDMFIO):
             raise TypeError("io must be an instance of HDMFIO")
-        if self.__read_io is not None:
+        if self.__read_io is not None and self.__read_io is not value:
             raise ValueError("io has already been set for this container (name=%s, type=%s)" %
                              (self.name, str(type(self))))
         else:

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -45,10 +45,13 @@ class TestContainer(TestCase):
 
     def setUp(self):
         self.path = "test_container.h5"
+        self.path2 = "test_container2.h5"
 
     def tearDown(self):
         if os.path.exists(self.path):
             os.remove(self.path)
+        if os.path.exists(self.path2):
+            os.remove(self.path2)
 
     def test_new(self):
         """Test that __new__ properly sets parent and other fields.
@@ -105,12 +108,15 @@ class TestContainer(TestCase):
         with self.assertRaises(TypeError):
             obj.read_io = "test"
         # Set read_io
-        with  HDF5IO(self.path, mode='w') as temp_io:
+        with HDF5IO(self.path, mode='w') as temp_io:
             obj.read_io = temp_io
             self.assertIs(obj.read_io, temp_io)
-            # Check that setting read_io again fails
-            with self.assertRaises(ValueError):
-                obj.read_io = temp_io
+            # test that setting the read_io object to the same io object is OK
+            obj.read_io = temp_io
+            # Check that setting read_io to another io object fails
+            with HDF5IO(self.path2, mode='w') as temp_io2:
+                with self.assertRaises(ValueError):
+                    obj.read_io = temp_io2
 
     def test_get_read_io_on_self(self):
         """Test that get_read_io works when the container is set on the container"""


### PR DESCRIPTION
## Motivation

Fix #914. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
