### PR TITLE
_gather_columns agnostic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.11.1 (Upcoming)
+
+### Minor Improvements
+- Updated `__gather_columns` to ignore the order of bases when generating columns from the super class. @mavaylon1 [#991](https://github.com/hdmf-dev/hdmf/pull/991)
+
 ## HDMF 3.11.0 (October 30, 2023)
 
 ### Enhancements

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -268,7 +268,7 @@ class DynamicTable(Container):
 
     @ExtenderMeta.pre_init
     def __gather_columns(cls, name, bases, classdict):
-        """
+        r"""
         Gather columns from the *\_\_columns\_\_* class attribute and add them to the class.
 
         This classmethod will be called during class declaration in the metaclass to automatically

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -268,7 +268,7 @@ class DynamicTable(Container):
 
     @ExtenderMeta.pre_init
     def __gather_columns(cls, name, bases, classdict):
-        r"""
+        """
         Gather columns from the *\_\_columns\_\_* class attribute and add them to the class.
 
         This classmethod will be called during class declaration in the metaclass to automatically
@@ -281,14 +281,11 @@ class DynamicTable(Container):
         if len(bases) and 'DynamicTable' in globals():
             for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
                 if issubclass(item, Container):
-                    try:
-                        if item.__columns__ is not cls.__columns__:
-                            new_columns = list(cls.__columns__)
-                            new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
-                            cls.__columns__ = tuple(new_columns)
-                            break
-                    except AttributeError:  # raises error when "__columns__" is not an attr of item
-                        continue
+                    if item.__columns__ is not cls.__columns__:
+                        new_columns = list(cls.__columns__)
+                        new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
+                        cls.__columns__ = tuple(new_columns)
+                        break
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table'},

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -286,7 +286,7 @@ class DynamicTable(Container):
                             new_columns = list(cls.__columns__)
                             new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)
-                    except AttributeError:
+                    except AttributeError:  # raises error when "__columns__" is not an attr of item
                         continue
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -281,11 +281,14 @@ class DynamicTable(Container):
         if len(bases) and 'DynamicTable' in globals():
             for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
                 if issubclass(item, Container):
-                    if item.__columns__ is not cls.__columns__:
-                        new_columns = list(cls.__columns__)
-                        new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
-                        cls.__columns__ = tuple(new_columns)
-                        break
+                    try:
+                        if item.__columns__ is not cls.__columns__:
+                            new_columns = list(cls.__columns__)
+                            new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
+                            cls.__columns__ = tuple(new_columns)
+                            break
+                    except AttributeError:  # raises error when "__columns__" is not an attr of item
+                        continue
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table'},

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -287,7 +287,7 @@ class DynamicTable(Container):
                             new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)
                             break
-                    except AttributeError:  # raises error when "__columns__" is not an attr of item
+                    except AttributeError:
                         continue
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -279,7 +279,7 @@ class DynamicTable(Container):
             raise TypeError(msg)
 
         if len(bases) and 'DynamicTable' in globals():
-            for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
+            for item in bases[::-1]: # look for __columns__ in the base classes, closest first
                 if issubclass(item, Container):
                     try:
                         if item.__columns__ is not cls.__columns__:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -279,7 +279,6 @@ class DynamicTable(Container):
             raise TypeError(msg)
 
         if len(bases) and 'DynamicTable' in globals():
-            breakpoint()
             for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
                 if issubclass(item, Container):
                     try:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -284,7 +284,7 @@ class DynamicTable(Container):
                     try:
                         if item.__columns__ is not cls.__columns__:
                             new_columns = list(cls.__columns__)
-                            new_columns[0:0] = bases[-1].__columns__  # prepend superclass columns to new_columns
+                            new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)
                     except AttributeError:
                         continue

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -287,7 +287,7 @@ class DynamicTable(Container):
                             new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)
                             break
-                    except AttributeError:
+                    except AttributeError:   # raises error when "__columns__" is not an attr of item
                         continue
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -279,13 +279,16 @@ class DynamicTable(Container):
             raise TypeError(msg)
 
         if len(bases) and 'DynamicTable' in globals():
-            for item in bases:
+            for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
                 if issubclass(item, Container):
                     try:
                         if item.__columns__ is not cls.__columns__:
+                            if cls.__name__ == 'PlaneSegmentation':
+                                breakpoint()
                             new_columns = list(cls.__columns__)
                             new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)
+                            break
                     except AttributeError:  # raises error when "__columns__" is not an attr of item
                         continue
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -283,8 +283,6 @@ class DynamicTable(Container):
                 if issubclass(item, Container):
                     try:
                         if item.__columns__ is not cls.__columns__:
-                            if cls.__name__ == 'PlaneSegmentation':
-                                breakpoint()
                             new_columns = list(cls.__columns__)
                             new_columns[0:0] = item.__columns__  # prepend superclass columns to new_columns
                             cls.__columns__ = tuple(new_columns)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -279,6 +279,7 @@ class DynamicTable(Container):
             raise TypeError(msg)
 
         if len(bases) and 'DynamicTable' in globals():
