### PR TITLE
Warn when unexpected keys in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## HDMF 3.14.2 (???)
 
+### Enhancements
+- Warn when unexpected keys are present in specs. @rly [#1134](https://github.com/hdmf-dev/hdmf/pull/1134)
+
 ### Bug fixes
 - Fix iterator increment causing an extra +1 added after the end of completion. @CodyCBakerPhD [#1128](https://github.com/hdmf-dev/hdmf/pull/1128)
-
-
 
 ## HDMF 3.14.1 (June 6, 2024)
 

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -93,9 +93,13 @@ class ConstructableDict(dict, metaclass=ABCMeta):
         vargs = cls.build_const_args(spec_dict)
         kwargs = dict()
         # iterate through the Spec docval and construct kwargs based on matching values in spec_dict
+        unused_vargs = list(vargs)
         for x in get_docval(cls.__init__):
             if x['name'] in vargs:
                 kwargs[x['name']] = vargs.get(x['name'])
+                unused_vargs.remove(x['name'])
+        if unused_vargs:
+            warn(f'Unexpected keys {unused_vargs} in spec {spec_dict}')
         return cls(**kwargs)
 
 

--- a/tests/unit/spec_tests/test_attribute_spec.py
+++ b/tests/unit/spec_tests/test_attribute_spec.py
@@ -91,3 +91,15 @@ class AttributeSpecTests(TestCase):
         msg = "AttributeSpec.__init__: missing argument 'doc'"
         with self.assertRaisesWith(TypeError, msg):
             AttributeSpec.build_spec(spec_dict)
+
+    def test_build_warn_extra_args(self):
+        spec_dict = {
+            'name': 'attribute1',
+            'doc': 'test attribute',
+            'dtype': 'int',
+            'quantity': '?',
+        }
+        msg = ("Unexpected keys ['quantity'] in spec {'name': 'attribute1', 'doc': 'test attribute', "
+               "'dtype': 'int', 'quantity': '?'}")
+        with self.assertWarnsWith(UserWarning, msg):
+            AttributeSpec.build_spec(spec_dict)

--- a/tests/unit/spec_tests/test_dataset_spec.py
+++ b/tests/unit/spec_tests/test_dataset_spec.py
@@ -245,3 +245,15 @@ class DatasetSpecTests(TestCase):
                 group = GroupSpec('A group', name='group',
                                   data_type_inc=data_type_inc, data_type_def=data_type_def)
                 self.assertEqual(group.data_type, data_type)
+
+    def test_build_warn_extra_args(self):
+        spec_dict = {
+            'name': 'dataset1',
+            'doc': 'test dataset',
+            'dtype': 'int',
+            'required': True,
+        }
+        msg = ("Unexpected keys ['required'] in spec {'name': 'dataset1', 'doc': 'test dataset', "
+               "'dtype': 'int', 'required': True}")
+        with self.assertWarnsWith(UserWarning, msg):
+            DatasetSpec.build_spec(spec_dict)

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -314,6 +314,16 @@ class GroupSpecTests(TestCase):
         expected = AttributeSpec('namespace', 'the namespace for the data type of this object', 'text', required=False)
         self.assertDictEqual(GroupSpec.get_namespace_spec(), expected)
 
+    def test_build_warn_extra_args(self):
+        spec_dict = {
+            'name': 'group1',
+            'doc': 'test group',
+            'required': True,
+        }
+        msg = "Unexpected keys ['required'] in spec {'name': 'group1', 'doc': 'test group', 'required': True}"
+        with self.assertWarnsWith(UserWarning, msg):
+            GroupSpec.build_spec(spec_dict)
+
 
 class TestNotAllowedConfig(TestCase):
 

--- a/tests/unit/spec_tests/test_link_spec.py
+++ b/tests/unit/spec_tests/test_link_spec.py
@@ -67,3 +67,15 @@ class LinkSpecTests(TestCase):
                 )
                 self.assertEqual(spec.required, req)
                 self.assertEqual(spec.is_many(), many)
+
+    def test_build_warn_extra_args(self):
+        spec_dict = {
+            'name': 'link1',
+            'doc': 'test link',
+            'target_type': 'TestType',
+            'required': True,
+        }
+        msg = ("Unexpected keys ['required'] in spec {'name': 'link1', 'doc': 'test link', "
+               "'target_type': 'TestType', 'required': True}")
+        with self.assertWarnsWith(UserWarning, msg):
+            LinkSpec.build_spec(spec_dict)


### PR DESCRIPTION
## Motivation

In a few separate instances, users have tried to create an extension with a group, dataset, or link with "required: true" or an attribute with "quantity: '?'" (I'm not 100% sure on this latter one but definitely the former one). The extension template now warns if the yaml fails schema validation. It would be useful to do this in the API as well. Right now, extra args to the spec constructors are ignored. This PR warns when reading a spec with extra args. We could make this an error, but I worry about breaking the reading of existing data with extensions that have extra args.

Ref: https://github.com/catalystneuro/ndx-patterned-ogen/pull/15#issuecomment-2192092651

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
