### PR TITLE
Warn when adding ragged arrays to DynamicTable without index argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.13.0 (Upcoming)
+
+### Enhancements
+- Added warning when using `add_row` or `add_column` to add a ragged array to `DynamicTable` without an index parameter. @stephprince [#1066](https://github.com/hdmf-dev/hdmf/pull/1066)
+
 ## HDMF 3.12.2 (February 9, 2024)
 
 ### Bug fixes

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -15,7 +15,7 @@ import itertools
 from . import register_class, EXP_NAMESPACE
 from ..container import Container, Data
 from ..data_utils import DataIO, AbstractDataChunkIterator
-from ..utils import docval, getargs, ExtenderMeta, popargs, pystr, AllowPositional, check_type
+from ..utils import docval, getargs, ExtenderMeta, popargs, pystr, AllowPositional, check_type, is_ragged
 from ..term_set import TermSetWrapper
 
 
@@ -709,6 +709,8 @@ class DynamicTable(Container):
                 c.add_vector(data[colname])
             else:
                 c.add_row(data[colname])
+                if is_ragged(c.data):
+                    raise ValueError("Data is ragged. Use the 'index' argument when creating a column that will have ragged data.")
 
     def __eq__(self, other):
         """Compare if the two DynamicTables contain the same data.
@@ -823,6 +825,11 @@ class DynamicTable(Container):
         # once we have created the column
         create_vector_index = None
         if ckwargs.get('data', None) is not None:
+
+            # if no index was provided, check that data is not ragged
+            if index is False and is_ragged(data):
+                raise ValueError("Data is ragged. Use the 'index' argument when adding a column with ragged data.")
+
             # Check that we are asked to create an index
             if (isinstance(index, bool) or isinstance(index, int)) and index > 0 and len(data) > 0:
                 # Iteratively flatten the data we use for the column based on the depth of the index to generate.

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -710,7 +710,8 @@ class DynamicTable(Container):
             else:
                 c.add_row(data[colname])
                 if is_ragged(c.data):
-                    raise ValueError("Data is ragged. Use the 'index' argument when creating a column that will have ragged data.")
+                    warn("Data is ragged. Use the 'index' argument when creating a column that will have ragged data.",
+                         stacklevel=2)
 
     def __eq__(self, other):
         """Compare if the two DynamicTables contain the same data.
@@ -828,7 +829,8 @@ class DynamicTable(Container):
 
             # if no index was provided, check that data is not ragged
             if index is False and is_ragged(data):
-                raise ValueError("Data is ragged. Use the 'index' argument when adding a column with ragged data.")
+                warn("Data is ragged. Use the 'index' argument when adding a column with ragged data.",
+                     stacklevel=2)
 
             # Check that we are asked to create an index
             if (isinstance(index, bool) or isinstance(index, int)) and index > 0 and len(data) > 0:

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -958,9 +958,8 @@ def is_ragged(data):
     """
     Test whether a list of lists or array is ragged / jagged
     """
-    if hasattr(data, '__len__') and not isinstance(data, str):
-        lengths = [len(sub_data) if hasattr(sub_data, '__len__') and not isinstance(sub_data, str) else 1
-                for sub_data in data]
+    if isinstance(data, (list, tuple)):
+        lengths = [len(sub_data) if isinstance(sub_data, (list, tuple)) else 1 for sub_data in data]
         if len(set(lengths)) > 1:
             return True  # ragged at this level
 

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -954,6 +954,21 @@ def to_uint_array(arr):
     raise ValueError('Cannot convert array of dtype %s to uint.' % arr.dtype)
 
 
+def is_ragged(data):
+    """
+    Test whether a list of lists or array is ragged / jagged
+    """
+    if hasattr(data, '__len__') and not isinstance(data, str):
+        lengths = [len(sub_data) if hasattr(sub_data, '__len__') and not isinstance(sub_data, str) else 1
+                for sub_data in data]
+        if len(set(lengths)) > 1:
+            return True  # ragged at this level
+
+        return any(is_ragged(sub_data) for sub_data in data)  # check next level
+
+    return False
+
+
 class LabelledDict(dict):
     """A dict wrapper that allows querying by an attribute of the values and running a callable on removed items.
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -356,20 +356,21 @@ class TestDynamicTable(TestCase):
 
     def test_add_column_without_required_index(self):
         """
-        Add a column as a ragged list of lists without specifying an index parameter
+        Add a column with different element lengths without specifying an index parameter
         """
         table = self.with_spec()
         table.add_row(foo=5, bar=50.0, baz='lizard')
         table.add_row(foo=5, bar=50.0, baz='lizard')
 
         # testing adding column without a necessary index parameter
-        msg = "Data is ragged. Use the 'index' argument when adding a column with ragged data."
         lol_data = [[1, 2, 3], [1, 2, 3, 4]]
         str_data = [['a', 'b'], ['a', 'b', 'c']]
         empty_data = [[1, 2], []]
         multi_nested_data = [[[1, 2, 3], [1, 2, 3, 4]], [1, 2]]
-        arr_data = np.array([[1, 2, 3], [1, 2, 3, 4]], dtype='object')
+        tuple_data = ((1, 2, 3), (1, 2, 3, 4))
 
+        msg = ("Data has elements with different lengths and therefore cannot be coerced into an N-dimensional "
+               "array. Use the 'index' argument when adding a column of data with different lengths.")
         with self.assertWarnsWith(UserWarning, msg):
             table.add_column(name='col1', description='', data=lol_data,)
         with self.assertWarnsWith(UserWarning, msg):
@@ -379,18 +380,47 @@ class TestDynamicTable(TestCase):
         with self.assertWarnsWith(UserWarning, msg):
             table.add_column(name='col4', description='', data=multi_nested_data,)
         with self.assertWarnsWith(UserWarning, msg):
-            table.add_column(name='col5', description='', data=arr_data,)
+            table.add_column(name='col5', description='', data=tuple_data,)
+
+    def test_add_column_without_required_index_and_no_ragged_check(self):
+        """
+        Add a column with different element lengths without checking for raggedness
+        """
+        lol_data = [[1, 2, 3], [1, 2, 3, 4]]
+        table = self.with_spec()
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        table.add_column(name='col1', description='', data=lol_data, check_ragged=False)
 
     def test_add_row_without_required_index(self):
         """
-        Add a column as a ragged list of lists without specifying an index parameter
+        Add rows with different element lengths without specifying an index parameter
+        """
+
+        # test adding row of list data with different lengths without index parameter
+        msg = ("Data has elements with different lengths and therefore cannot be coerced into an N-dimensional "
+               "array. Use the 'index' argument when creating a column to add rows with different lengths.")
+        table = self.with_spec()
+        table.add_column(name='qux', description='qux column')
+        table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3])
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4])
+        
+        # test adding row of tuple/str data with different lengths without index parameter
+        table = self.with_spec()
+        table.add_column(name='qux', description='qux column')
+        table.add_row(foo=5, bar=50.0, baz='lizard', qux=('a', 'b'))
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_row(foo=5, bar=50.0, baz='lizard', qux=('a', 'b', 'c'))
+
+    def test_add_row_without_required_index_and_no_ragged_check(self):
+        """
+        Add rows with different element lengths without checking for raggedness
         """
         table = self.with_spec()
         table.add_column(name='qux', description='qux column')
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3])
-        msg = "Data is ragged. Use the 'index' argument when creating a column that will have ragged data."
-        with self.assertWarnsWith(UserWarning, msg):
-            table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4])
+        table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4], check_ragged=False)
 
     def test_add_column_auto_index_int(self):
         """

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -354,6 +354,44 @@ class TestDynamicTable(TestCase):
                       ]
                       )
 
