### PR TITLE
Validate that int data is used for ElementIdentifiers on init, append, extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Bug fixes
 - Fixed issue with custom class generation when a spec has a `name`. @rly [#1006](https://github.com/hdmf-dev/hdmf/pull/1006)
 
+- Fixed issue where `ElementIdentifiers` data could be set to non-integer values. @rly [#1009](https://github.com/hdmf-dev/hdmf/pull/1009)
+
 ## HDMF 3.11.0 (October 30, 2023)
 
 ### Enhancements

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -763,6 +763,8 @@ class Data(AbstractContainer):
     def __init__(self, **kwargs):
         data = popargs('data', kwargs)
         super().__init__(**kwargs)
+
+        self._validate_new_data(data)
         self.__data = data
 
     @property
@@ -822,6 +824,7 @@ class Data(AbstractContainer):
         return self.data[args]
 
     def append(self, arg):
+        self._validate_new_data_element(arg)
         self.__data = append_data(self.__data, arg)
 
     def extend(self, arg):
@@ -831,7 +834,22 @@ class Data(AbstractContainer):
 
         :param arg: The iterable to add to the end of this VectorData
         """
+        self._validate_new_data(arg)
         self.__data = extend_data(self.__data, arg)
+
+    def _validate_new_data(self, data):
+        """Function to validate a new array that will be set or added to data. Raises an error if the data is invalid.
+
+        Subclasses should override this function to perform class-specific validation.
+        """
+        pass
+
+    def _validate_new_data_element(self, arg):
+        """Function to validate a new value that will be added to the data. Raises an error if the data is invalid.
+
+        Subclasses should override this function to perform class-specific validation.
+        """
+        pass
 
 
 class DataRegion(Data):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1061,6 +1061,8 @@ class DataIO:
             return self.__shape[0]
         if not self.valid:
             raise InvalidDataIOError("Cannot get length of data. Data is not valid.")
+        if isinstance(self.data, AbstractDataChunkIterator):
+            return self.data.maxshape[0]
         return len(self.data)
 
     def __bool__(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1392,6 +1392,38 @@ class TestElementIdentifiers(TestCase):
             _ = (self.e == 'test')
 
 
+class TestBadElementIdentifiers(TestCase):
+
+    def test_bad_dtype(self):
+        with self.assertRaisesWith(ValueError, "ElementIdentifiers must contain integers"):
+            ElementIdentifiers(name='ids', data=["1", "2"])
+
+        with self.assertRaisesWith(ValueError, "ElementIdentifiers must contain integers"):
+            ElementIdentifiers(name='ids', data=np.array(["1", "2"]))
+
+        with self.assertRaisesWith(ValueError, "ElementIdentifiers must contain integers"):
+            ElementIdentifiers(name='ids', data=[1.0, 2.0])
+
+    def test_dci_int_ok(self):
+        a = np.arange(30)
+        dci = DataChunkIterator(data=a, buffer_size=1)
+        e = ElementIdentifiers(name='ids', data=dci)  # test that no error is raised
+        self.assertIs(e.data, dci)
+
+    def test_dci_float_bad(self):
+        a = np.arange(30.0)
+        dci = DataChunkIterator(data=a, buffer_size=1)
+        with self.assertRaisesWith(ValueError, "ElementIdentifiers must contain integers"):
+            ElementIdentifiers(name='ids', data=dci)
+
+    def test_dataio_dci_ok(self):
+        a = np.arange(30)
+        dci = DataChunkIterator(data=a, buffer_size=1)
+        dio = H5DataIO(dci)
+        e = ElementIdentifiers(name='ids', data=dio)  # test that no error is raised
+        self.assertIs(e.data, dio)
+
+
 class SubTable(DynamicTable):
 
     __columns__ = (

--- a/tests/unit/utils_test/test_core_DataIO.py
+++ b/tests/unit/utils_test/test_core_DataIO.py
@@ -8,12 +8,6 @@ from hdmf.testing import TestCase
 
 class DataIOTests(TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_copy(self):
         obj = DataIO(data=[1., 2., 3.])
         obj_copy = copy(obj)


### PR DESCRIPTION
## Motivation

Fix #1001

Added hooks for validating `Data` objects when `data` is being set to a new array, a new element is being added to `data`, and when `data` is being extended with an iterable.

This will be useful when https://github.com/hdmf-dev/hdmf/pull/868 is finished.

This does NOT check when `Data.data` is set to a mutable object like a list and that list object is modified, e.g., 

```python
e = ElementIdentifiers(name="ids", data=[1, 2, 3])
e.data.append("test")  # will work
e.append("test")  # will raise error now
```

I do not think it is possible to stop the above operation.

## How to test the behavior?
```
pytest
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
