### PR TITLE
Config Typemap generalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated `TermSetWrapper` to support validating a single field within a compound array. @mavaylon1 [#1061](https://github.com/hdmf-dev/hdmf/pull/1061)
 - Updated testing to not install in editable mode and not run `coverage` by default. @rly [#1107](https://github.com/hdmf-dev/hdmf/pull/1107)
 - Add `post_init_method` parameter when generating classes to perform post-init functionality, i.e., validation. @mavaylon1 [#1089](https://github.com/hdmf-dev/hdmf/pull/1089)
+- Updated loading, unloading, and getting the `TypeConfigurator` to support a `TypeMap` parameter. @mavaylon1 [#1117](https://github.com/hdmf-dev/hdmf/pull/1117)
 
 ### Bug Fixes
 - Fixed `TermSetWrapper` warning raised during the setters. @mavaylon1 [#1116](https://github.com/hdmf-dev/hdmf/pull/1116)

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -22,6 +22,7 @@ from ..container import _set_exp  # noqa: E402
 global __TYPE_MAP
 
 @docval({'name': 'config_path', 'type': str, 'doc': 'Path to the configuration file.'},
+        {'name': 'type_map', 'type': TypeMap, 'doc': 'The TypeMap.', 'default': None},
         is_method=False)
 def load_type_config(**kwargs):
     """
@@ -29,23 +30,33 @@ def load_type_config(**kwargs):
     NOTE: This config is global and shared across all type maps.
     """
     config_path = kwargs['config_path']
-    __TYPE_MAP.type_config.load_type_config(config_path)
+    type_map = kwargs['type_map'] or get_type_map()
 
-def get_loaded_type_config():
+    type_map.type_config.load_type_config(config_path)
+
+@docval({'name': 'type_map', 'type': TypeMap, 'doc': 'The TypeMap.', 'default': None},
+        is_method=False)
+def get_loaded_type_config(**kwargs):
     """
     This method returns the entire config file.
     """
-    if __TYPE_MAP.type_config.config is None:
+    type_map = kwargs['type_map'] or get_type_map()
+
+    if type_map.type_config.config is None:
         msg = "No configuration is loaded."
         raise ValueError(msg)
     else:
-        return __TYPE_MAP.type_config.config
+        return type_map.type_config.config
 
-def unload_type_config():
+@docval({'name': 'type_map', 'type': TypeMap, 'doc': 'The TypeMap.', 'default': None},
+        is_method=False)
+def unload_type_config(**kwargs):
     """
     Unload the configuration file.
     """
-    return __TYPE_MAP.type_config.unload_type_config()
+    type_map = kwargs['type_map'] or get_type_map()
+
+    return type_map.type_config.unload_type_config()
 
 # a function to register a container classes with the global map
 @docval({'name': 'data_type', 'type': str, 'doc': 'the data_type to get the spec for'},


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

This cleans up the typemap defaults in pynwb and hdmf when loading TypeConfig. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
