### PR TITLE
Fix broken sphinx link in software_process.rst

### DIFF
--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -19,7 +19,7 @@ inconsistencies.
 There are badges in the README_ file which shows the current condition of the dev branch.
 
 .. _GitHub Actions: https://github.com/hdmf-dev/hdmf/actions
-.. _README: https://github.com/hdmf-dev/hdmf#readme
+.. _README: https://github.com/hdmf-dev/hdmf/blob/dev/README.rst
 
 
 --------


### PR DESCRIPTION
## Motivation

Sphinx link-check cannot detect/resolve https://github.com/hdmf-dev/hdmf#readme . It seems like GitHub dynamically generates this anchor. This code https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/linkcheck.py#L616 would normally detect it, but it looks like something changed with the GitHub layout a few days ago - there are now tabs on the main repo page for readme, code of conduct, and license.

This is minor enough not to need a changelog entry.

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
