### PR TITLE
Add base methods for iterator serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.8.2 (Upcoming)
+
+### New features and minor improvements
+- Added the magic `__reduce__` method as well as two private semi-abstract helper methods to enable pickling of the `GenericDataChunkIterator`. @codycbakerphd [#924](https://github.com/hdmf-dev/hdmf/pull/924)
+
 ## HDMF 3.8.1 (July 25, 2023)
 
 ### Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "ruamel.yaml>=0.16",
     "scipy>=1.4",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
-    "threadpoolct"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "ruamel.yaml>=0.16",
     "scipy>=1.4",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
+    "threadpoolct"
 ]
 dynamic = ["version"]
 

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -75,6 +75,10 @@ class HDMFIO(metaclass=ABCMeta):
         return container
 
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
+            {'name': 'number_of_jobs', 'type': int, 'doc': 'Number of jobs to use in parallel during write (only operates on GenericDataChunkIterator-wrapped datasets).', 'default': 1},
+            {'name': 'number_of_jobs', 'type': int,
+         'doc': "Number of jobs to use in parallel during write (only operates on GenericDataChunkIterator-wrapped datasets).",
+         'default': 1},
             allow_extra=True)
     def write(self, **kwargs):
         """Write a container to the IO source."""

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -75,10 +75,15 @@ class HDMFIO(metaclass=ABCMeta):
         return container
 
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
-            {'name': 'number_of_jobs', 'type': int, 'doc': 'Number of jobs to use in parallel during write (only operates on GenericDataChunkIterator-wrapped datasets).', 'default': 1},
-            {'name': 'number_of_jobs', 'type': int,
-         'doc': "Number of jobs to use in parallel during write (only operates on GenericDataChunkIterator-wrapped datasets).",
-         'default': 1},
+            {
+                "name": "number_of_jobs",
+                "type": int,
+                "doc": (
+                    "Number of jobs to use in parallel during write "
+                    "(only works with GenericDataChunkIterator-wrapped datasets)."
+                ),
+                "default": 1,
+            },
             allow_extra=True)
     def write(self, **kwargs):
         """Write a container to the IO source."""

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -74,17 +74,7 @@ class HDMFIO(metaclass=ABCMeta):
 
         return container
 
-    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
-            {
-                "name": "number_of_jobs",
-                "type": int,
-                "doc": (
-                    "Number of jobs to use in parallel during write "
-                    "(only works with GenericDataChunkIterator-wrapped datasets)."
-                ),
-                "default": 1,
-            },
-            allow_extra=True)
+    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'}, allow_extra=True)
     def write(self, **kwargs):
         """Write a container to the IO source."""
         container = popargs('container', kwargs)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -272,6 +272,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 if "total" in self.progress_bar_options:
                     warn("Option 'total' in 'progress_bar_options' is not allowed to be over-written! Ignoring.")
                     self.progress_bar_options.pop("total")
