### PR TITLE
Add `target_tables` argument to `DynamicTable.__init__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 3.11.0 (Upcoming)
+
+### Enhancements
+- Added `target_tables` attribute to `DynamicTable` to allow users to specify the target table of any predefined
+`DynamicTableRegion` columns of a `DynamicTable` subclass. @rly [#971](https://github.com/hdmf-dev/hdmf/pull/971)
+
 ## HDMF 3.10.0 (October 3, 2023)
 
 Since version 3.9.1 should have been released as 3.10.0 but failed to release on PyPI and conda-forge, this release

--- a/docs/gallery/plot_dynamictable_howto.py
+++ b/docs/gallery/plot_dynamictable_howto.py
@@ -321,13 +321,20 @@ table3 = DynamicTable(
 ###############################################################################
 # Setting the target table of a DynamicTableRegion column of a DynamicTable
 # -------------------------------------------------------------------------
-# A subclass of DynamicTable might have a pre-defined DynamicTableRegion column
-# that references rows of another table. The target table of this column might
-# not be initialized. In this case, the target table can be set using the
-# ``target_tables`` argument of the DynamicTable constructor. This argument
-# should be a dictionary mapping the name of the DynamicTableRegion column to
-# the target table. The target table can also be set after the DynamicTable
-# has been initialized using ``my_table.my_column.table = other_table``.
+# A subclass of DynamicTable might have a pre-defined DynamicTableRegion column.
+# To write this column correctly, the "table" attribute of the column must be set so
+# that users know to what table the row index values reference. Because the target
+# table could be any table, the "table" attribute must be set explicitly. There are three
+# ways to do so. First, you can use the ``target_tables`` argument of the
+# DynamicTable constructor as shown below. This argument
+# is a dictionary mapping the name of the DynamicTableRegion column to
+# the target table. Secondly, the target table can be set after the DynamicTable
+# has been initialized using ``my_table.my_column.table = other_table``. Finally,
+# you can create the DynamicTableRegion column and pass the ``table``
+# attribute to `DynamicTableRegion.__init__` and then pass the column to
+# `DynamicTable.__init__` using the `columns` argument. However, this approach
+# is not recommended for columns defined in the schema, because it is up to
+# the user to ensure that the column is created in accordance with the schema.
 
 class SubTable(DynamicTable):
     __columns__ = (

--- a/docs/gallery/plot_dynamictable_howto.py
+++ b/docs/gallery/plot_dynamictable_howto.py
@@ -319,6 +319,34 @@ table3 = DynamicTable(
 )
 
 ###############################################################################
+# Setting the target table of a DynamicTableRegion column of a DynamicTable
+# -------------------------------------------------------------------------
+# A subclass of DynamicTable might have a pre-defined DynamicTableRegion column
+# that references rows of another table. The target table of this column might
+# not be initialized. In this case, the target table can be set using the
+# ``target_tables`` argument of the DynamicTable constructor. This argument
+# should be a dictionary mapping the name of the DynamicTableRegion column to
+# the target table. The target table can also be set after the DynamicTable
+# has been initialized using ``my_table.my_column.table = other_table``.
+
+class SubTable(DynamicTable):
+    __columns__ = (
+        {'name': 'dtr', 'description': 'required region', 'required': True, 'table': True},
+    )
+
+referenced_table = DynamicTable(
+    name='referenced_table',
+    description='an example table',
+)
+
+sub_table = SubTable(
+    name='sub_table',
+    description='an example table',
+    target_tables={'dtr': referenced_table},
+)
+# now the target table of the DynamicTableRegion column 'dtr' is set to `referenced_table`
+
+###############################################################################
 # Creating an expandable table
 # ----------------------------
 # When using the default HDF5 backend, each column of these tables is an HDF5 Dataset,

--- a/src/hdmf/common/io/table.py
+++ b/src/hdmf/common/io/table.py
@@ -2,7 +2,7 @@ from .. import register_map
 from ..table import DynamicTable, VectorData, VectorIndex, DynamicTableRegion
 from ...build import ObjectMapper, BuildManager, CustomClassGenerator
 from ...spec import Spec
-from ...utils import docval, getargs, popargs, AllowPositional
+from ...utils import docval, getargs
 
 
 @register_map(DynamicTable)
@@ -111,55 +111,3 @@ class DynamicTableGenerator(CustomClassGenerator):
         columns = classdict.get('__columns__')
         if columns is not None:
             classdict['__columns__'] = tuple(columns)
-
-    @classmethod
-    def set_init(cls, classdict, bases, docval_args, not_inherited_fields, name):
-        if '__columns__' not in classdict:
-            return
-
-        base_init = classdict.get('__init__')
-        if base_init is None:  # pragma: no cover
-            raise ValueError("Generated class dictionary is missing base __init__ method.")
-
-        # add a specialized docval arg for __init__ for specifying targets for DTRs
-        docval_args_local = docval_args.copy()
-        target_tables_dvarg = dict(
-            name='target_tables',
-            doc=('dict mapping DynamicTableRegion column name to the table that the DTR points to. The column is '
-                 'added to the table if it is not already present (i.e., when it is optional).'),
-            type=dict,
-            default=None
-        )
-        cls._add_to_docval_args(docval_args_local, target_tables_dvarg, err_if_present=True)
-
-        @docval(*docval_args_local, allow_positional=AllowPositional.WARNING)
-        def __init__(self, **kwargs):
-            target_tables = popargs('target_tables', kwargs)
-            base_init(self, **kwargs)
-
-            # set target attribute on DTR
-            if target_tables:
-                for colname, table in target_tables.items():
-                    if colname not in self:  # column has not yet been added (it is optional)
-                        column_conf = None
-                        for conf in self.__columns__:
-                            if conf['name'] == colname:
-                                column_conf = conf
-                                break
-                        if column_conf is None:
-                            raise ValueError("'%s' is not the name of a predefined column of table %s."
-                                             % (colname, self))
-                        if not column_conf.get('table', False):
-                            raise ValueError("Column '%s' must be a DynamicTableRegion to have a target table."
-                                             % colname)
-                        self.add_column(name=column_conf['name'],
-                                        description=column_conf['description'],
-                                        index=column_conf.get('index', False),
-                                        table=True)
-                    if isinstance(self[colname], VectorIndex):
-                        col = self[colname].target
-                    else:
-                        col = self[colname]
-                    col.table = table
-
-        classdict['__init__'] = __init__

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1598,6 +1598,97 @@ class TestDynamicTableClassColumns(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             SubTable(name='subtable', description='subtable description', columns=[col1_ind, col1])
 
+    def test_no_set_target_tables(self):
+        """Test that the target table of a predefined DTR column is None."""
+        table = SubTable(name='subtable', description='subtable description')
+        self.assertIsNone(table.col5.table)
+
+    def test_set_target_tables(self):
+        """Test setting target tables for predefined DTR columns."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        table2 = SubTable(
+            name='subtable2',
+            description='subtable description',
+            target_tables={
+                'col5': table1,
+                'col6': table1,
+                'col7': table1,
+                'col8': table1,
+            },
+        )
+        self.assertIs(table2.col5.table, table1)
+        self.assertIs(table2.col6.table, table1)
+        self.assertIs(table2.col7.table, table1)
+        self.assertIs(table2.col8.table, table1)
+
+    def test_set_target_tables_unknown_col(self):
+        """Test setting target tables for unknown columns."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        msg = r"'bad_col' is not the name of a predefined column of table subtable2 .*"
+        with self.assertRaisesRegex(ValueError, msg):
+            SubTable(
+                name='subtable2',
+                description='subtable description',
+                target_tables={
+                    'bad_col': table1,
+                },
+            )
+
+    def test_set_target_tables_bad_init_col(self):
+        """Test setting target tables for predefined, required non-DTR columns."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        msg = "Column 'col1' must be a DynamicTableRegion to have a target table."
+        with self.assertRaisesWith(ValueError, msg):
+            SubTable(
+                name='subtable2',
+                description='subtable description',
+                target_tables={
+                    'col1': table1,
+                },
+            )
+
+    def test_set_target_tables_bad_opt_col(self):
+        """Test setting target tables for predefined, optional non-DTR columns."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        msg = "Column 'col2' must be a DynamicTableRegion to have a target table."
+        with self.assertRaisesWith(ValueError, msg):
+            SubTable(
+                name='subtable2',
+                description='subtable description',
+                target_tables={
+                    'col2': table1,
+                },
+            )
+
+    def test_set_target_tables_existing_col_mismatch(self):
+        """Test setting target tables for an existing DTR column with a mismatched, existing target table."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        table2 = SubTable(name='subtable2', description='subtable description')
+        dtr = DynamicTableRegion(name='dtr', data=[], description='desc', table=table1)
+        msg = "Column 'dtr' already has a target table that is not the passed table."
+        with self.assertRaisesWith(ValueError, msg):
+            SubTable(
+                name='subtable3',
+                description='subtable description',
+                columns=[dtr],
+                target_tables={
+                    'dtr': table2,
+                },
+            )
+
+    def test_set_target_tables_existing_col_match(self):
+        """Test setting target tables for an existing DTR column with a matching, existing target table."""
+        table1 = SubTable(name='subtable1', description='subtable description')
+        dtr = DynamicTableRegion(name='dtr', data=[], description='desc', table=table1)
+        SubTable(
+            name='subtable2',
+            description='subtable description',
+            columns=[dtr],
+            target_tables={
+                'dtr': table1,
+            },
+        )
+
 
 class TestEnumData(TestCase):
 


### PR DESCRIPTION
## Motivation

In a previous PR, we added the ability to specify the target table for a pre-defined `DynamicTableRegion` column in `DynamicTable.__init__` but this was only in generated subclasses of `DynamicTable`. This functionality works well, but could be useful to build in to `DynamicTable` in case users want to write their own custom subclass of `DynamicTable` and want to reuse this generic behavior (such as in pynwb and in extensions). Though in PyNWB, we often have a more specific constructor argument for this: https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/misc.py#L160 and some hacky code in `add_row` to handle setting the target table when the first row is added: https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/misc.py#L207

So I moved the functionality from the custom class generator for generated `DynamicTable` subclasses to the base `DynamicTable` itself.

This also has the benefit of fixing #970 when there are multiple chains of hierarchy below `DynamicTable`. Fixes #970. 

We can optionally adjust pynwb to reuse this behavior in the Units table and elsewhere.
 
## How to test the behavior?
```
pytest
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