+            breakpoint()
             for item in bases[::-1]: # reverse the bases tuple as the code suggest it should be last
                 if issubclass(item, Container):
                     try:

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -278,11 +278,16 @@ class DynamicTable(Container):
             msg = "'__columns__' must be of type tuple, found %s" % type(cls.__columns__)
             raise TypeError(msg)
 
-        if (len(bases) and 'DynamicTable' in globals() and issubclass(bases[-1], Container)
-                and bases[-1].__columns__ is not cls.__columns__):
-            new_columns = list(cls.__columns__)
-            new_columns[0:0] = bases[-1].__columns__  # prepend superclass columns to new_columns
-            cls.__columns__ = tuple(new_columns)
+        if len(bases) and 'DynamicTable' in globals():
+            for item in bases:
+                if issubclass(item, Container):
+                    try:
+                        if item.__columns__ is not cls.__columns__:
+                            new_columns = list(cls.__columns__)
+                            new_columns[0:0] = bases[-1].__columns__  # prepend superclass columns to new_columns
+                            cls.__columns__ = tuple(new_columns)
+                    except AttributeError:
+                        continue
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},  # noqa: C901
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table'},

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -837,6 +837,10 @@ class ExtenderMeta(ABCMeta):
 
     @classmethod
     def pre_init(cls, func):
+        """
+        A decorator that sets a '__preinit' attribute on the target function and
+        then returns the function as a classmethod. 
+        """
         setattr(func, cls.__preinit, True)
         return classmethod(func)
 

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -839,7 +839,7 @@ class ExtenderMeta(ABCMeta):
     def pre_init(cls, func):
         """
         A decorator that sets a '__preinit' attribute on the target function and
-        then returns the function as a classmethod. 
+        then returns the function as a classmethod.
         """
         setattr(func, cls.__preinit, True)
         return classmethod(func)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -15,7 +15,7 @@ from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 from hdmf.utils import StrDataset
 from hdmf.data_utils import DataChunkIterator
 
-from tests.unit.helpers.utils import get_temp_filepath
+from tests.unit.helpers.utils import get_temp_filepath, FooExtendDynamicTable0, FooExtendDynamicTable1, FooExtendDynamicTable2
 
 try:
     import linkml_runtime  # noqa: F401
@@ -2677,7 +2677,7 @@ class TestVectorIndexDtype(TestCase):
         self.assertEqual(index.data[0], 255)  # make sure the 255 is upgraded
         self.assertEqual(type(index.data[0]), np.uint32)
 
-from tests.unit.helpers.utils import FooExtendDynamicTable0, FooExtendDynamicTable1, FooExtendDynamicTable2
+
 class TestDynamicTableSubclassColumns(TestCase):
     def setUp(self):
         self.foo1 = FooExtendDynamicTable0()

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -2676,3 +2676,19 @@ class TestVectorIndexDtype(TestCase):
         index.add_vector(list(range(65536 - 255)))
         self.assertEqual(index.data[0], 255)  # make sure the 255 is upgraded
         self.assertEqual(type(index.data[0]), np.uint32)
+
+from tests.unit.helpers.utils import FooExtendDynamicTable0, FooExtendDynamicTable1, FooExtendDynamicTable2
+class TestDynamicTableSubclassColumns(TestCase):
+    def setUp(self):
+        self.foo1 = FooExtendDynamicTable0()
+        self.foo2 = FooExtendDynamicTable1()
+        self.foo3 = FooExtendDynamicTable2()
+
+    def test_columns(self):
+        self.assertEqual(self.foo1.__columns__,
+                        ({'name': 'col1', 'description': '...'}, {'name': 'col2', 'description': '...'}))
+        self.assertEqual(self.foo2.__columns__,
+                        ({'name': 'col1', 'description': '...'}, {'name': 'col2', 'description': '...'},
+                         {'name': 'col3', 'description': '...'}, {'name': 'col4', 'description': '...'})
+)
+        self.assertEqual(self.foo2.__columns__, self.foo3.__columns__)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -15,7 +15,8 @@ from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 from hdmf.utils import StrDataset
 from hdmf.data_utils import DataChunkIterator
 
-from tests.unit.helpers.utils import get_temp_filepath, FooExtendDynamicTable0, FooExtendDynamicTable1, FooExtendDynamicTable2
+from tests.unit.helpers.utils import (get_temp_filepath, FooExtendDynamicTable0,
+                                      FooExtendDynamicTable1, FooExtendDynamicTable2)
 
 try:
     import linkml_runtime  # noqa: F401

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -3,6 +3,7 @@ import tempfile
 from copy import copy, deepcopy
 
 from hdmf.build import BuildManager, ObjectMapper, TypeMap