+    def test_add_column_without_required_index(self):
+        """
+        Add a column as a ragged list of lists without specifying an index parameter
+        """
+        table = self.with_spec()
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+
+        # testing adding column without a necessary index parameter
+        msg = "Data is ragged. Use the 'index' argument when adding a column with ragged data."
+        lol_data = [[1, 2, 3], [1, 2, 3, 4]]
+        str_data = [['a', 'b'], ['a', 'b', 'c']]
+        empty_data = [[1, 2], []]
+        multi_nested_data = [[[1, 2, 3], [1, 2, 3, 4]], [1, 2]]
+        arr_data = np.array([[1, 2, 3], [1, 2, 3, 4]], dtype='object')
+
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='qux', description='qux column', data=lol_data,)
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='qux', description='qux column', data=str_data,)
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='qux', description='qux column', data=empty_data,)
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='qux', description='qux column', data=multi_nested_data,)
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_column(name='qux', description='qux column', data=arr_data,)
+
+    def test_add_row_without_required_index(self):
+        """
+        Add a column as a ragged list of lists without specifying an index parameter
+        """
+        table = self.with_spec()
+        table.add_column(name='qux', description='qux column')
+        table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3])
+        msg = "Data is ragged. Use the 'index' argument when creating a column that will have ragged data."
+        with self.assertRaisesWith(ValueError, msg):
+            table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4])
+
     def test_add_column_auto_index_int(self):
         """
         Add a column as a list of lists after we have already added data so that we need to create a single VectorIndex

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -405,7 +405,7 @@ class TestDynamicTable(TestCase):
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3])
         with self.assertWarnsWith(UserWarning, msg):
             table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4])
-        
+
         # test adding row of tuple/str data with different lengths without index parameter
         table = self.with_spec()
         table.add_column(name='qux', description='qux column')

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -370,16 +370,16 @@ class TestDynamicTable(TestCase):
         multi_nested_data = [[[1, 2, 3], [1, 2, 3, 4]], [1, 2]]
         arr_data = np.array([[1, 2, 3], [1, 2, 3, 4]], dtype='object')
 
-        with self.assertRaisesWith(ValueError, msg):
-            table.add_column(name='qux', description='qux column', data=lol_data,)
-        with self.assertRaisesWith(ValueError, msg):
-            table.add_column(name='qux', description='qux column', data=str_data,)
-        with self.assertRaisesWith(ValueError, msg):
-            table.add_column(name='qux', description='qux column', data=empty_data,)
-        with self.assertRaisesWith(ValueError, msg):
-            table.add_column(name='qux', description='qux column', data=multi_nested_data,)
-        with self.assertRaisesWith(ValueError, msg):
-            table.add_column(name='qux', description='qux column', data=arr_data,)
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col1', description='', data=lol_data,)
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col2', description='', data=str_data,)
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col3', description='', data=empty_data,)
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col4', description='', data=multi_nested_data,)
+        with self.assertWarnsWith(UserWarning, msg):
+            table.add_column(name='col5', description='', data=arr_data,)
 
     def test_add_row_without_required_index(self):
         """