+
                 self.progress_bar = tqdm(total=self.num_buffers, **self.progress_bar_options)
             except ImportError:
                 warn(
@@ -401,12 +402,16 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
 
     def _to_dict(self) -> dict:
         """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
-        raise NotImplementedError("The `._to_dict()` method for pickling has not been defined for this DataChunkIterator!")
+        raise NotImplementedError(
+            "The `._to_dict()` method for pickling has not been defined for this DataChunkIterator!"
+        )
 
     @staticmethod
     def _from_dict(self) -> Callable:
         """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
-        raise NotImplementedError("The `._from_dict()` method for pickling has not been defined for this DataChunkIterator!")
+        raise NotImplementedError(
+            "The `._from_dict()` method for pickling has not been defined for this DataChunkIterator!"
+        )
 
     def recommended_chunk_shape(self) -> Tuple[int, ...]:
         return self.chunk_shape

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -365,7 +365,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 self.progress_bar.write("\n")  # Allows text to be written to new lines after completion
             raise StopIteration
 
-    def __reduce__(self) -> Tuple[Callable, Iterable[dict]]:
+    def __reduce__(self) -> Tuple[Callable, Iterable]:
         instance_constructor = self._from_dict
         initialization_args = (self._to_dict(),)
         return (instance_constructor, initialization_args)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -400,14 +400,14 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         """Retrieve the dtype of the data using minimal I/O."""
         raise NotImplementedError("The setter for the internal dtype has not been built for this DataChunkIterator!")
 
-    def _to_dict(self) -> Iterable:
+    def _to_dict(self) -> dict:
         """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
-        pass
+        raise NotImplementedError("The `._to_dict()` method for pickling has not been defined for this DataChunkIterator!")
 
     @staticmethod
     def _from_dict(self) -> Callable:
         """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
-        pass
+        raise NotImplementedError("The `._from_dict()` method for pickling has not been defined for this DataChunkIterator!")
 
     def recommended_chunk_shape(self) -> Tuple[int, ...]:
         return self.chunk_shape

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -3,7 +3,7 @@ import math
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from warnings import warn
-from typing import Tuple
+from typing import Tuple, Callable
 from itertools import product, chain
 
 import h5py
@@ -191,9 +191,10 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         See https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf
         for more details.
         """
-        buffer_gb, buffer_shape, chunk_mb, chunk_shape, self.display_progress, self.progress_bar_options = getargs(
+        buffer_gb, buffer_shape, chunk_mb, chunk_shape, self.display_progress, progress_bar_options = getargs(
             "buffer_gb", "buffer_shape", "chunk_mb", "chunk_shape", "display_progress", "progress_bar_options", kwargs
         )
+        self.progress_bar_options = progress_bar_options or dict()
 
         if buffer_gb is None and buffer_shape is None:
             buffer_gb = 1.0
@@ -241,7 +242,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 for buffer_axis, maxshape_axis in zip(self.buffer_shape, self.maxshape)
             ],
         )
-        self.buffer_selection_generator = (
+        self.buffer_selections = tuple(  # temporary solution to cast as tuple to allow indexing
             tuple(
                 [
                     slice(lower_bound, upper_bound)
@@ -263,11 +264,9 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 ),
             )
         )
+        self.buffer_selection_generator = iter(self.buffer_selections)
 
         if self.display_progress:
-            if self.progress_bar_options is None:
-                self.progress_bar_options = dict()
-
             try:
                 from tqdm import tqdm
 
@@ -346,12 +345,6 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             ]
         )
 
-    def recommended_chunk_shape(self) -> Tuple[int, ...]:
-        return self.chunk_shape
-
-    def recommended_data_shape(self) -> Tuple[int, ...]:
-        return self.maxshape
-
     def __iter__(self):
         return self
 
@@ -371,6 +364,11 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
             if self.display_progress:
                 self.progress_bar.write("\n")  # Allows text to be written to new lines after completion
             raise StopIteration
+
+    def __reduce__(self) -> Tuple[Callable, Iterable]:
+        instance_constructor = self._from_dict
+        initialization_args = (self._to_dict(),)
+        return (instance_constructor, initialization_args)
 
     @abstractmethod
     def _get_data(self, selection: Tuple[slice]) -> np.ndarray:
@@ -392,23 +390,37 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         """
         raise NotImplementedError("The data fetching method has not been built for this DataChunkIterator!")
 
-    @property
-    def maxshape(self) -> Tuple[int, ...]:
-        return self._maxshape
-
     @abstractmethod
     def _get_maxshape(self) -> Tuple[int, ...]:
         """Retrieve the maximum bounds of the data shape using minimal I/O."""
         raise NotImplementedError("The setter for the maxshape property has not been built for this DataChunkIterator!")
 
-    @property
-    def dtype(self) -> np.dtype:
-        return self._dtype
-
     @abstractmethod
     def _get_dtype(self) -> np.dtype:
         """Retrieve the dtype of the data using minimal I/O."""
         raise NotImplementedError("The setter for the internal dtype has not been built for this DataChunkIterator!")
+
+    def _to_dict(self) -> Iterable:
+        """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
+        pass
+
+    @staticmethod
+    def _from_dict(self) -> Callable:
+        """Optional method to add in child classes to enable pickling (required for multiprocessing)."""
+        pass
+
+    def recommended_chunk_shape(self) -> Tuple[int, ...]:
+        return self.chunk_shape
+
+    def recommended_data_shape(self) -> Tuple[int, ...]:
+        return self.maxshape
+
+    @property
+    def maxshape(self) -> Tuple[int, ...]:
+        return self._maxshape
+    @property
+    def dtype(self) -> np.dtype:
+        return self._dtype
 
 
 class DataChunkIterator(AbstractDataChunkIterator):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -242,7 +242,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 for buffer_axis, maxshape_axis in zip(self.buffer_shape, self.maxshape)
             ],
         )
-        self.buffer_selections = tuple(  # temporary solution to cast as tuple to allow indexing
+        self.buffer_selection_generator = (
             tuple(
                 [
                     slice(lower_bound, upper_bound)
@@ -264,7 +264,6 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 ),
             )
         )
-        self.buffer_selection_generator = iter(self.buffer_selections)
 
         if self.display_progress:
             try:
@@ -365,7 +364,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
                 self.progress_bar.write("\n")  # Allows text to be written to new lines after completion
             raise StopIteration
 
-    def __reduce__(self) -> Tuple[Callable, Iterable]:
+    def __reduce__(self) -> Tuple[Callable, Iterable[dict]]:
         instance_constructor = self._from_dict
         initialization_args = (self._to_dict(),)
         return (instance_constructor, initialization_args)

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -1,4 +1,5 @@
 import unittest
+import pickle
 import numpy as np
 from pathlib import Path
 from tempfile import mkdtemp
@@ -204,6 +205,29 @@ class GenericDataChunkIteratorTests(TestCase):
                 progress_bar_options=dict(total=5),
             )
 
+    def test_private_to_dict_assertion(self):
+        with self.assertRaisesWith(
+            exc_type=NotImplementedError,
+            exc_msg="The `._to_dict()` method for pickling has not been defined for this DataChunkIterator!"
+        ):
+            iterator = self.TestNumpyArrayDataChunkIterator(array=self.test_array)
+            _ = iterator._to_dict()
+
+    def test_private_from_dict_assertion(self):
+        with self.assertRaisesWith(
+            exc_type=NotImplementedError,
+            exc_msg="The `._from_dict()` method for pickling has not been defined for this DataChunkIterator!"
+        ):
+            _ = self.TestNumpyArrayDataChunkIterator._from_dict(dict())
+
+    def test_direct_pickle_assertion(self):
+        with self.assertRaisesWith(
+            exc_type=NotImplementedError,
+            exc_msg="The `._to_dict()` method for pickling has not been defined for this DataChunkIterator!"
+        ):
+            iterator = self.TestNumpyArrayDataChunkIterator(array=self.test_array)
+            _ = pickle.dumps(iterator)
+            
     def test_maxshape_attribute_contains_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
         self.check_all_of_iterable_is_python_int(

--- a/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
+++ b/tests/unit/utils_test/test_core_GenericDataChunkIterator.py
@@ -227,7 +227,7 @@ class GenericDataChunkIteratorTests(TestCase):
         ):
             iterator = self.TestNumpyArrayDataChunkIterator(array=self.test_array)
             _ = pickle.dumps(iterator)
-            
+
     def test_maxshape_attribute_contains_int_type(self):
         """Motivated by issues described in https://github.com/hdmf-dev/hdmf/pull/780 & 781 regarding return types."""
         self.check_all_of_iterable_is_python_int(


### PR DESCRIPTION
## Motivation

Zarr supports efficient parallelization, and a sister PR (https://github.com/hdmf-dev/hdmf-zarr/pull/111) adds this capability but requires the argument `number_of_jobs` to be propagated from a top level of the `HDMFIO.write` due to the super call at [this line](https://github.com/hdmf-dev/hdmf-zarr/blob/d47fc8249e76a371fff990b07218a088e59ea590/src/hdmf_zarr/backend.py#L203)

It also has a subtle condition in that our iterators (which in this role primarily define how to access data from a source) must be pickleable, so I've defined methods related to that for the `GenericDataChunkIterator` (which for several reasons should be the only type of iterator allowed for usage in parallelization)

An example in practice can be found downstream: https://github.com/catalystneuro/neuroconv/pull/536


## Checklist

- [X] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
