### PR TITLE
Fix/read bad icephys table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.8.2 (Upcoming)
+
+### Bug fixes
+- Relaxed error checking in the `DynamicTable.__init__` and `AlginedDynamicTable.__init__` when reading from disk to help users access bad data files. @oruebel [#919](https://github.com/hdmf-dev/hdmf/pull/919)
+
 ## HDMF 3.8.1 (July 25, 2023)
 
 ### Bug fixes

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -394,7 +394,16 @@ class DynamicTable(Container):
         else:
             # Calculate the order of column names
             if columns is None:
-                raise ValueError("Must supply 'columns' if specifying 'colnames'")
+                # Invalid table. Custom colnames are given but the VectorData for those columns are missing.
+                if self._in_construct_mode:  # Relax error checking when reading from an existing file
+                    # To allow reading of bad files and since we don't have any actual data for the
+                    # custom columns, we can try to just ignore the columns and warn instead of raising a ValueError.
+                    self.colnames = tuple()
+                    self.columns = tuple()
+                    warn("Ignoring custom named columns. Must supply 'columns' if specifying"
+                         " 'colnames'=%s for table name=%s" % (str(colnames), self.name))
+                else: # be strict when constructing a new table
+                    raise ValueError("Must supply 'columns' if specifying 'colnames'")
             else:
                 # order the columns according to the column names, which does not include indices
                 self.colnames = tuple(pystr(c) for c in colnames)


### PR DESCRIPTION
## Motivation

Fix #918 

Relax the error checking in the ``__init__`` methods of ``DynamicTable`` and ``AlignedDynamicTable`` to raise warnings when reading from file and raise errors when creating new data. This is to try and allow users to access bad data files while ensuring that we don't construct bad files ourselves. 


## How to test the behavior?

See #918 for details

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
