### PR TITLE
Disable python requirements files checking in dependabot

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -3,7 +3,9 @@ Prepare for release of HDMF [version]
 ### Before merging:
 - [ ] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,
   `requirements-doc.txt`, `requirements-opt.txt`, and `environment-ros3.yml` to the latest versions,
-  and update dependency ranges in `pyproject.toml` and minimums in `requirements-min.txt` as needed
+  and update dependency ranges in `pyproject.toml` and minimums in `requirements-min.txt` as needed.
+  Run `pip install pur && pur -r requirements-dev.txt -r requirements.txt -r requirements-opt.txt`
+  and manually update `environment-ros3.yml`.
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `pyproject.toml` as needed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # many updates and dependabot will not ignore requirements-min.txt
   # until https://github.com/dependabot/dependabot-core/issues/2883 is resolved
   # workaround is to continue updating these files manually
-  
+
   # - package-ecosystem: "pip"
   #   directory: "/"
   #   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      # Check for updates to requirements files and pyproject.toml every week
-      interval: "weekly"
+  # disable checking python requirements files because there are too
+  # many updates and dependabot will not ignore requirements-min.txt
+  # until https://github.com/dependabot/dependabot-core/issues/2883 is resolved
+  # workaround is to continue updating these files manually
+  
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     # Check for updates to requirements files and pyproject.toml every week
+  #     interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updated `TermSet` to include `_repr_html_` for easy to read notebook representation. @mavaylon1 [#967](https://github.com/hdmf-dev/hdmf/pull/967)
 
 ### Minor improvements
-- Set up GitHub dependabot to check for updates to Python requirements and GitHub Actions. @rly [#977](https://github.com/hdmf-dev/hdmf/pull/977)
+- Set up GitHub dependabot to check for updates to GitHub Actions. @rly [#977](https://github.com/hdmf-dev/hdmf/pull/977)
 
 ### Bug fixes
 - Updated custom class generation to handle specs with fixed values and required names. @rly [#800](https://github.com/hdmf-dev/hdmf/pull/800)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,12 +2,12 @@
 # compute coverage, and create test environments. note that depending on the version of python installed, different
 # versions of requirements may be installed due to package incompatibilities.
 #
-black==23.9.1
+black==23.10.1
 codespell==2.2.6
 coverage==7.3.2
-pre-commit==3.4.0
-pytest==7.4.2
+pre-commit==3.5.0
+pytest==7.4.3
 pytest-cov==4.1.0
 python-dateutil==2.8.2
-ruff==0.0.292
+ruff==0.1.3
 tox==4.11.3

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -4,5 +4,5 @@ zarr==2.16.1
 linkml-runtime==1.6.0; python_version >= "3.9"
 schemasheets==0.1.24; python_version >= "3.9"
 oaklib==0.5.20; python_version >= "3.9"
-pydantic==1.10.13  # linkml-runtime 1.6.0 and related packages require pydantic<2
+pydantic==2.4.2  # linkml-runtime 1.6.0 and related packages require pydantic<2
 pyyaml==6.0.1; python_version >= "3.9"

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -4,5 +4,5 @@ zarr==2.16.1
 linkml-runtime==1.6.0; python_version >= "3.9"
 schemasheets==0.1.24; python_version >= "3.9"
 oaklib==0.5.20; python_version >= "3.9"
-pydantic==2.4.2
+pydantic==1.10.13  # linkml-runtime 1.6.0 and related packages require pydantic<2
 pyyaml==6.0.1; python_version >= "3.9"

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -4,5 +4,5 @@ zarr==2.16.1
 linkml-runtime==1.6.0; python_version >= "3.9"
 schemasheets==0.1.24; python_version >= "3.9"
 oaklib==0.5.20; python_version >= "3.9"
-pydantic==2.4.2  # linkml-runtime 1.6.0 and related packages require pydantic<2
+pydantic==2.4.2
 pyyaml==6.0.1; python_version >= "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # pinned dependencies to reproduce an entire development environment to use HDMF
-h5py==3.9.0
-importlib-resources==6.0.0; python_version < "3.9"  # TODO: remove when minimum python version is 3.9
+h5py==3.10.0
+importlib-resources==6.1.0; python_version < "3.9"  # TODO: remove when minimum python version is 3.9
 jsonschema==4.19.1
-numpy==1.26.0
-pandas==2.1.1
-ruamel.yaml==0.17.33
+numpy==1.26.1
+pandas==2.1.2
+ruamel.yaml==0.18.2
 scipy==1.11.3


### PR DESCRIPTION
## Motivation

Disable checking python requirements files with dependabot because there are too many updates and dependabot will not ignore `requirements-min.txt` until https://github.com/dependabot/dependabot-core/issues/2883 is resolved

Revert our process to continue updating these files manually. We can use the [pur package](https://github.com/alanhamlett/pip-update-requirements) to help.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
