### PR TITLE
Unwrap TermSetWrapper for the IO 

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1106,6 +1106,7 @@ class HDF5IO(HDMFIO):
         if isinstance(data, TermSetWrapper):
             # This is for when the wrapped item is a dataset
             # (refer to objectmapper.py for wrapped attributes)
+            breakpoint()
             data = data.value
         attributes = builder.attributes
         options['dtype'] = builder.dtype

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -90,7 +90,8 @@ class HDMFIO(metaclass=ABCMeta):
                 herd = HERD(type_map=self.manager.type_map)
 
             # add_ref_container to search for and resolve the TermSetWrapper
-            herd.add_ref_container(container) # container would be the NWBFile
+            herd.add_ref_container(root_container=container,
+                                   unwrap=True) # container would be the NWBFile
             # write HERD
             herd.to_zip(path=self.herd_path)
 

--- a/src/hdmf/backends/io.py
+++ b/src/hdmf/backends/io.py
@@ -91,12 +91,13 @@ class HDMFIO(metaclass=ABCMeta):
 
             # add_ref_container to search for and resolve the TermSetWrapper
             herd.add_ref_container(root_container=container,
-                                   unwrap=True) # container would be the NWBFile
+                                   unwrap=False) # container would be the NWBFile
             # write HERD
             herd.to_zip(path=self.herd_path)
 
         """Write a container to the IO source."""
         f_builder = self.__manager.build(container, source=self.__source, root=True)
+        breakpoint()
         self.write_builder(f_builder, **kwargs)
 
     @docval({'name': 'src_io', 'type': 'hdmf.backends.io.HDMFIO',

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -566,6 +566,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                        % (container.__class__.__name__, container.name, attr_name, spec))
                 raise ContainerConfigurationError(msg)
             if isinstance(attr_val, TermSetWrapper):
+                breakpoint()
                 attr_val = attr_val.value
             if attr_val is not None:
                 attr_val = self.__convert_string(attr_val, spec)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -446,7 +446,9 @@ class HERD(Container):
         return ret
 
     @docval({'name': 'root_container', 'type': HERDManager,
-             'doc': 'The root container or file containing objects with a TermSet.'})
+             'doc': 'The root container or file containing objects with a TermSet.'},
+            {'name': 'unwrap', 'type': bool, 'default': True,
+             'doc': 'Unwrap the wrapper within the containers.'})
     def add_ref_container(self, **kwargs):
         """
         Method to search through the root_container for all instances of TermSet.
@@ -475,6 +477,13 @@ class HERD(Container):
                              key=term,
                              entity_id=entity_id,
                              entity_uri=entity_uri)
+
+            #################################
+            # Unwrap the attribute for the IO
+            #################################
+            if kwargs['unwrap']:
+                setattr(obj, attr_name, wrapper.value)
+
 
     @docval({'name': 'file',  'type': HERDManager, 'doc': 'The file associated with the container.',
              'default': None},

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -352,26 +352,29 @@ class TestHERD(TestCase):
 
     @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_termset(self):
-        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        er = HERD()
-        em = HERDManagerContainer()
-
         col1 = VectorData(name='Species_Data',
                           description='species from NCBI and Ensemble',
                           data=['Homo sapiens'])
-
-        species = DynamicTable(name='species', description='My species', columns=[col1],)
-
-        er.add_ref_termset(file=em,
-                    container=species,
-                    attribute='Species_Data',
-                    key='Homo sapiens',
-                    termset=terms
-                   )
-        self.assertEqual(er.keys.data, [('Homo sapiens',)])
-        self.assertEqual(er.entities.data, [('NCBI_TAXON:9606',
-        'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606')])
-        self.assertEqual(er.objects.data, [(0, col1.object_id, 'VectorData', '', '')])
+        # terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        # er = HERD()
+        # em = HERDManagerContainer()
+        #
+        # col1 = VectorData(name='Species_Data',
+        #                   description='species from NCBI and Ensemble',
+        #                   data=['Homo sapiens'])
+        #
+        # species = DynamicTable(name='species', description='My species', columns=[col1],)
+        #
+        # er.add_ref_termset(file=em,
+        #             container=species,
+        #             attribute='Species_Data',
+        #             key='Homo sapiens',
+        #             termset=terms
+        #            )
+        # self.assertEqual(er.keys.data, [('Homo sapiens',)])
+        # self.assertEqual(er.entities.data, [('NCBI_TAXON:9606',
+        # 'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606')])
+        # self.assertEqual(er.objects.data, [(0, col1.object_id, 'VectorData', '', '')])
 
     @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_termset_data_object_error(self):

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -73,9 +73,17 @@ class Foo(Container):
     def my_data(self):
         return self.__data
 
+    @my_data.setter
+    def my_data(self, value):
+        self.__data = value
+
     @property
     def attr1(self):
         return self.__attr1
+
+    @attr1.setter
+    def attr1(self, value):
+        self.__attr1 = value
 
     @property
     def attr2(self):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -830,7 +830,7 @@ class TestRoundTrip(TestCase):
         foo = Foo(name="species", attr1='attr1', attr2=0,
                   my_data=TermSetWrapper(value=['Homo sapiens', 'Mus musculus'],
                                                          termset=terms))
-
+                                                         
         foobucket = FooBucket('bucket1', [foo])
         foofile = FooFile(buckets=[foobucket])
 
@@ -839,7 +839,7 @@ class TestRoundTrip(TestCase):
 
         with HDF5IO(self.path, manager=get_foo_buildmanager("text"), mode='r') as io:
             read_foofile = io.read()
-            self.assertListEqual(foofile.buckets['bucket1'].foos['species'].my_data.value,
+            self.assertListEqual(foofile.buckets['bucket1'].foos['species'].my_data,
                                  read_foofile.buckets['bucket1'].foos['species'].my_data[:].tolist())
         remove_test_file('./HERD.zip')
 
@@ -856,7 +856,7 @@ class TestRoundTrip(TestCase):
 
         with HDF5IO(self.path, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
-            self.assertEqual(foofile.buckets['bucket1'].foos['species'].attr1.value,
+            self.assertEqual(foofile.buckets['bucket1'].foos['species'].attr1,
                              read_foofile.buckets['bucket1'].foos['species'].attr1)
             remove_test_file('./HERD.zip')
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -830,7 +830,7 @@ class TestRoundTrip(TestCase):
         foo = Foo(name="species", attr1='attr1', attr2=0,
                   my_data=TermSetWrapper(value=['Homo sapiens', 'Mus musculus'],
                                                          termset=terms))
-                                                         
+
         foobucket = FooBucket('bucket1', [foo])
         foofile = FooFile(buckets=[foobucket])
 


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Goal: Remove the unwrapping of TermSetWrapper from HDF5IO to base HDMF. Why? The current setup only allows TermSetWrapper to be unwrapped for HDF5 and not Zarr. The desire is to not have two IO classes dealing with the unwrapping, but one shared tool.

Ideas:
- I had an idea to unwrap within add_ref_container, but not everything has a setter to allow me to reset via setattr. This could still work in general, but I like the next idea more.
- It is clearer (to me) to just unwrap when the builders are being constructed. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
