### PR TITLE
Delete MANIFEST.in and exclude artifacts from sdist and wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.14.1 (Upcoming)
+
+### Bug fixes
+- Excluded unnecessary artifacts from sdist and wheel. @rly [#1119](https://github.com/hdmf-dev/hdmf/pull/1119)
+
 ## HDMF 3.14.0 (May 20, 2024)
 
 ### Enhancements

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include license.txt Legal.txt src/hdmf/_due.py
-include requirements.txt requirements-dev.txt requirements-doc.txt requirements-min.txt requirements-opt.txt
-include test_gallery.py tox.ini
-graft tests
-global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,23 @@ source = "vcs"
 version-file = "src/hdmf/_version.py"
 
 [tool.hatch.build.targets.sdist]
-exclude = [".git_archival.txt"]
+exclude = [
+    ".git*",
+    ".codecov.yml",
+    ".readthedocs.yaml",
+    ".mailmap",
+    ".pre-commit-config.yaml",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hdmf"]
+exclude = [
+    ".git*",
+    ".codecov.yml",
+    ".readthedocs.yaml",
+    ".mailmap",
+    ".pre-commit-config.yaml",
+]
 
 # [tool.mypy]
 # no_incremental = true  # needed b/c mypy and ruamel.yaml do not play nice. https://github.com/python/mypy/issues/12664


### PR DESCRIPTION
Now that we use hatch to build instead of setuptools, and hatch has its own way of specifying which files go into the sdist/wheel, `MANIFEST.in` is no longer used and can be deleted. 

Analogous to https://github.com/NeurodataWithoutBorders/pynwb/pull/1902

Before switching to hatch, we included only certain files in the sdist/wheel (as shown in MANIFEST.in). Since switching to hatch, we include basically all files, which is unnecessary. So here I also exclude the ones we excluded previously.