+from hdmf.common.table import DynamicTable
 from hdmf.container import Container, HERDManager, Data
 from hdmf.spec import (
     AttributeSpec,
@@ -664,6 +665,11 @@ class FooExtendDynamicTable0(DynamicTable):
         {'name': 'col2', 'description': '...'},
     )
 
+    def __init__(self, **kwargs):
+        kwargs['name'] = 'foo0'
+        kwargs['description'] = '...'
+        super().__init__(**kwargs)
+
 
 class FooExtendDynamicTable1(FooExtendDynamicTable0):
     """
@@ -676,5 +682,14 @@ class FooExtendDynamicTable1(FooExtendDynamicTable0):
         {'name': 'col4', 'description': '...'},
     )
 
-class FooExtendDynamicTable2(FooExtendDynamicTable2):
-    pass
+    def __init__(self, **kwargs):
+        kwargs['name'] = 'foo1'
+        kwargs['description'] = '...'
+        super().__init__(**kwargs)
+
+
+class FooExtendDynamicTable2(FooExtendDynamicTable1):
+    def __init__(self, **kwargs):
+        kwargs['name'] = 'foo2'
+        kwargs['description'] = '...'
+        super().__init__(**kwargs)

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 
 from hdmf.build import BuildManager, ObjectMapper, TypeMap
 from hdmf.common.table import DynamicTable
-from hdmf.container import Container, HERDManager, Data
+from hdmf.container import Container, HERDManager, Data, MultiContainerInterface
 from hdmf.spec import (
     AttributeSpec,
     DatasetSpec,
@@ -688,7 +688,7 @@ class FooExtendDynamicTable1(FooExtendDynamicTable0):
         super().__init__(**kwargs)
 
 
-class FooExtendDynamicTable2(FooExtendDynamicTable1):
+class FooExtendDynamicTable2(FooExtendDynamicTable1, MultiContainerInterface):
     def __init__(self, **kwargs):
         kwargs['name'] = 'foo2'
         kwargs['description'] = '...'

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -653,3 +653,28 @@ class CustomSpecNamespace(SpecNamespace):
     @classmethod
     def types_key(cls):
         return cls.__types_key
+
+class FooExtendDynamicTable0(DynamicTable):
+    """
+    Within PyNWB, PlaneSegmentation extends DynamicTable and sets __columns__. This class is a helper
+    class for testing and is directly meant to test __gather_columns, i.e., class generation, downstream.
+    """
+    __columns__ = (
+        {'name': 'col1', 'description': '...'},
+        {'name': 'col2', 'description': '...'},
+    )
+
+
+class FooExtendDynamicTable1(FooExtendDynamicTable0):
+    """
+    In extensions, users can create new classes that inherit from classes that inherit from DynamicTable.
+    This is a helper class for testing and is directly meant to test __gather_columns, i.e.,
+    class generation, downstream.
+    """
+    __columns__ = (
+        {'name': 'col3', 'description': '...'},
+        {'name': 'col4', 'description': '...'},
+    )
+
+class FooExtendDynamicTable2(FooExtendDynamicTable2):
+    pass

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -693,6 +693,7 @@ class FooExtendDynamicTable2(FooExtendDynamicTable1, MultiContainerInterface):
         'add': '...',
         'get': '...',
         'create': '...',
+        'type': Container,
         'attr': '...'
     }
 

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -689,6 +689,13 @@ class FooExtendDynamicTable1(FooExtendDynamicTable0):
 
 
 class FooExtendDynamicTable2(FooExtendDynamicTable1, MultiContainerInterface):
+    __clsconf__ = {
+        'add': '...',
+        'get': '...',
+        'create': '...',
+        'attr': '...'
+    }
+
     def __init__(self, **kwargs):
         kwargs['name'] = 'foo2'
         kwargs['description'] = '...'


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Within DynamicTable is a pre-init method _gather_columns that uses the base classes in a conditional to create pre-defined columns. When autogenerating a class, the order of these classes are determined in classgenerator.py
```
if '__clsconf__' in classdict:
            # do not add MCI as a base if a base is already a subclass of MultiContainerInterface
            for b in bases:
                if issubclass(b, MultiContainerInterface):
                    break
            else:
                if issubclass(MultiContainerInterface, bases[0]):
                    # if bases[0] is Container or another superclass of MCI, then make sure MCI goes first
                    # otherwise, MRO is ambiguous
                    bases.insert(0, MultiContainerInterface)
                else:
                    # bases[0] is not a subclass of MCI and not a superclass of MCI. place that class first
                    # before MCI. that class __init__ should call super().__init__ which will call the
                    # MCI init
                    bases.insert(1, MultiContainerInterface)
```

This results in an issue for an extension that use the nwbinspector to validate the NWBFile. The best fix is to make the search in _gather_columns agnostic to the order.


## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
