### PR TITLE
Have VectorData expandable by default

### DIFF
--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -42,6 +42,7 @@ class VectorData(Data):
              'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()},
             allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
+        kwargs['data'] = H5DataIO(data=kwargs['data'], maxshape=(None,))
         description = popargs('description', kwargs)
         super().__init__(**kwargs)
         self.description = description

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -17,6 +17,7 @@ from ..container import Container, Data
 from ..data_utils import DataIO, AbstractDataChunkIterator
 from ..utils import docval, getargs, ExtenderMeta, popargs, pystr, AllowPositional, check_type
 from ..term_set import TermSetWrapper
+from ..backends.hdf5.h5_utils import H5DataIO
 
 
 @register_class('VectorData')

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -143,7 +143,8 @@ class VectorIndex(VectorData):
                     raise ValueError(msg)
                 self.__maxval = 2 ** nbits - 1
             self.__uint = np.dtype('uint%d' % nbits).type
-            # self.__adjust_precision(self.__uint) #TODO: Cannot adjust when wrapped with H5DataIO
+            if self.data is not None and not isinstance(self.data, DataIO):
+                self.__adjust_precision(self.__uint, self.data) #TODO: Cannot adjust when wrapped with H5DataIO
         return self.__uint(idx)
 
     def __adjust_precision(self, uint, data):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -40,10 +40,13 @@ class VectorData(Data):
             {'name': 'description', 'type': str, 'doc': 'a description for this column'},
             {'name': 'data', 'type': ('array_data', 'data'),
              'doc': 'a dataset where the first dimension is a concatenation of multiple vectors', 'default': list()},
+            {'name': 'extendable', 'type': bool, 'default': True,
+             'doc': 'Bool to decide whether to wrap the data with H5DataIO to be extendable by default.'},
             allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
-        kwargs['data'] = H5DataIO(data=kwargs['data'], maxshape=(None,))
-        description = popargs('description', kwargs)
+        description, extendable = popargs('description', 'extendable', kwargs)
+        if not isinstance(kwargs['data'], DataIO) and extendable:
+            kwargs['data'] = H5DataIO(data=kwargs['data'], maxshape=(None,))
         super().__init__(**kwargs)
         self.description = description
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -799,10 +799,7 @@ class Data(AbstractContainer):
 
     @property
     def data(self):
-        if isinstance(self.__data, DataIO):
-            return self.__data.data
-        else:
-            return self.__data
+        return self.__data
 
     @property
     def shape(self):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -799,7 +799,10 @@ class Data(AbstractContainer):
 
     @property
     def data(self):
-        return self.__data
+        if isinstance(self.__data, DataIO):
+            return self.__data.data
+        else:
+            return self.__data
 
     @property
     def shape(self):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -1082,7 +1082,10 @@ class DataIO:
         """Delegate slicing to the data object"""
         if not self.valid:
             raise InvalidDataIOError("Cannot get item from data. Data is not valid.")
