### PR TITLE
add option to use a custom html field generation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.12.2 (February 8, 2024)
+
+### Bug fixes
+- Fixed recursion error in html representation generation in jupyter notebooks. @stephprince [#1038](https://github.com/hdmf-dev/hdmf/pull/1038)
+
 ## HDMF 3.12.1 (February 5, 2024)
 
 ### Bug fixes
@@ -7,7 +12,6 @@
 - Fixed internal links in docstrings and tutorials. @stephprince [#1031](https://github.com/hdmf-dev/hdmf/pull/1031)
 - Fixed issue with creating documentation links to classes in docval arguments. @rly [#1036](https://github.com/hdmf-dev/hdmf/pull/1036)
 - Fixed issue with validator not validating against the spec that defines the data type of the builder. @rly [#1050](https://github.com/hdmf-dev/hdmf/pull/1050)
-- Fixed recursion error in html representation generation in jupyter notebooks. @stephprince [#1038](https://github.com/hdmf-dev/hdmf/pull/1038)
 
 ## HDMF 3.12.0 (January 16, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.12.2 (February 8, 2024)
+## HDMF 3.12.2 (February 9, 2024)
 
 ### Bug fixes
 - Fixed recursion error in html representation generation in jupyter notebooks. @stephprince [#1038](https://github.com/hdmf-dev/hdmf/pull/1038)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 - Fixed internal links in docstrings and tutorials. @stephprince [#1031](https://github.com/hdmf-dev/hdmf/pull/1031)
 - Fixed issue with creating documentation links to classes in docval arguments. @rly [#1036](https://github.com/hdmf-dev/hdmf/pull/1036)
+- Fixed recursion error in html representation generation in jupyter notebooks. @stephprince [#1038](https://github.com/hdmf-dev/hdmf/pull/1038)
 
 ## HDMF 3.12.0 (January 16, 2024)
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -642,7 +642,10 @@ class Container(AbstractContainer):
         return html_repr
 
     def _generate_field_html(self, key, value, level, access_code):
-        """Generates HTML for a single field."""
+        """Generates HTML for a single field.
+
+        This function can be overwritten by a child class to implement customized html representations.
+        """
 
         if isinstance(value, (int, float, str, bool)):
             return f'<div style="margin-left: {level * 20}px;" class="container-fields"><span class="field-key"' \

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -626,7 +626,10 @@ class Container(AbstractContainer):
         if isinstance(fields, dict):
             for key, value in fields.items():
                 current_access_code = f"{access_code}.{key}" if is_field else f"{access_code}['{key}']"
-                html_repr += self._generate_field_html(key, value, level, current_access_code)
+                if hasattr(value, '_generate_field_html'):
+                    html_repr += value._generate_field_html(key, value, level, current_access_code)
+                else:
+                    html_repr += self._generate_field_html(key, value, level, current_access_code)
         elif isinstance(fields, list):
             for index, item in enumerate(fields):
                 access_code += f'[{index}]'


### PR DESCRIPTION
## Motivation

Fix #1010 with accompanying changes in pynwb (see related PR https://github.com/NeurodataWithoutBorders/pynwb/pull/1831).

These changes will check whether a value has a  _generate_field_html method and use that method if it is an option when generating html representations.

## How to test the behavior?
See below for an example from the related issue in which timestamps are linked across multiple spatial series.

```
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile
from pynwb.testing.mock.behavior import mock_SpatialSeries, mock_Position
import numpy as np

nwbfile = mock_NWBFile()

test_timestamps = np.zeros((1000,))
test_data = np.random.rand(*(1000, 3))
spatial_series1 = mock_SpatialSeries(name="test1", rate=None, data=test_data, timestamps=test_timestamps)
spatial_series2 = mock_SpatialSeries(name="test2", rate=None, data=test_data, timestamps=spatial_series1)
spatial_series3 = mock_SpatialSeries(name="test3", rate=None, data=test_data, timestamps=spatial_series1)
spatial_series4 = mock_SpatialSeries(name="test4", rate=None, data=test_data, timestamps=spatial_series1)
position = mock_Position(spatial_series=[spatial_series1, spatial_series2, spatial_series3, spatial_series4])

nwbfile.create_processing_module("behavior", description="contains processed behavior data")
nwbfile.processing["behavior"].add(position)

with NWBHDF5IO("test.nwb", "w") as io:
    io.write(nwbfile)

read_io = NWBHDF5IO("test.nwb", "r")
nwbfile_in = read_io.read()

nwbfile_in
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
