### PR TITLE
Render code snippet in issue ticket as python

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
         Please copy and paste the code you were trying to run that caused the error.
 
         Feel free to include as little or as much as you think is relevant. This section will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: python
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Motivation

- Minor: Render(colorize) code snippet in issue ticket as python instead of shell. 

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