-        return self.data[item]
+        if isinstance(item, (tuple, list, np.ndarray)):
+            return [self.data[i] for i in item]
+        else:
+            return self.data[item]
 
     def __array__(self):
         """

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -10,7 +10,7 @@ from ..build import Builder
 from ..common import validate as common_validate, get_manager
 from ..container import AbstractContainer, Container, Data
 from ..utils import get_docval_macro
-from ..data_utils import AbstractDataChunkIterator
+from ..data_utils import AbstractDataChunkIterator, DataIO
 
 
 class TestCase(unittest.TestCase):
@@ -148,10 +148,17 @@ class TestCase(unittest.TestCase):
         self.assertTrue(isinstance(data1, Data), message)
         self.assertTrue(isinstance(data2, Data), message)
         self.assertEqual(len(data1), len(data2), message)
-        self._assert_array_equal(data1.data, data2.data,
-                                 ignore_hdmf_attrs=ignore_hdmf_attrs,
-                                 ignore_string_to_byte=ignore_string_to_byte,
-                                 message=message)
+        # breakpoint()
+        if isinstance(data1.data, DataIO) and isinstance(data2.data, DataIO):
+            self._assert_array_equal(data1.data.data, data2.data.data,
+                                     ignore_hdmf_attrs=ignore_hdmf_attrs,
+                                     ignore_string_to_byte=ignore_string_to_byte,
+                                     message=message)
+        else:
+            self._assert_array_equal(data1.data, data2.data,
+                                     ignore_hdmf_attrs=ignore_hdmf_attrs,
+                                     ignore_string_to_byte=ignore_string_to_byte,
+                                     message=message)
         self.assertContainerEqual(container1=data1,
                                   container2=data2,
                                   ignore_hdmf_attrs=ignore_hdmf_attrs,

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1806,7 +1806,6 @@ class TestEnumData(TestCase):
                       elements=['a', 'b', 'c'],
                       data=np.array([[0, 0], [1, 1], [2, 2]]))
         dat = ed[0]
-        breakpoint()
         np.testing.assert_array_equal(dat, ['a', 'a'])
 
     def test_get_2d_w_2d(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -389,6 +389,7 @@ class TestDynamicTable(TestCase):
                          description='qux column',
                          data=expected,
                          index=True)
+
         self.assertListEqual(table['qux'][:], expected)
         self.assertListEqual(table.qux_index.data, [3, 7])
         # Add more rows after we created the column
@@ -1805,6 +1806,7 @@ class TestEnumData(TestCase):
                       elements=['a', 'b', 'c'],
                       data=np.array([[0, 0], [1, 1], [2, 2]]))
         dat = ed[0]
+        breakpoint()
         np.testing.assert_array_equal(dat, ['a', 'a'])
 
     def test_get_2d_w_2d(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -84,10 +84,11 @@ class TestDynamicTable(TestCase):
         self.check_empty_table(table)
 
     def check_table(self, table):
+        # breakpoint()
         self.assertEqual(len(table), 5)
-        self.assertEqual(table.columns[0].data, [1, 2, 3, 4, 5])
-        self.assertEqual(table.columns[1].data, [10.0, 20.0, 30.0, 40.0, 50.0])
-        self.assertEqual(table.columns[2].data, ['cat', 'dog', 'bird', 'fish', 'lizard'])
+        self.assertEqual(table.columns[0].data.data, [1, 2, 3, 4, 5])
+        self.assertEqual(table.columns[1].data.data, [10.0, 20.0, 30.0, 40.0, 50.0])
+        self.assertEqual(table.columns[2].data.data, ['cat', 'dog', 'bird', 'fish', 'lizard'])
         self.assertEqual(table.id.data, [0, 1, 2, 3, 4])
         self.assertTrue(hasattr(table, 'baz'))
 
@@ -369,11 +370,11 @@ class TestDynamicTable(TestCase):
                          data=expected,
                          index=1)
         self.assertListEqual(table['qux'][:], expected)
-        self.assertListEqual(table.qux_index.data, [3, 7])
+        self.assertListEqual(table.qux_index.data.data, [3, 7])
         # Add more rows after we created the column
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[10, 11, 12])
         self.assertListEqual(table['qux'][:], expected + [[10, 11, 12], ])
-        self.assertListEqual(table.qux_index.data, [3, 7, 10])
+        self.assertListEqual(table.qux_index.data.data, [3, 7, 10])
 
     def test_add_column_auto_index_bool(self):
         """
@@ -389,13 +390,13 @@ class TestDynamicTable(TestCase):
                          description='qux column',
                          data=expected,
                          index=True)
-
+        # breakpoint()
         self.assertListEqual(table['qux'][:], expected)
-        self.assertListEqual(table.qux_index.data, [3, 7])
+        self.assertListEqual(table.qux_index.data.data, [3, 7])
         # Add more rows after we created the column
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[10, 11, 12])
         self.assertListEqual(table['qux'][:], expected + [[10, 11, 12], ])
-        self.assertListEqual(table.qux_index.data, [3, 7, 10])
+        self.assertListEqual(table.qux_index.data.data, [3, 7, 10])
 
     def test_add_column_auto_multi_index_int(self):
         """
@@ -412,13 +413,13 @@ class TestDynamicTable(TestCase):
                          data=expected,
                          index=2)
         self.assertListEqual(table['qux'][:], expected)
-        self.assertListEqual(table.qux_index_index.data, [2, 4])
-        self.assertListEqual(table.qux_index.data, [3, 4, 8, 10])
+        self.assertListEqual(table.qux_index_index.data.data, [2, 4])
+        self.assertListEqual(table.qux_index.data.data, [3, 4, 8, 10])
         # Add more rows after we created the column
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[[10, 11, 12], ])
         self.assertListEqual(table['qux'][:], expected + [[[10, 11, 12], ]])
-        self.assertListEqual(table.qux_index_index.data, [2, 4, 5])
-        self.assertListEqual(table.qux_index.data, [3, 4, 8, 10, 13])
+        self.assertListEqual(table.qux_index_index.data.data, [2, 4, 5])
+        self.assertListEqual(table.qux_index.data.data, [3, 4, 8, 10, 13])
 
     def test_add_column_auto_multi_index_int_bad_index_levels(self):
         """