@@ -389,7 +389,7 @@ class TestDynamicTable(TestCase):
         table.add_column(name='qux', description='qux column')
         table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3])
         msg = "Data is ragged. Use the 'index' argument when creating a column that will have ragged data."
-        with self.assertRaisesWith(ValueError, msg):
+        with self.assertWarnsWith(UserWarning, msg):
             table.add_row(foo=5, bar=50.0, baz='lizard', qux=[1, 2, 3 ,4])
 
     def test_add_column_auto_index_int(self):


### PR DESCRIPTION
## Motivation

Fix #1065. When a user tries to add a ragged array to a DynamicTable using `add_row` or `add_column`, a warning will occur prompting the user to use the `index` argument.  

I had some questions about these potential changes.
1. I found a related issue discussion that suggested that doing a full inspection of the data to detect whether it was ragged might be a costly operation - https://github.com/NeurodataWithoutBorders/pynwb/issues/1060. I was wondering if that's still a concern here or not.
2. Numpy's warning refers to the requested array having an "inhomogeneous shape". I wasn't sure if that type of phrasing is preferred over "ragged."

## How to test the behavior?
```python
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile

# test adding individual trials
nwbfile = mock_NWBFile()
nwbfile.add_trial_column(name="test", description="")
nwbfile.add_trial(start_time=0.0, stop_time=2.0, test=[1, 2])
nwbfile.add_trial(start_time=0.0, stop_time=2.0, test=[3, 4])
nwbfile.add_trial(start_time=0.0, stop_time=2.0, test=[5, 6, 7])  # Warning here

### test adding full column
nwbfile = mock_NWBFile()
nwbfile.add_trial(start_time=0.0, stop_time=2.0)
nwbfile.add_trial(start_time=0.0, stop_time=2.0)
nwbfile.add_trial_column(name="test1", description="", data=[[1, 2], [1, 2]])
nwbfile.add_trial_column(name="test2", description="", data=[[1, 2], [1, 2, 3]])  # Warning here

with NWBHDF5IO('test.nwb', 'w') as f:
    f.write(nwbfile)  # Error here
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
