### PR TITLE
Field_config refactored 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## HDMF 3.14.0 (Upcoming)
 
 ### Enhancements
-- Added `TermSetConfigurator` to automatically wrap fields with `TermSetWrapper` according to a configuration file. @mavaylon1 [#1016](https://github.com/hdmf-dev/hdmf/pull/1016)
+- Updated `_field_config` to take `type_map` as an argument for APIs. @mavaylon1 [#1094](https://github.com/hdmf-dev/hdmf/pull/1094)
+- Added `TypeConfigurator` to automatically wrap fields with `TermSetWrapper` according to a configuration file. @mavaylon1 [#1016](https://github.com/hdmf-dev/hdmf/pull/1016)
 - Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 
 ## HDMF 3.13.0 (March 20, 2024)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -148,6 +148,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
                 # Get the spec for the constructor arg
                 spec = obj_mapper.get_carg_spec(arg_name)
                 if spec is None:
+                    msg = "Spec not found for %s." % arg_name
+                    warn(msg)
                     return val
 
                 # Get spec attr name

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -128,7 +128,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
             return val
 
         # check to see that the namespace for the container is in the config
-        if self.namespace not in type_map.container_types:
+        if self.namespace not in termset_config['namespaces']:
             msg = "%s not found within loaded configuration." % self.namespace
             warn(msg)
             return val
@@ -147,6 +147,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
 
                 # Get the spec for the constructor arg
                 spec = obj_mapper.get_carg_spec(arg_name)
+                if spec is None:
+                    return val
 
                 # Get spec attr name
                 mapped_attr_name = obj_mapper.get_attribute(spec)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -86,9 +86,15 @@ class AbstractContainer(metaclass=ExtenderMeta):
             if name in self.fields:
                 msg = "can't set attribute '%s' -- already set" % name
                 raise AttributeError(msg)
-            self.fields[name] = self._field_config(arg_name=name, val=val)
-
+            # load termset configuration file from global Config
+            self.fields[name] = self._field_config(arg_name=name,
+                                                   val=val,
+                                                   type_map=self.__get_type_map())
         return setter
+
+    def __get_type_map(self):
+        from hdmf.common import get_type_map # circular import
+        return get_type_map()
 
     @property
     def data_type(self):
@@ -98,7 +104,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         return getattr(self, self._data_type_attr)
 
 
-    def _field_config(self, arg_name, val):
+    def _field_config(self, arg_name, val, type_map):
         """
         This method will be called in the setter. The termset configuration will be used (if loaded)
         to check for a defined TermSet associated with the field. If found, the value of the field
@@ -108,9 +114,6 @@ class AbstractContainer(metaclass=ExtenderMeta):
         itself is only one file. When a user loads custom configs, the config is appended/modified.
         The modifications are not written to file, avoiding permanent modifications.
         """
-        # load termset configuration file from global Config
-        from hdmf.common import get_type_map # circular import
-        type_map = get_type_map()
         configurator = type_map.type_config
 
         if len(configurator.path)>0:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -100,8 +100,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         """
         Return the spec data type associated with this container.
         """
-        _type = getattr(self, self._data_type_attr)
-        return _type
+        return getattr(self, self._data_type_attr)
 
     def _field_config(self, arg_name, val, type_map):
         """
@@ -155,13 +154,14 @@ class AbstractContainer(metaclass=ExtenderMeta):
                 mapped_attr_name = obj_mapper.get_attribute(spec)
 
                 try:
-                    termset_path = os.path.join(CUR_DIR,
-                                                config_namespace['data_types'][data_type][mapped_attr_name]['termset'])
-                    termset = TermSet(term_schema_path=termset_path)
-                    val = TermSetWrapper(value=val, termset=termset)
-                    return val
+                    config_termset_path = config_namespace['data_types'][data_type][mapped_attr_name]['termset']
                 except KeyError:
                     return val
+
+                termset_path = os.path.join(CUR_DIR, config_termset_path)
+                termset = TermSet(term_schema_path=termset_path)
+                val = TermSetWrapper(value=val, termset=termset)
+                return val
 
     @classmethod
     def _getter(cls, field):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -147,18 +147,17 @@ class AbstractContainer(metaclass=ExtenderMeta):
 
                 # Get the spec for the constructor arg
                 spec = obj_mapper.get_carg_spec(arg_name)
-                if spec is None:
-                    return val
 
                 # Get spec attr name
                 mapped_attr_name = obj_mapper.get_attribute(spec)
 
+                config_data_type = config_namespace['data_types'][data_type]
                 try:
-                    config_termset_path = config_namespace['data_types'][data_type][mapped_attr_name]['termset']
+                    config_termset_path = config_data_type[mapped_attr_name]
                 except KeyError:
                     return val
 
-                termset_path = os.path.join(CUR_DIR, config_termset_path)
+                termset_path = os.path.join(CUR_DIR, config_termset_path['termset'])
                 termset = TermSet(term_schema_path=termset_path)
                 val = TermSetWrapper(value=val, termset=termset)
                 return val

--- a/tests/unit/common/test_common.py
+++ b/tests/unit/common/test_common.py
@@ -17,8 +17,11 @@ class TestCommonTypeMap(TestCase):
         load_type_config(config_path=path)
         tm = get_type_map()
         config = {'namespaces': {'hdmf-common': {'version': '3.12.2',
-                  'data_types': {'VectorData': {'description': {'termset': 'example_test_term_set.yaml'}},
-                                 'VectorIndex': {'data': '...'}}}}}
+                  'data_types': {'VectorData':
+                 {'description': {'termset': 'example_test_term_set.yaml'}},
+                  'VectorIndex': {'data': '...'}}}, 'foo_namespace':
+                 {'version': '...', 'data_types':
+                 {'ExtensionContainer': {'description': None}}}}}
 
         self.assertEqual(tm.type_config.config, config)
         self.assertEqual(tm.type_config.path, [path])

--- a/tests/unit/hdmf_config.yaml
+++ b/tests/unit/hdmf_config.yaml
@@ -7,3 +7,8 @@ namespaces:
           termset: example_test_term_set.yaml
       VectorIndex:
         data: ...
+  foo_namespace:
+    version: ...
+    data_types:
+      ExtensionContainer:
+        description:

--- a/tests/unit/hdmf_config2.yaml
+++ b/tests/unit/hdmf_config2.yaml
@@ -9,7 +9,7 @@ namespaces:
         description:
           termset: example_test_term_set.yaml
       VectorData:
-        description: ...
+        name:
   namespace2:
     version: 0
     data_types:

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -4,7 +4,7 @@ import numpy as np
 from hdmf import Container
 from hdmf.term_set import TermSet, TermSetWrapper, TypeConfigurator
 from hdmf.testing import TestCase, remove_test_file
-from hdmf.common import (VectorIndex, VectorData, unload_type_config,
+from hdmf.common import (VectorData, unload_type_config,
                          get_loaded_type_config, load_type_config)
 from hdmf.utils import popargs
 
@@ -325,12 +325,3 @@ class TestGlobalTypeConfig(TestCase):
             VectorData(name='foo',
                        data=[0],
                        description=TermSetWrapper(value='Homo sapiens', termset=terms))
-
-    def test_warn_field_not_in_spec(self):
-        col1 = VectorData(name='col1',
-                                  description='Homo sapiens',
-                                  data=['1a', '1b', '1c', '2a'])
-        with self.assertWarns(Warning):
-            VectorIndex(name='col1_index',
-                        target=col1,
-                        data=[3, 4])

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -267,12 +267,13 @@ class TestTypeConfig(TestCase):
         tc = TypeConfigurator(path=path)
         tc.load_type_config(config_path=path2)
         config = {'namespaces': {'hdmf-common': {'version': '3.12.2',
-                  'data_types': {'VectorData': {'description': '...'},
+                                 'data_types': {'VectorData': {'name': None},
                                  'VectorIndex': {'data': '...'},
                                  'Data': {'description': {'termset': 'example_test_term_set.yaml'}},
                                  'EnumData': {'description': {'termset': 'example_test_term_set.yaml'}}}},
                   'namespace2': {'version': 0,
-                  'data_types': {'MythicData': {'description': {'termset': 'example_test_term_set.yaml'}}}}}}
+                                 'data_types':
+                                 {'MythicData': {'description': {'termset': 'example_test_term_set.yaml'}}}}}}
         self.assertEqual(tc.path, [path, path2])
         self.assertEqual(tc.config, config)
 

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -279,13 +279,20 @@ class TestTypeConfig(TestCase):
 
 
 class ExtensionContainer(Container):
-    __fields__ = ("description", "data")
+    __fields__ = ("description",)
 
     def __init__(self, **kwargs):
         description, namespace = popargs('description', 'namespace', kwargs)
         self.namespace = namespace
         super().__init__(**kwargs)
         self.description = description
+
+    @property
+    def data_type(self):
+        """
+        Return the spec data type associated with this container.
+        """
+        return "ExtensionContainer"
 
 
 class TestGlobalTypeConfig(TestCase):
@@ -332,3 +339,8 @@ class TestGlobalTypeConfig(TestCase):
         load_type_config(config_path='tests/unit/hdmf_config2.yaml')
 
         VectorData(name='foo', data=[0], description='Homo sapiens')
+
+    def test_spec_none(self):
+        ExtensionContainer(name='foo',
+                           namespace='foo_namespace',
+                           description='Homo sapiens')

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -278,7 +278,7 @@ class TestTypeConfig(TestCase):
 
 
 class ExtensionContainer(Container):
-    __fields__ = ("description",)
+    __fields__ = ("description", "data")
 
     def __init__(self, **kwargs):
         description, namespace = popargs('description', 'namespace', kwargs)
@@ -325,3 +325,9 @@ class TestGlobalTypeConfig(TestCase):
             VectorData(name='foo',
                        data=[0],
                        description=TermSetWrapper(value='Homo sapiens', termset=terms))
+
+    def test_field_not_in_config(self):
+        unload_type_config()
+        load_type_config(config_path='tests/unit/hdmf_config2.yaml')
+
+        VectorData(name='foo', data=[0], description='Homo sapiens')

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -267,13 +267,15 @@ class TestTypeConfig(TestCase):
         tc = TypeConfigurator(path=path)
         tc.load_type_config(config_path=path2)
         config = {'namespaces': {'hdmf-common': {'version': '3.12.2',
-                                 'data_types': {'VectorData': {'name': None},
-                                 'VectorIndex': {'data': '...'},
-                                 'Data': {'description': {'termset': 'example_test_term_set.yaml'}},
-                                 'EnumData': {'description': {'termset': 'example_test_term_set.yaml'}}}},
-                  'namespace2': {'version': 0,
-                                 'data_types':
-                                 {'MythicData': {'description': {'termset': 'example_test_term_set.yaml'}}}}}}
+                  'data_types': {'VectorData': {'name': None},
+                  'VectorIndex': {'data': '...'},
+                  'Data': {'description': {'termset': 'example_test_term_set.yaml'}},
+                  'EnumData': {'description': {'termset': 'example_test_term_set.yaml'}}}},
+                  'foo_namespace': {'version': '...',
+                  'data_types': {'ExtensionContainer': {'description': None}}},
+                  'namespace2': {'version': 0, 'data_types':
+                  {'MythicData': {'description':
+                  {'termset': 'example_test_term_set.yaml'}}}}}}
         self.assertEqual(tc.path, [path, path2])
         self.assertEqual(tc.config, config)
 
@@ -308,8 +310,12 @@ class TestGlobalTypeConfig(TestCase):
         config = get_loaded_type_config()
         self.assertEqual(config,
         {'namespaces': {'hdmf-common': {'version': '3.12.2',
-        'data_types': {'VectorData': {'description': {'termset': 'example_test_term_set.yaml'}},
-                       'VectorIndex': {'data': '...'}}}}})
+         'data_types': {'VectorData':
+        {'description': {'termset': 'example_test_term_set.yaml'}},
+         'VectorIndex': {'data': '...'}}}, 'foo_namespace':
+        {'version': '...', 'data_types':
+        {'ExtensionContainer': {'description': None}}}}}
+)
 
     def test_validate_with_config(self):
         data = VectorData(name='foo', data=[0], description='Homo sapiens')
@@ -341,6 +347,7 @@ class TestGlobalTypeConfig(TestCase):
         VectorData(name='foo', data=[0], description='Homo sapiens')
 
     def test_spec_none(self):
-        ExtensionContainer(name='foo',
-                           namespace='foo_namespace',
-                           description='Homo sapiens')
+        with self.assertWarns(Warning):
+            ExtensionContainer(name='foo',
+                               namespace='foo_namespace',
+                               description='Homo sapiens')


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

1. We want to use the PyNWB typemap when using the TypeConfigurator in pynwb. As a result we need to update the field setter to take in typemap. 
2. I cleaned up the field_config method.

We can override the get type map function on the pynwb side. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
