### PR TITLE
Update coverage call, don't install in editable mode in testing

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install -e .
+          pip install .
           pip list
 
       - name: Conda reporting

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install package
         run: |
-          python -m pip install -e .  # must install in editable mode for coverage to find sources
+          python -m pip install .
           python -m pip list
 
       - name: Run tests and generate coverage report

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           # coverage is configured in pyproject.toml
-          pytest --cov=hdmf --cov-report=xml --cov-report=term  # codecov uploader requires xml format
+          pytest --cov --cov-report=xml --cov-report=term  # codecov uploader requires xml format
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -67,5 +67,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          file: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -60,9 +60,8 @@ jobs:
 
       - name: Run tests and generate coverage report
         run: |
-          pytest
-          python -m coverage xml  # codecov uploader requires xml format
-          python -m coverage report -m
+          # coverage is configured in pyproject.toml
+          pytest --cov=hdmf --cov-report=xml --cov-report=term  # codecov uploader requires xml format
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run tests and generate coverage report
         run: |
-          pytest --cov
+          pytest
           python -m coverage xml  # codecov uploader requires xml format
           python -m coverage report -m
 

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -32,8 +32,7 @@ jobs:
           git clone https://github.com/hdmf-dev/hdmf-zarr.git --recurse-submodules
           cd hdmf-zarr
           python -m pip install -r requirements-dev.txt  # do not install the pinned install requirements
-          # must install in editable mode for coverage to find sources
-          python -m pip install -e .  # this will install a different version of hdmf from the current one
+          python -m pip install .  # this will install a different version of hdmf from the current one
           cd ..
           python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -32,8 +32,7 @@ jobs:
           git clone https://github.com/NeurodataWithoutBorders/pynwb.git --recurse-submodules
           cd pynwb
           python -m pip install -r requirements-dev.txt  # do not install the pinned install requirements
-          # must install in editable mode for coverage to find sources
-          python -m pip install -e .  # this will install a different version of hdmf from the current one
+          python -m pip install .  # this will install a different version of hdmf from the current one
           cd ..
           python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install -e .
+          pip install .
           pip list
 
       - name: Conda reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Updated `_field_config` to take `type_map` as an argument for APIs. @mavaylon1 [#1094](https://github.com/hdmf-dev/hdmf/pull/1094)
 - Added `TypeConfigurator` to automatically wrap fields with `TermSetWrapper` according to a configuration file. @mavaylon1 [#1016](https://github.com/hdmf-dev/hdmf/pull/1016)
 - Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
-- Update CI and testing to not install in editable mode. @rly [#1107](https://github.com/hdmf-dev/hdmf/pull/1107)
+- Updated testing to not install in editable mode and not run `coverage` by default. @rly [#1107](https://github.com/hdmf-dev/hdmf/pull/1107)
 
 ## HDMF 3.13.0 (March 20, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `_field_config` to take `type_map` as an argument for APIs. @mavaylon1 [#1094](https://github.com/hdmf-dev/hdmf/pull/1094)
 - Added `TypeConfigurator` to automatically wrap fields with `TermSetWrapper` according to a configuration file. @mavaylon1 [#1016](https://github.com/hdmf-dev/hdmf/pull/1016)
 - Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
+- Update CI and testing to not install in editable mode. @rly [#1107](https://github.com/hdmf-dev/hdmf/pull/1107)
 
 ## HDMF 3.13.0 (March 20, 2024)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ignore-words-list = "datas"
 
 [tool.coverage.run]
 branch = true
-source = ["src"]
+source = ["hdmf"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ packages = ["src/hdmf"]
 # verbose = 1
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/hdmf --cov-report html"
+addopts = "--cov=hdmf --cov-report html"
 norecursedirs = "tests/unit/helpers"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ packages = ["src/hdmf"]
 # verbose = 1
 
 [tool.pytest.ini_options]
-addopts = "--cov=hdmf --cov-report html"
 norecursedirs = "tests/unit/helpers"
 
 [tool.codespell]
@@ -86,16 +85,16 @@ ignore-words-list = "datas"
 
 [tool.coverage.run]
 branch = true
-source = ["src/"]
-omit = [
-    "src/hdmf/_due.py",
-    "src/hdmf/testing/*",
-]
+source = ["src"]
 
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
     "@abstract"
+]
+omit = [
+    "*/hdmf/_due.py",
+    "*/hdmf/testing/*",
 ]
 
 # [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ packages = ["src/hdmf"]
 # verbose = 1
 
 [tool.pytest.ini_options]
-addopts = "--cov=hdmf --cov-report html"
+addopts = "--cov=src/hdmf --cov-report html"
 norecursedirs = "tests/unit/helpers"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ packages = ["src/hdmf"]
 # verbose = 1
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-report html"
+addopts = "--cov=hdmf --cov-report html"
 norecursedirs = "tests/unit/helpers"
 
 [tool.codespell]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ requires = pip >= 22.0
 
 [testenv]
 download = True
-usedevelop = True
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
     VIRTUALENV_PIP = 23.3.1


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/NeurodataWithoutBorders/nwbinspector/pull/450#discussion_r1583475196

https://setuptools.pypa.io/en/latest/userguide/development_mode.html says
> Editable installs are not a perfect replacement for regular installs in a test environment. When in doubt, please test your projects as installed via a regular wheel. There are tools in the Python ecosystem, like [tox](https://pypi.org/project/tox) or [nox](https://pypi.org/project/nox), that can help you with that (when used with appropriate configuration).

We use editable installs in testing in a couple places, mostly to help `coverage` find the sources, but we can configure that in `pyproject.toml` instead.


## How to test the behavior?
Run all GitHub actions

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
