### PR TITLE
Update HERD.get_key to replace ValueError with return values

### DIFF
--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -480,10 +480,12 @@ class HERD(Container):
              'doc': ('The field of the compound data type using an external resource.')})
     def get_key(self, **kwargs):
         """
-        Return a Key.
+        Get a Key by name
 
         If container, relative_path, and field are provided, the Key that corresponds to the given name of the key
         for the given container, relative_path, and field is returned.
+
+        :returns: Single Key object, or a list of Key objects, or None, depending on how many Keys match the query
         """
         key_name, container, relative_path, field = popargs('key_name', 'container', 'relative_path', 'field', kwargs)
         key_idx_matches = self.keys.which(key=key_name)
@@ -503,15 +505,13 @@ class HERD(Container):
                 key_idx = self.object_keys['keys_idx', row_idx]
                 if key_idx in key_idx_matches:
                     return self.keys.row[key_idx]
-            msg = "No key found with that container."
-            raise ValueError(msg)
+            return None
         else:
             if len(key_idx_matches) == 0:
                 # the key has never been used before
-                raise ValueError("key '%s' does not exist" % key_name)
+                return None
             elif len(key_idx_matches) > 1:
-                msg = "There are more than one key with that name. Please search with additional information."
-                raise ValueError(msg)
+                return [self.keys.row[ki] for ki in key_idx_matches]
             else:
                 return self.keys.row[key_idx_matches[0]]
 


### PR DESCRIPTION
## Motivation

`HERD.get_key` currently raises a number of different errors. I propose to change the errors to more useful return values:
* If no key is found return `None` instead of raising a `ValueError`
* If multiple matching keys are found, then return a list of `Key` objects rather than raising a `ValueError`

Alternatively, we could also always return a list of Key objects such that the list is empty when no Key is found, has 1 element when an exact match is found, and has multiple elements if many keys match. 

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
