### PR TITLE
Compound Dataset Support for TermSetWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 3.12.3
+## HDMF 3.12.3 (Upcoming)
 ### Enhancements
 - Update `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HDMF Changelog
 
+## HDMF 3.12.3
+### Enhancements
+- Update `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
+
 ## HDMF 3.12.2 (February 9, 2024)
 
 ### Bug fixes
@@ -126,8 +130,8 @@ will increase the minor version number to 3.10.0. See the 3.9.1 release notes be
 ## HDMF 3.6.0 (May 12, 2023)
 
 ### New features and minor improvements
-- Updated `ExternalResources` to have `FileTable` and new methods to query data. the `ResourceTable` has been removed along with methods relating to `Resource`. @mavaylon [#850](https://github.com/hdmf-dev/hdmf/pull/850)
-- Updated hdmf-common-schema version to 1.6.0. @mavaylon [#850](https://github.com/hdmf-dev/hdmf/pull/850)
+- Updated `ExternalResources` to have `FileTable` and new methods to query data. the `ResourceTable` has been removed along with methods relating to `Resource`. @mavaylon1 [#850](https://github.com/hdmf-dev/hdmf/pull/850)
+- Updated hdmf-common-schema version to 1.6.0. @mavaylon1 [#850](https://github.com/hdmf-dev/hdmf/pull/850)
 - Added testing of HDMF-Zarr on PR and nightly. @rly [#859](https://github.com/hdmf-dev/hdmf/pull/859)
 - Replaced `setup.py` with `pyproject.toml`. @rly [#844](https://github.com/hdmf-dev/hdmf/pull/844)
 - Use `ruff` instead of `flake8`. @rly [#844](https://github.com/hdmf-dev/hdmf/pull/844)
@@ -141,7 +145,7 @@ will increase the minor version number to 3.10.0. See the 3.9.1 release notes be
   [#853](https://github.com/hdmf-dev/hdmf/pull/853)
 
 ### Documentation and tutorial enhancements:
-- Updated `ExternalResources` how to tutorial to include the new features. @mavaylon [#850](https://github.com/hdmf-dev/hdmf/pull/850)
+- Updated `ExternalResources` how to tutorial to include the new features. @mavaylon1 [#850](https://github.com/hdmf-dev/hdmf/pull/850)
 
 ## HDMF 3.5.6 (April 28, 2023)
 
@@ -181,13 +185,13 @@ will increase the minor version number to 3.10.0. See the 3.9.1 release notes be
 
 ### Bug fixes
 - Fixed issue with conda CI. @rly [#823](https://github.com/hdmf-dev/hdmf/pull/823)
-- Fixed issue with deprecated `pkg_resources`. @mavaylon [#822](https://github.com/hdmf-dev/hdmf/pull/822)
-- Fixed `hdmf.common` deprecation warning. @mavaylon [#826]((https://github.com/hdmf-dev/hdmf/pull/826)
+- Fixed issue with deprecated `pkg_resources`. @mavaylon1 [#822](https://github.com/hdmf-dev/hdmf/pull/822)
+- Fixed `hdmf.common` deprecation warning. @mavaylon1 [#826]((https://github.com/hdmf-dev/hdmf/pull/826)
 
 ### Internal improvements
 - A number of typos fixed and Github action running codespell to ensure that no typo sneaks in [#825](https://github.com/hdmf-dev/hdmf/pull/825) was added.
-- Added additional documentation for `__fields__` in `AbstactContainer`. @mavaylon [#827](https://github.com/hdmf-dev/hdmf/pull/827)
-- Updated warning message for broken links. @mavaylon [#829](https://github.com/hdmf-dev/hdmf/pull/829)
+- Added additional documentation for `__fields__` in `AbstactContainer`. @mavaylon1 [#827](https://github.com/hdmf-dev/hdmf/pull/827)
+- Updated warning message for broken links. @mavaylon1 [#829](https://github.com/hdmf-dev/hdmf/pull/829)
 
 ## HDMF 3.5.1 (January 26, 2023)
 
@@ -206,9 +210,9 @@ will increase the minor version number to 3.10.0. See the 3.9.1 release notes be
 - Added ``HDMFIO.__del__`` to ensure that I/O objects are being closed on delete. @oruebel[#811](https://github.com/hdmf-dev/hdmf/pull/811)
 
 ### Minor improvements
-- Added support for reading and writing `ExternalResources` to and from denormalized TSV files. @mavaylon [#799](https://github.com/hdmf-dev/hdmf/pull/799)
-- Changed the name of `ExternalResources.export_to_sqlite` to `ExternalResources.to_sqlite`. @mavaylon [#799](https://github.com/hdmf-dev/hdmf/pull/799)
-- Updated the tutorial for `ExternalResources`. @mavaylon [#799](https://github.com/hdmf-dev/hdmf/pull/799)
+- Added support for reading and writing `ExternalResources` to and from denormalized TSV files. @mavaylon1 [#799](https://github.com/hdmf-dev/hdmf/pull/799)
+- Changed the name of `ExternalResources.export_to_sqlite` to `ExternalResources.to_sqlite`. @mavaylon1 [#799](https://github.com/hdmf-dev/hdmf/pull/799)
+- Updated the tutorial for `ExternalResources`. @mavaylon1 [#799](https://github.com/hdmf-dev/hdmf/pull/799)
 - Added `message` argument for assert methods defined by `hdmf.testing.TestCase` to allow developers to include custom error messages with asserts. @oruebel [#812](https://github.com/hdmf-dev/hdmf/pull/812)
 - Clarify the expected chunk shape behavior for `DataChunkIterator`. @oruebel [#813](https://github.com/hdmf-dev/hdmf/pull/813)
 
@@ -349,7 +353,7 @@ the fields (i.e., when the constructor sets some fields to fixed values). @rly
 - Plotted results in external resources tutorial. @oruebel (#667)
 - Added support for Python 3.10. @rly (#679)
 - Updated requirements. @rly @TheChymera (#681)
-- Improved testing for `ExternalResources`. @mavaylon (#673)
+- Improved testing for `ExternalResources`. @mavaylon1 (#673)
 - Improved docs for export. @rly (#674)
 - Enhanced data chunk iteration speeds through new ``GenericDataChunkIterator`` class.  @CodyCBakerPhD (#672)
 - Enhanced issue template forms on GitHub. @CodyCBakerPHD (#700)
@@ -425,7 +429,7 @@ the fields (i.e., when the constructor sets some fields to fixed values). @rly
 - Allow passing ``index=True`` to ``DynamicTable.to_dataframe()`` to support returning `DynamicTableRegion` columns
   as indices or Pandas DataFrame. @rly (#579)
 - Improve ``DynamicTable`` documentation. @rly (#639)
-- Updated external resources tutorial. @mavaylon (#611)
+- Updated external resources tutorial. @mavaylon1 (#611)
 
 ### Breaking changes and deprecations
 - Previously, when using ``DynamicTable.__getitem__`` or ``DynamicTable.get`` to access a selection of a
@@ -510,7 +514,7 @@ the fields (i.e., when the constructor sets some fields to fixed values). @rly
   - Add experimental namespace to HDMF common schema. New data types should go in the experimental namespace
     (hdmf-experimental) prior to being added to the core (hdmf-common) namespace. The purpose of this is to provide
     a place to test new data types that may break backward compatibility as they are refined. @ajtritt (#545)
-  - `ExternalResources` was changed to support storing both names and URIs for resources. @mavaylon (#517, #548)
+  - `ExternalResources` was changed to support storing both names and URIs for resources. @mavaylon1 (#517, #548)
   - The `VocabData` data type was replaced by `EnumData` to provide more flexible support for data from a set of
     fixed values.
   - Added `AlignedDynamicTable`, which defines a `DynamicTable` that supports storing a collection of sub-tables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ## HDMF 3.13.0 (March 20, 2024)
 
 ### Enhancements
-- Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 - Unwrap `TermSetWrapper` within the builder to support different backends more efficiently. @mavaylon1 [#1070](https://github.com/hdmf-dev/hdmf/pull/1070)
 - Added docs page that lists limitations of support for the HDMF specification language. @rly [#1069](https://github.com/hdmf-dev/hdmf/pull/1069)
 - Added warning when using `add_row` or `add_column` to add a ragged array to `DynamicTable` without an index parameter. @stephprince [#1066](https://github.com/hdmf-dev/hdmf/pull/1066)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HDMF 3.12.3 (Upcoming)
 ### Enhancements
-- Update `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
+- Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 
 ## HDMF 3.12.2 (February 9, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HDMF Changelog
 
-## HDMF 3.12.3 (Upcoming)
+## HDMF 3.13.0 (Upcoming)
+
 ### Enhancements
 - Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.14.0 (March 20, 2024)
+
+### Enhancements
+- Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
+
 ## HDMF 3.13.0 (March 20, 2024)
 
 ### Enhancements

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -141,7 +141,7 @@ data = VectorData(
     name='species',
     description='...',
     data=TermSetWrapper(value=c_data, termset=terms, field='species')
-    )
+)
 
 
 ######################################################

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -67,6 +67,7 @@ for this tutorial, which provides a concise example of how a term set schema loo
 """
 from hdmf.common import DynamicTable, VectorData
 import os
+import numpy as np
 
 try:
     import linkml_runtime  # noqa: F401

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -143,7 +143,6 @@ data = VectorData(
     data=TermSetWrapper(value=c_data, termset=terms, field='species')
 )
 
-
 ######################################################
 # Validate Attributes with TermSetWrapper
 # ----------------------------------------------------

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -130,6 +130,20 @@ data = VectorData(
     )
 
 ######################################################
+# Validate Compound Data with TermSetWrapper
+# ----------------------------------------------------
+# :py:class:`~hdmf.term_set.TermSetWrapper` can be wrapped around compound data.
+# The user will set the field within the compound data type that is to be validated
+# with the termset.
+c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+data = VectorData(
+    name='species',
+    description='...',
+    data=TermSetWrapper(value=c_data, termset=terms, field='species')
+    )
+
+
+######################################################
 # Validate Attributes with TermSetWrapper
 # ----------------------------------------------------
 # Similar to wrapping datasets, :py:class:`~hdmf.term_set.TermSetWrapper` can be wrapped around any attribute.

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -21,12 +21,14 @@ def append_data(data, arg):
         return data
     elif isinstance(data, np.ndarray):
         if isinstance(arg, np.ndarray):
-            if data.ndim != arg.ndim:
-                return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
-            else:
+            if data.ndim == arg.ndim:
                 # arg is a structured array or an array with matching data
                 # dimensions
                 return np.append(data, arg)
+            else: # arg is a row vector
+                return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
+        else: # arg is a scalar
+            return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,7 +20,9 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(data.dtype)>0: # arg is a structured array
+        if len(data.dtype)>0 or isinstance(arg, np.ndarray):
+            # arg is a structured array or an array with matching data
+            # dimensions
             return np.append(data, arg)
         else: # arg is a scalar or arg is a row being appended to a matrix
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,14 +20,10 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if isinstance(arg, np.ndarray):
-            if data.ndim == arg.ndim:
-                # arg is a structured array or an array with matching data
-                # dimensions
-                return np.append(data, arg)
-            else: # arg is a row vector
-                return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
-        else: # arg is a scalar
+        if len(data.dtype)>0:
+            # data is a structured array
+            return np.append(data, arg)
+        else: # arg is a scalar or row vector
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,7 +20,7 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(arg.dtype)>0: # arg is a structured array
+        if len(data.dtype)>0: # arg is a structured array
             return np.append(data, arg)
         else: # arg is a scalar or arg is a row being appended to a matrix
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,7 +20,7 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
+        return np.append(data, arg)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,8 +20,7 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(data.dtype)!=0:
-            # This is for compound data, i.e., structured arrays
+        if isinstance(arg, np.ndarray):
             return np.append(data, arg)
         else:
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,8 +20,7 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(data.dtype)>0:
-            # data is a structured array
+        if len(data.dtype)>0: # data is a structured array
             return np.append(data, arg)
         else: # arg is a scalar or row vector
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,7 +20,7 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(data.dtype)>0 or isinstance(arg, np.ndarray):
+        if len(data.dtype)>0 or data.ndim==arg.ndim:
             # arg is a structured array or an array with matching data
             # dimensions
             return np.append(data, arg)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,7 +20,11 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        return np.append(data, arg)
+        if len(data.dtype)!=0:
+            # This is for compound data, i.e., structured arrays
+            return np.append(data, arg)
+        else:
+            return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,12 +20,13 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if len(data.dtype)>0 or data.ndim==arg.ndim:
-            # arg is a structured array or an array with matching data
-            # dimensions
-            return np.append(data, arg)
-        else: # arg is a scalar or arg is a row being appended to a matrix
-            return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
+        if isinstance(arg, np.ndarray):
+            if data.ndim != arg.ndim:
+                return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
+            else:
+                # arg is a structured array or an array with matching data
+                # dimensions
+                return np.append(data, arg)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -20,9 +20,9 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        if isinstance(arg, np.ndarray):
+        if len(arg.dtype)>0: # arg is a structured array
             return np.append(data, arg)
-        else:
+        else: # arg is a scalar or arg is a row being appended to a matrix
             return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -290,7 +290,7 @@ class TermSetWrapper:
         Note: Within HDMF append also includes numpy array append. This is not the same as list append.
         Numpy array append is essentially list extend. Now if a user appends an array, we need to
         support validating arrays with multiple items. This method has an internal bulk validation
-        check just for numpy arrays due to numpy array append. 
+        check just for numpy arrays due to numpy array append.
         """
         if isinstance(arg, np.ndarray):
             values = arg[self.__field]

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -314,8 +314,12 @@ class TermSetWrapper:
         This append resolves the wrapper to use the extend of the container using
         the wrapper.
         """
+        if isinstance(arg, np.ndarray):
+            values = arg[self.__field]
+        else:
+            values = [arg]
         bad_data = []
-        for item in arg:
+        for item in values:
             if not self.termset.validate(term=item):
                 bad_data.append(item)
 

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -301,7 +301,7 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            if len(arg.dtype)!=0: # check if compound array
+            if self.__field is not None: # compound array
                 values = arg[self.__field]
             else:
                 values = arg
@@ -322,7 +322,7 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            if len(arg.dtype)!=0: # check if compound array
+            if self.__field is not None: # compound array
                 values = arg[self.__field]
             else:
                 values = arg

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -308,7 +308,6 @@ class TermSetWrapper:
 
         self.__value = append_data(self.__value, arg)
 
-
     def extend(self, arg):
         """
         This append resolves the wrapper to use the extend of the container using

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -287,7 +287,7 @@ class TermSetWrapper:
         This append resolves the wrapper to use the append of the container using
         the wrapper.
 
-        Note: Within HDMF append also includes numpy array append. This is not the same as list append.
+        Note: append_data includes numpy arrays. This is not the same as list append.
         Numpy array append is essentially list extend. Now if a user appends an array, we need to
         support validating arrays with multiple items. This method has an internal bulk validation
         check just for numpy arrays due to numpy array append.

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -317,7 +317,7 @@ class TermSetWrapper:
         if isinstance(arg, np.ndarray):
             values = arg[self.__field]
         else:
-            values = [arg]
+            values = arg
         bad_data = []
         for item in values:
             if not self.termset.validate(term=item):

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -224,8 +224,8 @@ class TermSetWrapper:
         self.__validate()
 
     def __validate(self):
-        if self.field is not None:
-            values = self.__value[self.field]
+        if self.__field is not None:
+            values = self.__value[self.__field]
         else:
             # check if list, tuple, array
             if isinstance(self.__value, (list, np.ndarray, tuple)):

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -214,19 +214,26 @@ class TermSetWrapper:
             {'name': 'value',
              'type': (list, np.ndarray, dict, str, tuple),
              'doc': 'The target item that is wrapped, either data or attribute.'},
+            {'name': 'field', 'type': str, 'default': None,
+             'doc': 'The field within a compound array.'}
             )
     def __init__(self, **kwargs):
         self.__value = kwargs['value']
         self.__termset = kwargs['termset']
+        self.field = kwargs['field']
         self.__validate()
 
     def __validate(self):
-        # check if list, tuple, array
-        if isinstance(self.__value, (list, np.ndarray, tuple)): # TODO: Future ticket on DataIO support
-            values = self.__value
-        # create list if none of those -> mostly for attributes
+        if self.field is not None:
+            breakpoint()
+            values = self.__value[self.field]
         else:
-            values = [self.__value]
+            # check if list, tuple, array
+            if isinstance(self.__value, (list, np.ndarray, tuple)):
+                values = self.__value
+            # create list if none of those -> mostly for attributes
+            else:
+                values = [self.__value]
         # iteratively validate
         bad_values = []
         for term in values:
@@ -262,13 +269,6 @@ class TermSetWrapper:
         """
         return self.__value[val]
 
-    # uncomment when DataChunkIterator objects can be wrapped by TermSet
-    # def __next__(self):
-    #     """
-    #     Return the next item of a wrapped iterator.
-    #     """
-    #     return self.__value.__next__()
-    #
     def __len__(self):
         return len(self.__value)
 

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -220,7 +220,7 @@ class TermSetWrapper:
     def __init__(self, **kwargs):
         self.__value = kwargs['value']
         self.__termset = kwargs['termset']
-        self.field = kwargs['field']
+        self.__field = kwargs['field']
         self.__validate()
 
     def __validate(self):
@@ -246,6 +246,10 @@ class TermSetWrapper:
     @property
     def value(self):
         return self.__value
+
+    @property
+    def field(self):
+        return self.__field
 
     @property
     def termset(self):

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -282,7 +282,7 @@ class TermSetWrapper:
         """
         return self.__value.__iter__()
 
-    def __multi_validation(self, data: list):
+    def __multi_validation(self, data):
         """
         append_data includes numpy arrays. This is not the same as list append.
         Numpy array append is essentially list extend. Now if a user appends an array, we need to
@@ -301,7 +301,10 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            values = arg[self.__field]
+            if len(arg.dtype)!=0: # check if compound array
+                values = arg[self.__field]
+            else:
+                values = arg
         else:
             values = [arg]
 
@@ -319,7 +322,10 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            values = arg[self.__field]
+            if len(arg.dtype)!=0: # check if compound array
+                values = arg[self.__field]
+            else:
+                values = arg
         else:
             values = arg
 

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -287,7 +287,7 @@ class TermSetWrapper:
     def __multi_validation(self, data):
         """
         append_data includes numpy arrays. This is not the same as list append.
-        Numpy array append is essentially list extend. Now if a user appends an array, we need to
+        Numpy array append is essentially list extend. Now if a user appends an array (for compound data), we need to
         support validating arrays with multiple items. This method is an internal bulk validation
         check for numpy arrays and extend.
         """

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -306,7 +306,7 @@ class TermSetWrapper:
             if self.__field is not None: # compound array
                 values = arg[self.__field]
             else:
-                msg = "Array needs to be a compound array"
+                msg = "Array needs to be a structured array with compound dtype. If this does not apply, use extend. "
                 raise ValueError(msg)
         else:
             values = [arg]

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -230,7 +230,7 @@ class TermSetWrapper:
             # check if list, tuple, array
             if isinstance(self.__value, (list, np.ndarray, tuple)):
                 values = self.__value
-            # create list if none of those -> mostly for attributes
+            # create list if none of those -> mostly for scalar attributes
             else:
                 values = [self.__value]
         # iteratively validate

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -306,7 +306,8 @@ class TermSetWrapper:
             if self.__field is not None: # compound array
                 values = arg[self.__field]
             else:
-                values = arg
+                msg = "Array needs to be a compound array"
+                raise ValueError(msg)
         else:
             values = [arg]
 

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -306,7 +306,7 @@ class TermSetWrapper:
             if self.__field is not None: # compound array
                 values = arg[self.__field]
             else:
-                msg = "Array needs to be a structured array with compound dtype. If this does not apply, use extend. "
+                msg = "Array needs to be a structured array with compound dtype. If this does not apply, use extend."
                 raise ValueError(msg)
         else:
             values = [arg]

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -225,7 +225,6 @@ class TermSetWrapper:
 
     def __validate(self):
         if self.field is not None:
-            breakpoint()
             values = self.__value[self.field]
         else:
             # check if list, tuple, array

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -245,7 +245,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.vstack((c_data, c_data2)))
 
-
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
@@ -259,6 +259,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data.data, np.append(c_data, c_data2))
 
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -272,7 +272,6 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(vector_data.data.data, np.vstack((data, data2)))
 
-
     @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -238,14 +238,14 @@ class TestDynamicTable(TestCase):
         c_data2 = np.array(['Mus musculus'])
 
         terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        compound_vector_data = VectorData(
+        vectordata_termset = VectorData(
             name='Species_1',
             description='...',
             data=TermSetWrapper(value=c_data, termset=terms)
         )
 
         with self.assertRaises(ValueError):
-            compound_vector_data.append(c_data2)
+            vectordata_termset.append(c_data2)
 
     def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -233,14 +233,6 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
 
-    def test_append_array(self):
-        a = np.array([[1, 2, 3]])
-        b = np.array([7, 8, 9])
-        col = VectorData(name='foo', description='...', data=a)
-        col.append(b)
-
-        np.testing.assert_array_equal(col.data, np.array([[1,2,3],[7,8,9]]))
-
     def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
@@ -256,7 +248,7 @@ class TestDynamicTable(TestCase):
     @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_array_append(self):
         data = np.array(['Homo sapiens'])
-        data2 = np.array(['Mus musculus'])
+        data2 = 'Mus musculus'
         terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
         vector_data = VectorData(
             name='Species_1',

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -221,7 +221,7 @@ class TestDynamicTable(TestCase):
         with self.assertRaises(ValueError):
             species.add_row(Species_1='bad data', Species_2='bad data')
 
-    def test_add_ref_compound_data_append(self):
+    def test_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         compound_vector_data = VectorData(

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -238,7 +238,7 @@ class TestDynamicTable(TestCase):
         b = np.array([7, 8, 9])
         data = VectorData(name='foo', description='...', data=a)
         data.append(b)
-        
+
         np.testing.assert_array_equal(data, np.array([[1,2,3],[7,8,9]]))
 
     def test_compound_data_extend(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -232,6 +232,17 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
 
+    def test_array_append_error(self):
+        c_data = np.array(['Homo sapiens'])
+        c_data2 = np.array(['Mus musculus', 24])
+        compound_vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=c_data
+        )
+        with self.assertRaises(ValueError):
+            compound_vector_data.append(c_data2)
+
     def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -233,7 +233,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
 
-    def test_add_ref_compound_data_extend(self):
+    def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         compound_vector_data = VectorData(

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -272,7 +272,6 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data.data, np.vstack((c_data, c_data2)))
 
-
     def test_constructor_bad_columns(self):
         columns = ['bad_column']
         msg = "'columns' must be a list of dict, VectorData, DynamicTableRegion, or VectorIndex"

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -221,6 +221,33 @@ class TestDynamicTable(TestCase):
         with self.assertRaises(ValueError):
             species.add_row(Species_1='bad data', Species_2='bad data')
 
+    def test_add_ref_compound_data_append(self):
+        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        compound_vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=c_data
+        )
+        compound_vector_data.append(c_data2)
+
+    def test_add_ref_compound_data_extend(self):
+        pass
+
+    def test_add_ref_wrapped_compound_data_append(self):
+        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        compound_vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=TermSetWrapper(value=c_data, field='species', termset=terms)
+        )
+        compound_vector_data.append(c_data2)
+
+    def test_add_ref_wrapped_compound_data_extend(self):
+        pass
+
     def test_constructor_bad_columns(self):
         columns = ['bad_column']
         msg = "'columns' must be a list of dict, VectorData, DynamicTableRegion, or VectorIndex"

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -236,10 +236,10 @@ class TestDynamicTable(TestCase):
     def test_append_array(self):
         a = np.array([[1, 2, 3]])
         b = np.array([7, 8, 9])
-        data = VectorData(name='foo', description='...', data=a)
-        data.append(b)
+        col = VectorData(name='foo', description='...', data=a)
+        col.append(b)
 
-        np.testing.assert_array_equal(data, np.array([[1,2,3],[7,8,9]]))
+        np.testing.assert_array_equal(col.data, np.array([[1,2,3],[7,8,9]]))
 
     def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -244,7 +244,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.vstack((c_data, c_data2)))
 
-    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_array_append(self):
         data = np.array(['Homo sapiens'])
         data2 = 'Mus musculus'
@@ -258,7 +258,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(vector_data.data.data, np.append(data, data2))
 
-    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_array_extend(self):
         data = np.array(['Homo sapiens'])
         data2 = np.array(['Mus musculus'])
@@ -273,7 +273,7 @@ class TestDynamicTable(TestCase):
         np.testing.assert_array_equal(vector_data.data.data, np.vstack((data, data2)))
 
 
-    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
@@ -287,7 +287,7 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data.data, np.append(c_data, c_data2))
 
-    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -231,8 +231,20 @@ class TestDynamicTable(TestCase):
         )
         compound_vector_data.append(c_data2)
 
+        np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
+
     def test_add_ref_compound_data_extend(self):
-        pass
+        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        compound_vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=c_data
+        )
+        compound_vector_data.extend(c_data2)
+
+        np.testing.assert_array_equal(compound_vector_data.data, np.vstack((c_data, c_data2)))
+
 
     def test_add_ref_wrapped_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
@@ -245,8 +257,21 @@ class TestDynamicTable(TestCase):
         )
         compound_vector_data.append(c_data2)
 
+        np.testing.assert_array_equal(compound_vector_data.data.data, np.append(c_data, c_data2))
+
     def test_add_ref_wrapped_compound_data_extend(self):
-        pass
+        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        compound_vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=TermSetWrapper(value=c_data, field='species', termset=terms)
+        )
+        compound_vector_data.extend(c_data2)
+
+        np.testing.assert_array_equal(compound_vector_data.data.data, np.vstack((c_data, c_data2)))
+
 
     def test_constructor_bad_columns(self):
         columns = ['bad_column']

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -246,6 +246,35 @@ class TestDynamicTable(TestCase):
         np.testing.assert_array_equal(compound_vector_data.data, np.vstack((c_data, c_data2)))
 
     @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_wrapped_array_append(self):
+        data = np.array(['Homo sapiens'])
+        data2 = np.array(['Mus musculus'])
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=TermSetWrapper(value=data, termset=terms)
+        )
+        vector_data.append(data2)
+
+        np.testing.assert_array_equal(vector_data.data.data, np.append(data, data2))
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_wrapped_array_extend(self):
+        data = np.array(['Homo sapiens'])
+        data2 = np.array(['Mus musculus'])
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        vector_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=TermSetWrapper(value=data, termset=terms)
+        )
+        vector_data.extend(data2)
+
+        np.testing.assert_array_equal(vector_data.data.data, np.vstack((data, data2)))
+
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_append(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -232,14 +232,18 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
 
+    @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_array_append_error(self):
         c_data = np.array(['Homo sapiens'])
-        c_data2 = np.array(['Mus musculus', 24])
+        c_data2 = np.array(['Mus musculus'])
+
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
         compound_vector_data = VectorData(
             name='Species_1',
             description='...',
-            data=c_data
+            data=TermSetWrapper(value=c_data, termset=terms)
         )
+
         with self.assertRaises(ValueError):
             compound_vector_data.append(c_data2)
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -233,6 +233,14 @@ class TestDynamicTable(TestCase):
 
         np.testing.assert_array_equal(compound_vector_data.data, np.append(c_data, c_data2))
 
+    def test_append_array(self):
+        a = np.array([[1, 2, 3]])
+        b = np.array([7, 8, 9])
+        data = VectorData(name='foo', description='...', data=a)
+        data.append(b)
+        
+        np.testing.assert_array_equal(data, np.array([[1,2,3],[7,8,9]]))
+
     def test_compound_data_extend(self):
         c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
         c_data2 = np.array([('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -162,16 +162,6 @@ class TestTermSetWrapper(TestCase):
             description='...',
             data=self.wrapped_array
         )
-        self.list_data = VectorData(
-            name='Species_1',
-            description='...',
-            data=self.wrapped_list
-        )
-        self.comp_np_data = VectorData(
-            name='Species_1',
-            description='...',
-            data=self.wrapped_comp_array
-        )
 
     def test_properties(self):
         self.assertEqual(self.wrapped_array.value, ['Homo sapiens'])

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -215,3 +215,9 @@ class TestTermSetWrapper(TestCase):
         data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
         with self.assertRaises(ValueError):
             data_obj.extend(['bad_data'])
+
+    def test_wrap_compound_type(self):
+        c_data = np.array([('Homo sapiens', 24), ('Mus musculus', 3)], dtype=[('species', 'U30'), ('age', 'i4')])
+        termset = TermSetWrapper(value=c_data,
+                                 termset=self.termset,
+                                 field='species')

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -152,6 +152,11 @@ class TestTermSetWrapper(TestCase):
         self.wrapped_array = TermSetWrapper(value=np.array(['Homo sapiens']), termset=self.termset)
         self.wrapped_list = TermSetWrapper(value=['Homo sapiens'], termset=self.termset)
 
+        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        self.wrapped_comp_array = TermSetWrapper(value=c_data,
+                                                 termset=self.termset,
+                                                 field='species')
+
         self.np_data = VectorData(
             name='Species_1',
             description='...',
@@ -162,11 +167,17 @@ class TestTermSetWrapper(TestCase):
             description='...',
             data=self.wrapped_list
         )
+        self.comp_np_data = VectorData(
+            name='Species_1',
+            description='...',
+            data=self.wrapped_comp_array
+        )
 
     def test_properties(self):
         self.assertEqual(self.wrapped_array.value, ['Homo sapiens'])
         self.assertEqual(self.wrapped_array.termset.view_set, self.termset.view_set)
         self.assertEqual(self.wrapped_array.dtype, 'U12') # this covers __getattr__
+        self.assertEqual(self.wrapped_comp_array.field, 'species')
 
     def test_get_item(self):
         self.assertEqual(self.np_data.data[0], 'Homo sapiens')
@@ -215,9 +226,3 @@ class TestTermSetWrapper(TestCase):
         data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
         with self.assertRaises(ValueError):
             data_obj.extend(['bad_data'])
-
-    def test_wrap_compound_type(self):
-        c_data = np.array([('Homo sapiens', 24), ('Mus musculus', 3)], dtype=[('species', 'U30'), ('age', 'i4')])
-        termset = TermSetWrapper(value=c_data,
-                                 termset=self.termset,
-                                 field='species')


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Add the ability to wrap compound data. This only supports one field in the compound type. (first step)

Fix #938 

TODO:

- [x] Update documentation/tutorials
- [x] Update tests

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
