### PR TITLE
Ignore config cache warnings in sphinx 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,6 +93,8 @@ nitpick_ignore = [('py:class', 'Intracomm'),
                   ('py:class', 'unittest.case.TestCase'),
                   ]
 
+suppress_warnings = ["config.cache"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
## Motivation

The sphinx_gallery_conf configuration contains classes that are unpickleable and will now warn the user. This warning causes the link checker workflow to fail.

## How to test the behavior?

Update sphinx and run the following:
```
cd docs
make clean && make html
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
