### PR TITLE
Prepare for release of HDMF 3.11.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,4 +1,4 @@
-Prepare for release of HDMF [version]
+Prepare for release of HDMF 3.11.0
 
 ### Before merging:
 - [ ] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,
@@ -16,6 +16,8 @@ Prepare for release of HDMF [version]
   (`pytest && python test_gallery.py`)
 - [ ] Run PyNWB tests locally including gallery and validation tests, and inspect all warnings and outputs
   (`cd pynwb; python test.py -v > out.txt 2>&1`)
+- [ ] Run HDMF-Zarr tests locally including gallery and validation tests, and inspect all warnings and outputs
+  (`cd hdmf-zarr; pytest && python test_gallery.py`)
 - [ ] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
 - [ ] Push changes to this PR and make sure all PRs to be included in this release have been merged
 - [ ] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,4 +1,4 @@
-Prepare for release of HDMF 3.11.0
+Prepare for release of HDMF [version]
 
 ### Before merging:
 - [ ] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,9 @@ Overall Health
 .. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/run_pynwb_tests.yml/badge.svg
     :target: https://github.com/hdmf-dev/hdmf/actions/workflows/run_pynwb_tests.yml
 
+.. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/run_hdmf_zarr_tests.yml/badge.svg
+    :target: https://github.com/hdmf-dev/hdmf/actions/workflows/run_hdmf_zarr_tests.yml
+
 .. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/run_all_tests.yml/badge.svg
     :target: https://github.com/hdmf-dev/hdmf/actions/workflows/run_all_tests.yml
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -565,9 +565,9 @@ class TestDynamicTable(TestCase):
         rows = table[0:5:2]
         self.assertIsInstance(rows, pd.DataFrame)
         self.assertTupleEqual(rows.shape, (3, 3))
-        self.assertEqual(rows.iloc[2][0], 5)
-        self.assertEqual(rows.iloc[2][1], 50.0)
-        self.assertEqual(rows.iloc[2][2], 'lizard')
+        self.assertEqual(rows.iloc[2].iloc[0], 5)
+        self.assertEqual(rows.iloc[2].iloc[1], 50.0)
+        self.assertEqual(rows.iloc[2].iloc[2], 'lizard')
 
     def test_getitem_invalid_keytype(self):
         table = self.with_spec()


### PR DESCRIPTION
Prepare for release of HDMF 3.11.0

Minor changes to fix a pandas deprecation warning, missing badge, and add a check to the release checklist. I set the release date to Oct. 30. 

### Before merging:
- [x] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,
  `requirements-doc.txt`, `requirements-opt.txt`, and `environment-ros3.yml` to the latest versions,
  and update dependency ranges in `pyproject.toml` and minimums in `requirements-min.txt` as needed.
  Run `pip install pur && pur -r requirements-dev.txt -r requirements.txt -r requirements-opt.txt`
  and manually update `environment-ros3.yml`.
- [x] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `pyproject.toml` as needed
- [x] Update `README.rst` as needed
- [x] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number and commit SHA manually
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs
  (`pytest && python test_gallery.py`)
- [x] Run PyNWB tests locally including gallery and validation tests, and inspect all warnings and outputs
  (`cd pynwb; python test.py -v > out.txt 2>&1`)
- [x] Run HDMF-Zarr tests locally including gallery and validation tests, and inspect all warnings and outputs
  (`cd hdmf-zarr; pytest && python test_gallery.py`)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/hdmf/builds/

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
   [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
3. Check that the readthedocs "latest" and "stable" builds run and succeed
4. Update [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock) with the latest version number
   and SHA256 retrieved from PyPI > HDMF > Download Files > View hashes for the `.tar.gz` file. Re-render as needed
