### PR TITLE
Use simpler tox.ini, add testing for Python 3.12, and other small updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,6 +64,7 @@ body:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -1,6 +1,6 @@
 name: Check Sphinx external links
 on:
-  pull_request:
+  push:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
@@ -8,22 +8,20 @@ on:
 jobs:
   check-external-links:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -1,6 +1,6 @@
 name: Check Sphinx external links
 on:
-  push:
+  pull_request:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.11'  # TODO update to 3.12 when optional reqs (e.g., oaklib) support 3.12
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,6 @@
 name: Codespell
 on:
-  push:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,19 +1,14 @@
----
 name: Codespell
-
 on:
   push:
-    branches: [dev]
-  pull_request:
-    branches: [dev]
+  workflow_dispatch:
 
 jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
+      - name: Checkout repo
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install build dependencies
         run: |
@@ -28,20 +28,20 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py311-upgraded
+          tox -e py312-upgraded
 
       - name: Build wheel and source distribution
         run: |
-          tox -e build-py311-upgraded
+          tox -e build
           ls -1 dist
 
       - name: Test installation from a wheel
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
+          tox -e wheelinstall --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+          tox -e wheelinstall --installpkg dist/*.tar.gz
 
       - name: Upload wheel and source distributions to PyPI
         run: |

--- a/.github/workflows/project_action.yml
+++ b/.github/workflows/project_action.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: generate_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PEM }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,5 +5,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Run ruff
+        uses: chartboost/ruff-action@v1

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -18,42 +18,43 @@ jobs:
     defaults:
       run:
         shell: bash
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-optional    , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-prerelease  , test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-optional  , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-prerelease, test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: windows-latest }
-          - { name: macos-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-optional    , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-prerelease  , test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: macos-latest }
+          - { name: linux-python3.8-minimum       , test-tox-env: py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.9               , test-tox-env: py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10              , test-tox-env: py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11              , test-tox-env: py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-optional     , test-tox-env: py311-optional   , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12              , test-tox-env: py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-upgraded     , test-tox-env: py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-prerelease   , test-tox-env: py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
+          - { name: windows-python3.8-minimum     , test-tox-env: py38-minimum     , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.9             , test-tox-env: py39-pinned      , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10            , test-tox-env: py310-pinned     , python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.11            , test-tox-env: py311-pinned     , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-optional   , test-tox-env: py311-optional   , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12            , test-tox-env: py312-pinned     , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-upgraded   , test-tox-env: py312-upgraded   , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-prerelease , test-tox-env: py312-prerelease , python-ver: "3.12", os: windows-latest }
+          - { name: macos-python3.8-minimum       , test-tox-env: py38-minimum     , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.9               , test-tox-env: py39-pinned      , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.10              , test-tox-env: py310-pinned     , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.11              , test-tox-env: py311-pinned     , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-optional     , test-tox-env: py311-optional   , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12              , test-tox-env: py312-pinned     , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-upgraded     , test-tox-env: py312-upgraded   , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-prerelease   , test-tox-env: py312-prerelease , python-ver: "3.12", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -77,11 +78,11 @@ jobs:
 
       - name: Test installation from a wheel
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
+          tox -e wheelinstall --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+          tox -e wheelinstall --installpkg dist/*.tar.gz
 
   run-all-gallery-tests:
     name: ${{ matrix.name }}
@@ -89,33 +90,31 @@ jobs:
     defaults:
       run:
         shell: bash
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
           - { name: linux-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: ubuntu-latest }
           - { name: windows-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: windows-latest }
           - { name: windows-gallery-python3.11-optional  , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: windows-latest }
-          - { name: windows-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: windows-latest }
-          - { name: windows-gallery-python3.11-prerelease, test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.12-upgraded  , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: windows-latest }
+          - { name: windows-gallery-python3.12-prerelease, test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: windows-latest }
           - { name: macos-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: macos-latest }
           - { name: macos-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: macos-latest }
-          - { name: macos-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: macos-latest }
-          - { name: macos-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: macos-latest }
+          - { name: macos-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: macos-latest }
+          - { name: macos-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -138,28 +137,27 @@ jobs:
     defaults:
      run:
        shell: bash -l {0}  # needed for conda environment to work
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11-optional  , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11-prerelease, test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum     , test-tox-env: py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.9             , test-tox-env: py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: conda-linux-python3.10            , test-tox-env: py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11            , test-tox-env: py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-optional   , test-tox-env: py311-optional   , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12            , test-tox-env: py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-upgraded   , test-tox-env: py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-prerelease , test-tox-env: py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -190,11 +188,11 @@ jobs:
 
       - name: Test installation from a wheel
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
+          tox -e wheelinstall --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+          tox -e wheelinstall --installpkg dist/*.tar.gz
 
   run-gallery-ros3-tests:
     name: ${{ matrix.name }}
@@ -202,23 +200,22 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}  # necessary for conda
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-gallery-python3.11-ros3, python-ver: "3.11", os: windows-latest }
-          - { name: macos-gallery-python3.11-ros3  , python-ver: "3.11", os: macos-latest }
+          - { name: linux-gallery-python3.12-ros3   , python-ver: "3.12", os: ubuntu-latest }
+          - { name: windows-gallery-python3.12-ros3 , python-ver: "3.12", os: windows-latest }
+          - { name: macos-gallery-python3.12-ros3   , python-ver: "3.12", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build wheel and source distribution
         run: |
-          tox -e ${{ matrix.build-tox-env }}
+          tox -e build
           ls -1 dist
 
       - name: Test installation from a wheel
@@ -183,7 +183,7 @@ jobs:
 
       - name: Build wheel and source distribution
         run: |
-          tox -e ${{ matrix.build-tox-env }}
+          tox -e build
           ls -1 dist
 
       - name: Test installation from a wheel

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
   push:
-    # tags:  # run only on new tags that follow semver
-    #   - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
+    tags:  # run only on new tags that follow semver
+      - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -25,30 +25,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum       , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.9               , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.10              , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.11              , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-optional     , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.12              , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
-          - { name: windows-python3.8-minimum     , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.9             , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.10            , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.11            , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-optional   , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.12            , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: windows-latest }
-          - { name: windows-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: windows-latest }
-          - { name: windows-python3.12-prerelease , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: windows-latest }
-          - { name: macos-python3.8-minimum       , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.9               , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.10              , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.11              , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-optional     , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.12              , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: macos-latest }
-          - { name: macos-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: macos-latest }
-          - { name: macos-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: macos-latest }
+          - { name: linux-python3.8-minimum       , test-tox-env: pytest-py38-minimum          , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.9               , test-tox-env: pytest-py39-pinned           , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10              , test-tox-env: pytest-py310-pinned          , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11              , test-tox-env: pytest-py311-pinned          , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-optional     , test-tox-env: pytest-py311-optional-pinned , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12              , test-tox-env: pytest-py312-pinned          , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded        , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease      , python-ver: "3.12", os: ubuntu-latest }
+          - { name: windows-python3.8-minimum     , test-tox-env: pytest-py38-minimum          , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.9             , test-tox-env: pytest-py39-pinned           , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10            , test-tox-env: pytest-py310-pinned          , python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.11            , test-tox-env: pytest-py311-pinned          , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-optional   , test-tox-env: pytest-py311-optional-pinned , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12            , test-tox-env: pytest-py312-pinned          , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded        , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-prerelease , test-tox-env: pytest-py312-prerelease      , python-ver: "3.12", os: windows-latest }
+          - { name: macos-python3.8-minimum       , test-tox-env: pytest-py38-minimum          , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.9               , test-tox-env: pytest-py39-pinned           , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.10              , test-tox-env: pytest-py310-pinned          , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.11              , test-tox-env: pytest-py311-pinned          , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-optional     , test-tox-env: pytest-py311-optional-pinned , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12              , test-tox-env: pytest-py312-pinned          , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded        , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease      , python-ver: "3.12", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -97,18 +97,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: ubuntu-latest }
-          - { name: windows-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-gallery-python3.11-optional  , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: windows-latest }
-          - { name: windows-gallery-python3.12-upgraded  , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: windows-latest }
-          - { name: windows-gallery-python3.12-prerelease, test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: windows-latest }
-          - { name: macos-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional  , python-ver: "3.11", os: macos-latest }
-          - { name: macos-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded  , python-ver: "3.12", os: macos-latest }
-          - { name: macos-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease, python-ver: "3.12", os: macos-latest }
+          - { name: linux-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum          , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional-pinned , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded        , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease      , python-ver: "3.12", os: ubuntu-latest }
+          - { name: windows-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum          , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-gallery-python3.11-optional  , test-tox-env: gallery-py311-optional-pinned , python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.12-upgraded  , test-tox-env: gallery-py312-upgraded        , python-ver: "3.12", os: windows-latest }
+          - { name: windows-gallery-python3.12-prerelease, test-tox-env: gallery-py312-prerelease      , python-ver: "3.12", os: windows-latest }
+          - { name: macos-gallery-python3.8-minimum      , test-tox-env: gallery-py38-minimum          , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-gallery-python3.11-optional    , test-tox-env: gallery-py311-optional-pinned , python-ver: "3.11", os: macos-latest }
+          - { name: macos-gallery-python3.12-upgraded    , test-tox-env: gallery-py312-upgraded        , python-ver: "3.12", os: macos-latest }
+          - { name: macos-gallery-python3.12-prerelease  , test-tox-env: gallery-py312-prerelease      , python-ver: "3.12", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -144,14 +144,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum     , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.9             , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.10            , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.11            , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11-optional   , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.12            , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
-          - { name: conda-linux-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: conda-linux-python3.12-prerelease , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum     , test-tox-env: pytest-py38-minimum          , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.9             , test-tox-env: pytest-py39-pinned           , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: conda-linux-python3.10            , test-tox-env: pytest-py310-pinned          , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11            , test-tox-env: pytest-py311-pinned          , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-optional   , test-tox-env: pytest-py311-optional-pinned , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12            , test-tox-env: pytest-py312-pinned          , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded        , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-prerelease , test-tox-env: pytest-py312-prerelease      , python-ver: "3.12", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
   push:
-    tags:  # run only on new tags that follow semver
-      - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
+    # tags:  # run only on new tags that follow semver
+    #   - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          conda install -c conda-forge tox
+          conda install -c conda-forge "tox>=4"
 
       - name: Conda reporting
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -25,30 +25,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum       , test-tox-env: py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.9               , test-tox-env: py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.10              , test-tox-env: py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.11              , test-tox-env: py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-optional     , test-tox-env: py311-optional   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.12              , test-tox-env: py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-python3.12-upgraded     , test-tox-env: py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-python3.12-prerelease   , test-tox-env: py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
-          - { name: windows-python3.8-minimum     , test-tox-env: py38-minimum     , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.9             , test-tox-env: py39-pinned      , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.10            , test-tox-env: py310-pinned     , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.11            , test-tox-env: py311-pinned     , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-optional   , test-tox-env: py311-optional   , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.12            , test-tox-env: py312-pinned     , python-ver: "3.12", os: windows-latest }
-          - { name: windows-python3.12-upgraded   , test-tox-env: py312-upgraded   , python-ver: "3.12", os: windows-latest }
-          - { name: windows-python3.12-prerelease , test-tox-env: py312-prerelease , python-ver: "3.12", os: windows-latest }
-          - { name: macos-python3.8-minimum       , test-tox-env: py38-minimum     , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.9               , test-tox-env: py39-pinned      , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.10              , test-tox-env: py310-pinned     , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.11              , test-tox-env: py311-pinned     , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-optional     , test-tox-env: py311-optional   , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.12              , test-tox-env: py312-pinned     , python-ver: "3.12", os: macos-latest }
-          - { name: macos-python3.12-upgraded     , test-tox-env: py312-upgraded   , python-ver: "3.12", os: macos-latest }
-          - { name: macos-python3.12-prerelease   , test-tox-env: py312-prerelease , python-ver: "3.12", os: macos-latest }
+          - { name: linux-python3.8-minimum       , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.9               , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10              , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11              , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-optional     , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12              , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
+          - { name: windows-python3.8-minimum     , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.9             , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10            , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.11            , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-optional   , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12            , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.12-prerelease , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: windows-latest }
+          - { name: macos-python3.8-minimum       , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.9               , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.10              , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.11              , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-optional     , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12              , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-upgraded     , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.12-prerelease   , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -144,14 +144,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum     , test-tox-env: py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.9             , test-tox-env: py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.10            , test-tox-env: py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.11            , test-tox-env: py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.11-optional   , test-tox-env: py311-optional   , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.12            , test-tox-env: py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
-          - { name: conda-linux-python3.12-upgraded   , test-tox-env: py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: conda-linux-python3.12-prerelease , test-tox-env: py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum     , test-tox-env: pytest-py38-minimum     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.9             , test-tox-env: pytest-py39-pinned      , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: conda-linux-python3.10            , test-tox-env: pytest-py310-pinned     , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11            , test-tox-env: pytest-py311-pinned     , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-optional   , test-tox-env: pytest-py311-optional   , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12            , test-tox-env: pytest-py312-pinned     , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-upgraded   , test-tox-env: pytest-py312-upgraded   , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-prerelease , test-tox-env: pytest-py312-prerelease , python-ver: "3.12", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -31,7 +31,7 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.12'
+      PYTHON: '3.11'  # TODO update to 3.12 when optional reqs (e.g., oaklib) support 3.12
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -19,6 +19,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.opt_req }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:
@@ -28,18 +31,13 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.11'
+      PYTHON: '3.12'
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -31,11 +31,11 @@ jobs:
           python -m pip list
           git clone https://github.com/hdmf-dev/hdmf-zarr.git --recurse-submodules
           cd hdmf-zarr
-          python -m pip install -r requirements-dev.txt -r requirements.txt
+          python -m pip install -r requirements-dev.txt  # do not install the pinned install requirements
           # must install in editable mode for coverage to find sources
-          python -m pip install -e .  # this will install a pinned version of hdmf instead of the current one
+          python -m pip install -e .  # this will install a different version of hdmf from the current one
           cd ..
-          python -m pip uninstall -y hdmf  # uninstall the pinned version of hdmf
+          python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf
           python -m pip list
 

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.10'  # use 3.10 until hdmf-zarr updates versioneer.py which breaks on newer python
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -8,22 +8,20 @@ on:
 jobs:
   run-hdmf-zarr-tests:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -8,22 +8,20 @@ on:
 jobs:
   run-pynwb-tests:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -31,11 +31,11 @@ jobs:
           python -m pip list
           git clone https://github.com/NeurodataWithoutBorders/pynwb.git --recurse-submodules
           cd pynwb
-          python -m pip install -r requirements-dev.txt -r requirements.txt
+          python -m pip install -r requirements-dev.txt  # do not install the pinned install requirements
           # must install in editable mode for coverage to find sources
-          python -m pip install -e .  # this will install a pinned version of hdmf instead of the current one
+          python -m pip install -e .  # this will install a different version of hdmf from the current one
           cd ..
-          python -m pip uninstall -y hdmf  # uninstall the pinned version of hdmf
+          python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf
           python -m pip list
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -79,7 +79,7 @@ jobs:
       run:
         shell: bash
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
      run:
        shell: bash -l {0}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -174,7 +174,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules
@@ -213,7 +213,7 @@ jobs:
       run:
         shell: bash -l {0}  # necessary for conda
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,29 +15,27 @@ jobs:
     defaults:
       run:
         shell: bash
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
-          - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
-          - { name: windows-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
-          - { name: macos-python3.8-minimum      , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: macos-latest }
+          - { name: linux-python3.8-minimum      , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.11             , test-tox-env: pytest-py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-upgraded    , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
+          - { name: windows-python3.8-minimum    , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.11-upgraded  , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: windows-latest }
+          - { name: macos-python3.8-minimum      , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.11-upgraded    , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -56,16 +54,16 @@ jobs:
 
       - name: Build wheel and source distribution
         run: |
-          tox -e ${{ matrix.build-tox-env }}
+          tox -e build
           ls -1 dist
 
       - name: Test installation from a wheel
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
+          tox -e wheelinstall --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+          tox -e wheelinstall --installpkg dist/*.tar.gz
 
       - name: Upload distribution as a workspace artifact
         if: ${{ matrix.upload-wheels }}
@@ -80,6 +78,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -89,15 +90,11 @@ jobs:
           - { name: windows-gallery-python3.8-minimum  , test-tox-env: gallery-py38-minimum  , python-ver: "3.8" , os: windows-latest }
           - { name: windows-gallery-python3.11-upgraded, test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: windows-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -120,23 +117,21 @@ jobs:
     defaults:
      run:
        shell: bash -l {0}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , build-tox-env: build-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -162,33 +157,31 @@ jobs:
 
       - name: Build wheel and source distribution
         run: |
-          tox -e ${{ matrix.build-tox-env }}
+          tox -e build
           ls -1 dist
 
       - name: Test installation from a wheel
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
+          tox -e wheelinstall --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
         run: |
-          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+          tox -e wheelinstall --installpkg dist/*.tar.gz
 
   deploy-dev:
     name: Deploy pre-release from dev
     needs: [run-tests, run-gallery-tests, run-tests-on-conda]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -219,21 +212,20 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}  # necessary for conda
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         include:
           - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -247,7 +239,6 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install matplotlib
           pip install -e .
           pip list
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -124,8 +124,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.12-upgraded  , test-tox-env: py312-upgraded  , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.8-minimum    , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.12-upgraded  , test-tox-env: pytest-py312-upgraded  , python-ver: "3.12", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.8-minimum      , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: pytest-py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11             , test-tox-env: pytest-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.11-upgraded    , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.8-minimum    , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: windows-latest }
           - { name: windows-python3.11-upgraded  , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: windows-latest }
@@ -85,10 +85,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.8-minimum    , test-tox-env: gallery-py38-minimum  , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: ubuntu-latest }
-          - { name: windows-gallery-python3.8-minimum  , test-tox-env: gallery-py38-minimum  , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-gallery-python3.11-upgraded, test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: windows-latest }
+          - { name: linux-gallery-python3.8-minimum     , test-tox-env: gallery-py38-minimum   , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-upgraded   , test-tox-env: gallery-py311-upgraded , python-ver: "3.11", os: ubuntu-latest }
+          - { name: windows-gallery-python3.8-minimum   , test-tox-env: gallery-py38-minimum   , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-gallery-python3.11-upgraded , test-tox-env: gallery-py311-upgraded , python-ver: "3.11", os: windows-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          conda install -c conda-forge tox
+          conda install -c conda-forge "tox>=4"
 
       - name: Conda reporting
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,12 +24,12 @@ jobs:
         include:
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.8-minimum      , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: pytest-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-upgraded    , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
+          - { name: linux-python3.12             , test-tox-env: pytest-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.12-upgraded    , test-tox-env: pytest-py312-upgraded  , python-ver: "3.12", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.8-minimum    , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.11-upgraded  , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12-upgraded  , test-tox-env: pytest-py312-upgraded  , python-ver: "3.12", os: windows-latest }
           - { name: macos-python3.8-minimum      , test-tox-env: pytest-py38-minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.11-upgraded    , test-tox-env: pytest-py311-upgraded  , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12-upgraded    , test-tox-env: pytest-py312-upgraded  , python-ver: "3.12", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -86,9 +86,9 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.8-minimum     , test-tox-env: gallery-py38-minimum   , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.11-upgraded   , test-tox-env: gallery-py311-upgraded , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-upgraded   , test-tox-env: gallery-py312-upgraded , python-ver: "3.12", os: ubuntu-latest }
           - { name: windows-gallery-python3.8-minimum   , test-tox-env: gallery-py38-minimum   , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-gallery-python3.11-upgraded , test-tox-env: gallery-py311-upgraded , python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.12-upgraded , test-tox-env: gallery-py312-upgraded , python-ver: "3.12", os: windows-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
       matrix:
         include:
           - { name: conda-linux-python3.8-minimum    , test-tox-env: py38-minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12-upgraded  , test-tox-env: py312-upgraded  , python-ver: "3.12", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v3
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.12-ros3  , python-ver: "3.12", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.11.0 (Upcoming)
+## HDMF 3.11.0 (October 30, 2023)
 
 ### Enhancements
 - Added `target_tables` attribute to `DynamicTable` to allow users to specify the target table of any predefined
@@ -10,6 +10,7 @@
 ### Minor improvements
 - Set up GitHub dependabot to check for updates to GitHub Actions. @rly [#977](https://github.com/hdmf-dev/hdmf/pull/977)
 - Simplify tox configuration. @rly [#988](https://github.com/hdmf-dev/hdmf/pull/988)
+- Add testing for Python 3.12. @rly [#988](https://github.com/hdmf-dev/hdmf/pull/988)
 
 ### Bug fixes
 - Updated custom class generation to handle specs with fixed values and required names. @rly [#800](https://github.com/hdmf-dev/hdmf/pull/800)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Minor improvements
 - Set up GitHub dependabot to check for updates to Python requirements and GitHub Actions. @rly [#977](https://github.com/hdmf-dev/hdmf/pull/977)
+- Simplify tox configuration. @rly [#988](https://github.com/hdmf-dev/hdmf/pull/988)
 
 ### Bug fixes
 - Updated custom class generation to handle specs with fixed values and required names. @rly [#800](https://github.com/hdmf-dev/hdmf/pull/800)

--- a/README.rst
+++ b/README.rst
@@ -60,12 +60,12 @@ See the `HDMF documentation <https://hdmf.readthedocs.io/en/stable/install_users
 Code of Conduct
 ===============
 
-This project and everyone participating in it is governed by our `code of conduct guidelines <.github/CODE_OF_CONDUCT.md>`_. By participating, you are expected to uphold this code.
+This project and everyone participating in it is governed by our `code of conduct guidelines <https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md>`_. By participating, you are expected to uphold this code.
 
 Contributing
 ============
 
-For details on how to contribute to HDMF see our `contribution guidelines <docs/CONTRIBUTING.rst>`_.
+For details on how to contribute to HDMF see our `contribution guidelines <https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst>`_.
 
 Citing HDMF
 ===========

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ sphinx_gallery_conf = {
 }
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.11", None),
+    "python": ("https://docs.python.org/3.12", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),

--- a/docs/source/install_developers.rst
+++ b/docs/source/install_developers.rst
@@ -52,11 +52,11 @@ Option 2: Using conda
 
 The `conda package and environment management system`_ is an alternate way of managing virtual environments.
 First, install Anaconda_ to install the ``conda`` tool. Then create and
-activate a new virtual environment called ``"hdmf-env"`` with Python 3.11 installed.
+activate a new virtual environment called ``"hdmf-env"`` with Python 3.12 installed.
 
 .. code:: bash
 
-    conda create --name hdmf-env python=3.11
+    conda create --name hdmf-env python=3.12
     conda activate hdmf-env
 
 Similar to a virtual environment created with ``venv``, a conda environment

--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -4,7 +4,7 @@
 Installing HDMF
 ---------------
 
-HDMF requires having Python 3.8, 3.9, 3.10, or 3.11 installed. If you don't have Python installed and want the simplest way to
+HDMF requires having Python 3.8, 3.9, 3.10, 3.11, or 3.12 installed. If you don't have Python installed and want the simplest way to
 get started, we recommend you install and use the `Anaconda Distribution`_. It includes Python, NumPy, and many other
 commonly used packages for scientific computing and data science.
 

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -4,12 +4,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.11
-  - h5py==3.9.0
+  - python==3.12
+  - h5py==3.10.0
   - matplotlib==3.8.0
-  - numpy==1.26.0
-  - pandas==2.1.1
+  - numpy==1.26.1
+  - pandas==2.1.2
   - python-dateutil==2.8.2
-  - pytest==7.4.2
+  - pytest==7.4.3
   - pytest-cov==4.1.0
   - setuptools

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -7,7 +7,7 @@ dependencies:
   - python==3.12
   - h5py==3.10.0
   - matplotlib==3.8.0
-  - numpy==1.26.1
+  - numpy==1.26.0
   - pandas==2.1.2
   - python-dateutil==2.8.2
   - pytest==7.4.3

--- a/test_gallery.py
+++ b/test_gallery.py
@@ -35,6 +35,12 @@ _experimental_warning_re = (
 
 pydantic_warning_re = ("Support for class-based `config` is deprecated, use ConfigDict instead.")
 
+datetime_warning_re = (
+    "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
+    "in a future version. Use timezone-aware objects to represent datetimes in UTC: "
+    "datetime.datetime.fromtimestamp(timestamp, datetime.UTC)."
+)
+
 
 def run_gallery_tests():
     global TOTAL, FAILURES, ERRORS
@@ -77,6 +83,12 @@ def run_gallery_tests():
                     # will be deprecated in the future
                     "ignore",
                     message=pydantic_warning_re,
+                    category=DeprecationWarning,
+                )
+                warnings.filterwarnings(
+                    # this warning is triggered from pandas 2.1.2 and python 3.12
+                    "ignore",
+                    message=datetime_warning_re,
                     category=DeprecationWarning,
                 )
                 _import_from_file(script)

--- a/test_gallery.py
+++ b/test_gallery.py
@@ -26,21 +26,10 @@ def _import_from_file(script):
 
 _numpy_warning_re = "numpy.ufunc size changed, may indicate binary incompatibility. Expected 216, got 192"
 
-_distutils_warning_re = "distutils Version classes are deprecated. Use packaging.version instead."
-
 _experimental_warning_re = (
     "[a-zA-Z0-9]+ is experimental -- it may be removed in the future "
     "and is not guaranteed to maintain backward compatibility"
 )
-
-pydantic_warning_re = ("Support for class-based `config` is deprecated, use ConfigDict instead.")
-
-datetime_warning_re = (
-    "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
-    "in a future version. Use timezone-aware objects to represent datetimes in UTC: "
-    "datetime.datetime.fromtimestamp(timestamp, datetime.UTC)."
-)
-
 
 def run_gallery_tests():
     global TOTAL, FAILURES, ERRORS
@@ -54,6 +43,10 @@ def run_gallery_tests():
                 gallery_file_names.append(os.path.join(root, f))
 
     warnings.simplefilter("error")
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,  # these can be triggered by downstream packages. ignore for these tests
+    )
 
     TOTAL += len(gallery_file_names)
     for script in gallery_file_names:
@@ -66,30 +59,11 @@ def run_gallery_tests():
                     category=UserWarning,
                 )
                 warnings.filterwarnings(
-                    # this warning is triggered from pandas when HDMF is installed with the minimum requirements
-                    "ignore",
-                    message=_distutils_warning_re,
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings(
                     # this warning is triggered when some numpy extension code in an upstream package was compiled
                     # against a different version of numpy than the one installed
                     "ignore",
                     message=_numpy_warning_re,
                     category=RuntimeWarning,
-                )
-                warnings.filterwarnings(
-                    # this warning is triggered when some linkml dependency like curies uses pydantic in a way that
-                    # will be deprecated in the future
-                    "ignore",
-                    message=pydantic_warning_re,
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings(
-                    # this warning is triggered from pandas 2.1.2 and python 3.12
-                    "ignore",
-                    message=datetime_warning_re,
-                    category=DeprecationWarning,
                 )
                 _import_from_file(script)
         except (ImportError, ValueError) as e:

--- a/test_gallery.py
+++ b/test_gallery.py
@@ -81,8 +81,8 @@ def run_gallery_tests():
                 )
                 _import_from_file(script)
         except (ImportError, ValueError) as e:
-            if "linkml" in str(e) and sys.version_info < (3, 9):
-                pass  # this is OK because plot_term_set.py and plot_external_resources.py cannot be run on Python 3.8
+            if "linkml" in str(e):
+                pass  # this is OK because linkml is not always installed
             else:
                 raise e
         except Exception:

--- a/tox.ini
+++ b/tox.ini
@@ -1,193 +1,59 @@
 # Tox (https://tox.readthedocs.io/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# and then run "tox -e [envname]" from this directory.
 
 [tox]
-envlist = py38, py39, py310, py311
 requires = pip >= 22.0
 
 [testenv]
 download = True
 usedevelop = True
 setenv =
-  PYTHONDONTWRITEBYTECODE = 1
-  VIRTUALENV_PIP = 22.3.1
+    PYTHONDONTWRITEBYTECODE = 1
+    VIRTUALENV_PIP = 23.3.1
+recreate =
+    pinned, minimum, upgraded, prerelease: False
+    build, wheelinstall: True  # good practice to recreate the environment
+skip_install =
+    pinned, minimum, upgraded, prerelease, wheelinstall: False
+    build: True  # no need to install anything when building
 install_command =
-    python -m pip install {opts} {packages}
-
+    # when using [testenv:wheelinstall] and --installpkg, the wheel and its dependencies
+    # are installed, instead of the package in the current directory
+    pinned, minimum, wheelinstall: python -I -m pip install {opts} {packages}
+    upgraded:                      python -I -m pip install -U {opts} {packages}
+    prerelease:                    python -I -m pip install -U --pre {opts} {packages}
 deps =
-    -rrequirements-dev.txt
-    -rrequirements.txt
+    # use pinned, minimum, or neither (use dependencies in pyproject.toml)
+    pytest, gallery: -rrequirements-dev.txt
+    gallery:         -rrequirements-doc.txt
+    optional:        -rrequirements-opt.txt
+    pinned:          -rrequirements.txt
+    minimum:         -rrequirements-min.txt
 commands =
-    python -m pip check  # Check for conflicting packages
-    python -m pip list
-    pytest -v
+    python --version     # print python version for debugging
+    python -m pip check  # check for conflicting packages
+    python -m pip list   # list installed packages for debugging
+    pytest:       pytest -v
+    gallery:      python test_gallery.py
+    build:        python -m pip install -U build
+    build:        python -m build
+    wheelinstall: python -c "import hdmf; import hdmf.common"
 
-# Test with python 3.11; pinned dev and optional reqs
-[testenv:py311-optional]
-basepython = python3.11
-deps =
-    {[testenv]deps}
-    -rrequirements-opt.txt
-commands = {[testenv]commands}
+# list of pre-defined environments. (Technically environments not listed here
+# like build-py312 can also be used.)
+[testenv:pytest-py312-upgraded]
+[testenv:pytest-py312-prerelease]
+[testenv:pytest-py311-optional-pinned]  # some optional reqs not compatible with py312 yet
+[testenv:pytest-py{38,39,310,311,312}-pinned]
+[testenv:pytest-py38-minimum]
 
-# Test with python 3.11; pinned dev and optional reqs; upgraded run reqs
-[testenv:py311-upgraded]
-basepython = python3.11
-install_command =
-    python -m pip install -U {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-opt.txt
-commands = {[testenv]commands}
-
-# Test with python 3.11; pinned dev and optional reqs; upgraded, pre-release run reqs
-[testenv:py311-prerelease]
-basepython = python3.11
-install_command =
-    python -m pip install -U --pre {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-opt.txt
-commands = {[testenv]commands}
-
-# Test with python 3.8; pinned dev reqs; minimum run reqs
-[testenv:py38-minimum]
-basepython = python3.8
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-min.txt
-commands = {[testenv]commands}
-
-# Envs that builds wheels and source distribution
-[testenv:build]
-commands =
-    python -m pip install --upgrade build
-    python -m build
-
-[testenv:build-py38]
-basepython = python3.8
-commands = {[testenv:build]commands}
-
-[testenv:build-py39]
-basepython = python3.9
-commands = {[testenv:build]commands}
-
-[testenv:build-py310]
-basepython = python3.10
-commands = {[testenv:build]commands}
-
-[testenv:build-py311]
-basepython = python3.11
-commands = {[testenv:build]commands}
-
-[testenv:build-py311-optional]
-basepython = python3.11
-deps =
-    {[testenv]deps}
-    -rrequirements-opt.txt
-commands = {[testenv:build]commands}
-
-[testenv:build-py311-upgraded]
-basepython = python3.11
-install_command =
-    python -m pip install -U {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-opt.txt
-commands = {[testenv:build]commands}
-
-[testenv:build-py311-prerelease]
-basepython = python3.11
-install_command =
-    python -m pip install -U --pre {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-opt.txt
-commands = {[testenv:build]commands}
-
-[testenv:build-py38-minimum]
-basepython = python3.8
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-min.txt
-commands = {[testenv:build]commands}
-
-# Envs that will test installation from a wheel
-[testenv:wheelinstall]
-deps = null
-commands = python -c "import hdmf; import hdmf.common"
-
-# Envs that will execute gallery tests
-[testenv:gallery]
-install_command =
-    python -m pip install {opts} {packages}
-
-deps =
-    -rrequirements-dev.txt
-    -rrequirements.txt
-    -rrequirements-doc.txt
-
-commands =
-    python test_gallery.py
-
-[testenv:gallery-py38]
-basepython = python3.8
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
-[testenv:gallery-py39]
-basepython = python3.9
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
-[testenv:gallery-py310]
-basepython = python3.10
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
-[testenv:gallery-py311]
-basepython = python3.11
-deps = {[testenv:gallery]deps}
-commands = {[testenv:gallery]commands}
-
-[testenv:gallery-py311-optional]
-basepython = python3.11
-deps =
-    -rrequirements-dev.txt
-    -rrequirements.txt
-    -rrequirements-doc.txt
-    -rrequirements-opt.txt
-commands = {[testenv:gallery]commands}
-
-# Test with python 3.11; pinned dev, doc, and optional reqs; upgraded run reqs
-[testenv:gallery-py311-upgraded]
-basepython = python3.11
-install_command =
-    python -m pip install -U {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-doc.txt
-    -rrequirements-opt.txt
-commands = {[testenv:gallery]commands}
-
-# Test with python 3.11; pinned dev, doc, and optional reqs; pre-release run reqs
-[testenv:gallery-py311-prerelease]
-basepython = python3.11
-install_command =
-    python -m pip install -U --pre {opts} {packages}
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-doc.txt
-    -rrequirements-opt.txt
-commands = {[testenv:gallery]commands}
-
-# Test with python 3.8; pinned dev and doc reqs; minimum run reqs
+[testenv:gallery-py312-upgraded]
+[testenv:gallery-py312-prerelease]
+[testenv:gallery-py311-optional-pinned]
+[testenv:gallery-py{38,39,310,311,312}-pinned]
 [testenv:gallery-py38-minimum]
-basepython = python3.8
-deps =
-    -rrequirements-dev.txt
-    -rrequirements-min.txt
-    -rrequirements-doc.txt
-commands = {[testenv:gallery]commands}
+
+[testenv:build]  # using tox for this so that we can have a clean build environment
+[testenv:wheelinstall]  # use with `--installpkg dist/*-none-any.whl`


### PR DESCRIPTION
## Motivation

1. We have to update `tox.ini` regularly when we want to test with new versions of python or make other changes to the testing infastructure. This PR simplifies `tox.ini` and makes tox more efficient in some ways, though it makes it more complex in others. I think this will be easier to maintain, since the only changes we need to make when adding new versions of python are to the list of predefined environments (which technically do not need to be listed at all, but it is nice to). 

2. Add testing for Python 3.12. Fix #904.

3. Replace the `styfle/cancel-workflow-action@0.11.0` action with the github action `concurrency` key that the workflow authors recommend.

4. Change some links to absolute links in `README.rst` to work on the PyPI page.
5. Update package versions in `environment-ros3.yml`
6. Normally all warnings generated from `test_gallery.py` result in errors / test failures. I realize now that this is too strict for `DeprecationWarning`s that come from updates to upstream packages. We should inspect those warnings when running local tests, but adding an exception for every `DeprecationWarning` from an upstream package that we have no control over is very tedious.

## How to test the behavior?
```
Run GitHub Actions workflows
```