@@ -466,13 +467,13 @@ class TestDynamicTable(TestCase):
                          data=expected,
                          index=2)
         self.assertListEqual(table['qux'][:], expected)
-        self.assertListEqual(table.qux_index_index.data, [2, 4])
-        self.assertListEqual(table.qux_index.data, [0, 0, 0, 0])
+        self.assertListEqual(table.qux_index_index.data.data, [2, 4])
+        self.assertListEqual(table.qux_index.data.data, [0, 0, 0, 0])
         # Add more rows after we created the column
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[[10, 11, 12], ])
         self.assertListEqual(table['qux'][:], expected + [[[10, 11, 12], ]])
-        self.assertListEqual(table.qux_index_index.data, [2, 4, 5])
-        self.assertListEqual(table.qux_index.data, [0, 0, 0, 0, 3])
+        self.assertListEqual(table.qux_index_index.data.data, [2, 4, 5])
+        self.assertListEqual(table.qux_index.data.data, [0, 0, 0, 0, 3])
 
     def test_auto_multi_index_required(self):
 
@@ -514,7 +515,7 @@ class TestDynamicTable(TestCase):
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)
-        self.assertEqual(table.qux_index_index_index.data, [1, 2])
+        self.assertEqual(table.qux_index_index_index.data.data, [1, 2])
 
     def test_auto_multi_index(self):
 
@@ -556,7 +557,7 @@ class TestDynamicTable(TestCase):
             ]
         ]
         self.assertListEqual(table['qux'][:], expected)
-        self.assertEqual(table.qux_index_index_index.data, [1, 2])
+        self.assertEqual(table.qux_index_index_index.data.data, [1, 2])
 
     def test_getitem_row_num(self):
         table = self.with_spec()
@@ -1409,7 +1410,7 @@ class TestBadElementIdentifiers(TestCase):
         a = np.arange(30)
         dci = DataChunkIterator(data=a, buffer_size=1)
         e = ElementIdentifiers(name='ids', data=dci)  # test that no error is raised
-        self.assertIs(e.data, dci)
+        self.assertIs(e.data.data, dci)
 
     def test_dci_float_bad(self):
         a = np.arange(30.0)
@@ -1422,7 +1423,7 @@ class TestBadElementIdentifiers(TestCase):
         dci = DataChunkIterator(data=a, buffer_size=1)
         dio = H5DataIO(dci)
         e = ElementIdentifiers(name='ids', data=dio)  # test that no error is raised
-        self.assertIs(e.data, dio)
+        self.assertIs(e.data.data, dio)
 
 
 class SubTable(DynamicTable):
@@ -1606,7 +1607,7 @@ class TestDynamicTableClassColumns(TestCase):
         table = SubTable(name='subtable', description='subtable description')
         table.add_row(col1='a', col3='c', col5='e', col7='g')
         table.add_column(name='col2', description='column #2', data=('b', ))
-        self.assertTupleEqual(table.col2.data, ('b', ))
+        self.assertTupleEqual(table.col2.data.data, ('b', ))
 
     def test_add_opt_ind_column_after_data(self):
         """Test that adding an optional, indexed column from __columns__ with data works."""
@@ -1623,8 +1624,8 @@ class TestDynamicTableClassColumns(TestCase):
         self.assertTupleEqual(table.colnames, ('col1', 'col3', 'col5', 'col7', 'col2', 'col4'))
         self.assertEqual(table.col2.description, 'optional column')
         self.assertEqual(table.col4.description, 'optional, indexed column')
-        self.assertListEqual(table.col2.data, ['b', 'b2'])
-        # self.assertListEqual(table.col4.data, [('d1', 'd2'), ('d3', 'd4')])  # TODO this should work
+        self.assertListEqual(table.col2.data.data, ['b', 'b2'])
+        # self.assertListEqual(table.col4.data.data, [('d1', 'd2'), ('d3', 'd4')])  # TODO this should work
 
     def test_add_row_opt_column_after_data(self):
         """Test that adding a row with an optional column after adding a row without the column raises an error."""
@@ -1820,14 +1821,14 @@ class TestEnumData(TestCase):
         ed.add_row('b')
         ed.add_row('a')
         ed.add_row('c')
-        np.testing.assert_array_equal(ed.data, np.array([1, 0, 2], dtype=np.uint8))
+        np.testing.assert_array_equal(ed.data.data, np.array([1, 0, 2], dtype=np.uint8))
 
     def test_add_row_index(self):
         ed = EnumData(name='cv_data', description='a test EnumData', elements=['a', 'b', 'c'])
         ed.add_row(1, index=True)
         ed.add_row(0, index=True)
         ed.add_row(2, index=True)
