### PR TITLE
remove 1 MB chunk recommendation

### DIFF
--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -290,7 +290,7 @@ class GenericDataChunkIterator(AbstractDataChunkIterator):
         dict(
             name="chunk_mb",
             type=(float, int),
-            doc="Size of the HDF5 chunk in megabytes. Recommended to be less than 1MB.",
+            doc="Size of the HDF5 chunk in megabytes.",
             default=None,
         )
     )


### PR DESCRIPTION
change recommendation. This is no longer true as 1 MB is not ideal for cloud computing

