### PR TITLE
Expanding support for Append

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -711,6 +711,7 @@ class HDF5IO(HDMFIO):
                     kwargs['dtype'] = d.dtype
                 elif isinstance(elem1, Reference):
                     d = BuilderH5ReferenceDataset(h5obj, self)
+                    breakpoint()
                     kwargs['dtype'] = d.dtype
             elif h5obj.dtype.kind == 'V':  # table / compound data type
                 cpd_dt = h5obj.dtype

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -949,6 +949,7 @@ class Data(AbstractContainer):
 
     def append(self, arg):
         self._validate_new_data_element(arg)
+        # breakpoint()
         self.__data = append_data(self.__data, arg)
 
     def extend(self, arg):

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -5,16 +5,22 @@ from collections.abc import Iterable, Callable
 from warnings import warn
 from typing import Tuple
 from itertools import product, chain
+from zarr import Array as ZarrArray
 
 import h5py
 import numpy as np
 
 from .utils import docval, getargs, popargs, docval_macro, get_data_shape
 
-
 def append_data(data, arg):
-    if isinstance(data, (list, DataIO)):
+    from hdmf.backends.hdf5.h5_utils import HDMFDataset
+
+    if isinstance(data, (list, DataIO, HDMFDataset)):
         data.append(arg)
+        return data
+    elif isinstance(data, ZarrArray):
+        # breakpoint()
+        data.append([arg], axis=0)
         return data
     elif type(data).__name__ == 'TermSetWrapper': # circular import
         data.append(arg)
@@ -31,6 +37,7 @@ def append_data(data, arg):
         data[-1] = arg
         return data
     else:
+        breakpoint()
         msg = "Data cannot append to object of type '%s'" % type(data)
         raise ValueError(msg)
 

--- a/src/hdmf/query.py
+++ b/src/hdmf/query.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .array import Array
 from .utils import ExtenderMeta, docval_macro, docval, getargs
-
+from .data_utils import DataIO, append_data
 
 class Query(metaclass=ExtenderMeta):
     __operations__ = (
@@ -162,6 +162,9 @@ class HDMFDataset(metaclass=ExtenderMeta):
 
     def next(self):
         return self.dataset.next()
+
+    def append(self, arg):
+        append_data(self.dataset, arg)
 
 
 class ReferenceResolver(metaclass=ABCMeta):

--- a/tests/unit/foo.py
+++ b/tests/unit/foo.py
@@ -1,0 +1,53 @@
+# create mock NWB file
+from pynwb.testing.mock.file import mock_NWBFile
+from pynwb.file import Device
+from pynwb.ecephys import ElectrodeGroup
+from hdmf_zarr.nwb import NWBZarrIO
+
+nwbfile = mock_NWBFile()
+
+# add device
+device = Device(name="my_device", description="my device")
+_ = nwbfile.add_device(device)
+# add electrode group
+eg = ElectrodeGroup(name="tetrode", description="my_tetrode", location="unknown", device=device)
+_ = nwbfile.add_electrode_group(eg)
+
+nwbfile.add_electrode_column(name="source", description="1st or 2nd round")
+
+# add a few electrodes
+rel_xs = [0., 10., 20., 30.]
+rel_ys = [0., 0., 0., 0.]
+
+for x, y in zip(rel_xs, rel_ys):
+    for x, y in zip(rel_xs, rel_ys):
+        nwbfile.add_electrode(
+            rel_x=x,
+            rel_y=y,
+            enforce_unique_id=True,
+            source="first",
+            group=eg,
+            location="unknown"
+        )
+
+
+# save to Zarr (same error in "a" mode)
+with NWBZarrIO("test.nwb", mode="w") as io:
+    io.write(nwbfile)
+
+# now reload and try to add some more electrodes
+io = NWBZarrIO("test.nwb", mode="r+d")
+nwbfile_read = io.read()
+
+rel_xs = [50., 60., 70., 80.]
+rel_ys = [0., 0., 0., 0.]
+
+for x, y in zip(rel_xs, rel_ys):
+    nwbfile_read.add_electrode(
+        rel_x=x,
+        rel_y=y,
+        enforce_unique_id=True,
+        source="second",
+        group=eg,
+        location="unknown"
+    )

--- a/tests/unit/foo.py
+++ b/tests/unit/foo.py
@@ -36,7 +36,7 @@ with NWBZarrIO("test.nwb", mode="w") as io:
     io.write(nwbfile)
 
 # now reload and try to add some more electrodes
-io = NWBZarrIO("test.nwb", mode="r+d")
+io = NWBZarrIO("test.nwb", mode="r+")
 nwbfile_read = io.read()
 
 rel_xs = [50., 60., 70., 80.]


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

DatasetOfReferences (thoughts):
Say I have a DatasetofReferences (that has been opened in append mode). I want to append to it. This DoR is the data of a VectorData. There are a few problems here. 
1. There is no support in append_data for appending a DoR.
2. We also have two types of DoR classes, so we can get by this with a check of HDMFDataset. 
3. Even with HDMFDataset there is no append method that will append to the data itself. This data would either be a H5 dataset or a zarr array.

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
