### PR TITLE
Fix link checker badge in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Overall Health
 .. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/ruff.yml/badge.svg
     :target: https://github.com/hdmf-dev/hdmf/actions/workflows/ruff.yml
 
-.. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/check_external_links.yml/badge.svg
-    :target: https://github.com/hdmf-dev/hdmf/actions/workflows/check_external_links.yml
+.. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/check_sphinx_links.yml/badge.svg
+    :target: https://github.com/hdmf-dev/hdmf/actions/workflows/check_sphinx_links.yml
 
 .. image:: https://github.com/hdmf-dev/hdmf/actions/workflows/run_pynwb_tests.yml/badge.svg
     :target: https://github.com/hdmf-dev/hdmf/actions/workflows/run_pynwb_tests.yml


### PR DESCRIPTION
## Motivation

The link checker badge is currently broken in the README, because it points to a non-existing workflow

![Screen Shot 2024-02-22 at 9 26 48 AM](https://github.com/hdmf-dev/hdmf/assets/10999845/7beaac32-4ffa-44e8-8dbc-b266f7934a11)

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