-        np.testing.assert_array_equal(ed.data, np.array([1, 0, 2], dtype=np.uint8))
+        np.testing.assert_array_equal(ed.data.data, np.array([1, 0, 2], dtype=np.uint8))
 
 
 class TestIndexedEnumData(TestCase):
@@ -2295,12 +2296,12 @@ class TestVectorIndex(TestCase):
         self.assertEqual(foo_ind.name, 'foo_index')
         self.assertEqual(foo_ind.description, "Index for VectorData 'foo'")
         self.assertIs(foo_ind.target, foo)
-        self.assertListEqual(foo_ind.data, list())
+        self.assertListEqual(foo_ind.data.data, list())
 
     def test_init_data(self):
         foo = VectorData(name='foo', description='foo column', data=['a', 'b', 'c'])
         foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3])
-        self.assertListEqual(foo_ind.data, [2, 3])
+        self.assertListEqual(foo_ind.data.data, [2, 3])
         self.assertListEqual(foo_ind[0], ['a', 'b'])
         self.assertListEqual(foo_ind[1], ['c'])
 
@@ -2333,11 +2334,11 @@ class TestDoubleIndex(TestCase):
 
         foo_ind_ind.add_vector([['c11', 'c12', 'c13'], ['c21', 'c22']])
 
-        self.assertListEqual(foo.data, ['a11', 'a12', 'a21', 'b11', 'c11', 'c12', 'c13', 'c21', 'c22'])
-        self.assertListEqual(foo_ind.data, [2, 3, 4, 7, 9])
+        self.assertListEqual(foo.data.data, ['a11', 'a12', 'a21', 'b11', 'c11', 'c12', 'c13', 'c21', 'c22'])
+        self.assertListEqual(foo_ind.data.data, [2, 3, 4, 7, 9])
         self.assertListEqual(foo_ind[3], ['c11', 'c12', 'c13'])
         self.assertListEqual(foo_ind[4], ['c21', 'c22'])
-        self.assertListEqual(foo_ind_ind.data, [2, 3, 5])
+        self.assertListEqual(foo_ind_ind.data.data, [2, 3, 5])
         self.assertListEqual(foo_ind_ind[2], [['c11', 'c12', 'c13'], ['c21', 'c22']])
 
 
@@ -2706,6 +2707,7 @@ class TestVectorIndexDtype(TestCase):
     def test_array_inc_precision(self):
         index = self.set_up_array_index()
         index.add_vector(np.empty((255, )))
+        # breakpoint()
         self.assertEqual(index.data[0], 255)
         self.assertEqual(index.data.dtype, np.uint8)
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1410,7 +1410,7 @@ class TestBadElementIdentifiers(TestCase):
         a = np.arange(30)
         dci = DataChunkIterator(data=a, buffer_size=1)
         e = ElementIdentifiers(name='ids', data=dci)  # test that no error is raised
-        self.assertIs(e.data.data, dci)
+        self.assertIs(e.data, dci)
 
     def test_dci_float_bad(self):
         a = np.arange(30.0)
@@ -1423,7 +1423,7 @@ class TestBadElementIdentifiers(TestCase):
         dci = DataChunkIterator(data=a, buffer_size=1)
         dio = H5DataIO(dci)
         e = ElementIdentifiers(name='ids', data=dio)  # test that no error is raised
-        self.assertIs(e.data.data, dio)
+        self.assertIs(e.data, dio)
 
 
 class SubTable(DynamicTable):


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Have VectorData expandable by default:

- [ ] Check that reading existing non-expandable data into the now expandable VectorData is not a problem (due to shape).
- [ ] Make to test that the data is wrapped with H5DataIO on read
- [ ] Update VectorData
- [ ] Add tests
- [ ] Investigate VectorIndex. When indexing vector index that has a wrapped target vector data, an error arises.
- [ ] TBD

Questions to look into:
- Do we have tests where we look at add_row when the data is wrapped with H5DataIO? ---> Yes 
- If a user wanted to make a EnumData column extendable, would they wrap both data and elements with H5DataIO?

Ideas:
- We support Zarr, so wrapping with H5DataIO for every instance does not work. Do we instead want a field that is default to True that will wrap data if true. In hdmf-zarr, we will override this to False (similar to how we import HERD in pynwb into a pynwb version in order to reset the typemap). We will also have logic that says if the user provides their own instance of DataIO, it will not wrap automatically either. We could also just skip the field and within HDMF-zarr just unwrap and reset data, but I understand if that is a little messy. 


## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
