### PR TITLE
Improve issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,9 +80,9 @@ body:
         If GitHub upload is not working, you can also copy and paste the output into this section.
   - type: markdown
     attributes:
-      value: | 
+      value: |
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
         Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
-        
+
         Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,6 +83,6 @@ body:
       value: | 
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
-        Before submitting this issue, please review the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) guide.
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
         
         Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,8 +41,8 @@ body:
     attributes:
       label: Operating System
       options:
-        - Windows
         - macOS
+        - Windows
         - Linux
     validations:
       required: true
@@ -60,11 +60,11 @@ body:
     attributes:
       label: Python Version
       options:
-        - "3.8"
-        - "3.9"
-        - "3.10"
-        - "3.11"
         - "3.12"
+        - "3.11"
+        - "3.10"
+        - "3.9"
+        - "3.8"
     validations:
       required: true
   - type: textarea
@@ -78,15 +78,13 @@ body:
 
         You can attach images or log files by clicking this area to highlight it and then dragging files in.
         If GitHub upload is not working, you can also copy and paste the output into this section.
-  - type: checkboxes
+  - type: markdown
     id: terms
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this bug was not already [reported](https://github.com/hdmf-dev/hdmf/issues)?
-          required: true
+      label: Terms
+      description: | 
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) guide.
+        
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -79,10 +79,8 @@ body:
         You can attach images or log files by clicking this area to highlight it and then dragging files in.
         If GitHub upload is not working, you can also copy and paste the output into this section.
   - type: markdown
-    id: terms
     attributes:
-      label: Terms
-      description: | 
+      value: | 
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
         Before submitting this issue, please review the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) guide.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -37,6 +37,6 @@ body:
       value: | 
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
-        Before submitting this issue, please review the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) guide.
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
         
         Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -34,9 +34,9 @@ body:
       required: true
   - type: markdown
     attributes:
-      value: | 
+      value: |
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
         Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
-        
+
         Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -32,15 +32,11 @@ body:
         - No.
     validations:
       required: true
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this change was not already [requested](https://github.com/hdmf-dev/hdmf/issues)?
-          required: true
+      value: | 
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) guide.
+        
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -49,9 +49,9 @@ body:
       required: true
   - type: markdown
     attributes:
-      value: | 
+      value: |
         By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
 
         Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
-        
+
         Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,13 +19,10 @@ body:
         What are you trying to achieve with **HDMF**?
 
         Is this a more convenient way to do something that is already possible, or is a workaround currently unfeasible?
+
+        If the change is related to a problem, please provide a clear and concise description of the problem.
     validations:
       required: true
-  - type: textarea
-    id: problem
-    attributes:
-      label: Is your feature request related to a problem?
-      description: A clear and concise description of what the problem is.
   - type: textarea
     id: solution
     attributes:
@@ -50,15 +47,11 @@ body:
         - No.
     validations:
       required: true
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md)
-          required: true
-        - label: Have you checked the [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
-          required: true
-        - label: Have you ensured this change was not already [requested](https://github.com/hdmf-dev/hdmf/issues)?
-          required: true
+      value: | 
+        By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/hdmf-dev/hdmf/blob/dev/.github/CODE_OF_CONDUCT.md).
+
+        Before submitting this issue, please review the [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst).
+        
+        Please also ensure that this issue has not already been [reported](https://github.com/hdmf-dev/hdmf/issues). Thank you!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,7 @@ Show how to reproduce the new behavior (can be a bug fix or a new feature)
 
 ## Checklist
 
-- [ ] Did you update CHANGELOG.md with your changes?
-- [ ] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
-- [ ] Have you ensured the PR clearly describes the problem and the solution?
-- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
-- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
-- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
+- [ ] Did you update `CHANGELOG.md` with your changes?
+- [ ] Does the PR clearly describe the problem and the solution?
+- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
+- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor Improvements
 - Updated `__gather_columns` to ignore the order of bases when generating columns from the super class. @mavaylon1 [#991](https://github.com/hdmf-dev/hdmf/pull/991)
+- Improved issue and PR templates. @rly [#1004](https://github.com/hdmf-dev/hdmf/pull/1004)
 
 ## HDMF 3.11.0 (October 30, 2023)
 


### PR DESCRIPTION
## Motivation

Fix #1003. I also simplified the PR template to reduce the number of checkboxes and text.

I also reordered the Python versions in the issue template to newer first, and I changed the order of OS's to Mac first since that is currently used by all of the core HDMF developers.

## How to test the behavior?
Need to merge this PR to see the changes.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
