### PR TITLE
Zarr append for datasets (non-reference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # HDMF Changelog
 
-## HDMF 3.14.2 (???)
+## HDMF 3.14.2 (Upcoming)
 
 ### Bug fixes
 - Fix iterator increment causing an extra +1 added after the end of completion. @CodyCBakerPhD [#1128](https://github.com/hdmf-dev/hdmf/pull/1128)
 
-
+### Enhancements
+- Support appending to zarr arrays. @mavaylon1 [#1136](https://github.com/hdmf-dev/hdmf/pull/1136)
 
 ## HDMF 3.14.1 (June 6, 2024)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pandas>=1.0.5",
     "ruamel.yaml>=0.16",
     "scipy>=1.4",
+    "zarr >= 2.12.0",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,9 +118,6 @@ omit = [
 
 [tool.ruff]
 lint.select = ["E", "F", "T100", "T201", "T203"]
-ignore = [
-    "E721" # We use it for good reasons
-]
 exclude = [
   ".git",
   ".tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-zarr = ["zarr>=2.12.0"]
 tqdm = ["tqdm>=4.41.0"]
 termset = ["linkml-runtime>=1.5.5; python_version >= '3.9'",
            "schemasheets>=0.1.23; python_version >= '3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ omit = [
 
 [tool.ruff]
 lint.select = ["E", "F", "T100", "T201", "T203"]
+ignore = [
+    "E721" # We use it for good reasons
+]
 exclude = [
   ".git",
   ".tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pandas>=1.0.5",
     "ruamel.yaml>=0.16",
     "scipy>=1.4",
-    # "zarr >= 2.12.0",
+    "zarr >= 2.12.0",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
 ]
 dynamic = ["version"]
@@ -117,7 +117,7 @@ omit = [
 # force-exclude = "src/hdmf/common/hdmf-common-schema|docs/gallery"
 
 [tool.ruff]
-select = ["E", "F", "T100", "T201", "T203"]
+lint.select = ["E", "F", "T100", "T201", "T203"]
 exclude = [
   ".git",
   ".tox",
@@ -132,11 +132,11 @@ exclude = [
 ]
 line-length = 120
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "docs/gallery/*" = ["E402", "T201"]
 "src/*/__init__.py" = ["F401"]
 "setup.py" = ["T201"]
 "test_gallery.py" = ["T201"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pandas>=1.0.5",
     "ruamel.yaml>=0.16",
     "scipy>=1.4",
-    "zarr >= 2.12.0",
+    # "zarr >= 2.12.0",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
 ]
 dynamic = ["version"]

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -728,7 +728,7 @@ class HDF5IO(HDMFIO):
     def _check_str_dtype(self, h5obj):
         dtype = h5obj.dtype
         if dtype.kind == 'O':
-            if dtype.metadata.get('vlen') == str and H5PY_3:
+            if isinstance(dtype.metadata.get('vlen'), str) and H5PY_3:
                 return StrDataset(h5obj, None)
         return h5obj
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -728,7 +728,7 @@ class HDF5IO(HDMFIO):
     def _check_str_dtype(self, h5obj):
         dtype = h5obj.dtype
         if dtype.kind == 'O':
-            if isinstance(dtype.metadata.get('vlen'), str) and H5PY_3:
+            if dtype.metadata.get('vlen') == str and H5PY_3:
                 return StrDataset(h5obj, None)
         return h5obj
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -728,7 +728,7 @@ class HDF5IO(HDMFIO):
     def _check_str_dtype(self, h5obj):
         dtype = h5obj.dtype
         if dtype.kind == 'O':
-            if dtype.metadata.get('vlen') == str and H5PY_3:
+            if dtype.metadata.get('vlen') is str and H5PY_3:
                 return StrDataset(h5obj, None)
         return h5obj
 

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1164,7 +1164,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             if not isinstance(builder, DatasetBuilder):  # pragma: no cover
                 raise ValueError("__get_subspec_values - must pass DatasetBuilder with DatasetSpec")
             if (spec.shape is None and getattr(builder.data, 'shape', None) == (1,) and
-                    type(builder.data[0]) != np.void):
+                    type(builder.data[0]) is not np.void):
                 # if a scalar dataset is expected and a 1-element non-compound dataset is given, then read the dataset
                 builder['data'] = builder.data[0]  # use dictionary reference instead of .data to bypass error
             ret[spec] = self.__check_ref_resolver(builder.data)

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -5,16 +5,19 @@ from collections.abc import Iterable, Callable
 from warnings import warn
 from typing import Tuple
 from itertools import product, chain
+from zarr import Array as ZarrArray
 
 import h5py
 import numpy as np
 
 from .utils import docval, getargs, popargs, docval_macro, get_data_shape
 
-
 def append_data(data, arg):
     if isinstance(data, (list, DataIO)):
         data.append(arg)
+        return data
+    elif isinstance(data, ZarrArray):
+        data.append([arg], axis=0)
         return data
     elif type(data).__name__ == 'TermSetWrapper': # circular import
         data.append(arg)

--- a/src/hdmf/testing/testcase.py
+++ b/src/hdmf/testing/testcase.py
@@ -174,7 +174,7 @@ class TestCase(unittest.TestCase):
         :param message: custom additional message to show when assertions as part of this assert are failing
         """
         array_data_types = tuple([i for i in get_docval_macro('array_data')
-                                  if (i != list and i != tuple and i != AbstractDataChunkIterator)])
+                                  if (i is not list and i is not tuple and i is not AbstractDataChunkIterator)])
         # We construct array_data_types this way to avoid explicit dependency on h5py, Zarr and other
         # I/O backends. Only list and tuple do not support [()] slicing, and AbstractDataChunkIterator
         # should never occur here. The effective value of array_data_types is then:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -164,7 +164,7 @@ def get_type(data, builder_dtype=None):
                 # Empty array
                 else:
                     # Empty string array
-                    if isinstance(data.dtype.metadata["vlen"], str):
+                    if data.dtype.metadata["vlen"] is str:
                         return "utf", None
                     # Undetermined variable length data type.
                     else:                        # pragma: no cover

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -164,7 +164,7 @@ def get_type(data, builder_dtype=None):
                 # Empty array
                 else:
                     # Empty string array
-                    if data.dtype.metadata["vlen"] == str:
+                    if isinstance(data.dtype.metadata["vlen"], str):
                         return "utf", None
                     # Undetermined variable length data type.
                     else:                        # pragma: no cover

--- a/tests/unit/utils_test/test_data_utils.py
+++ b/tests/unit/utils_test/test_data_utils.py
@@ -1,0 +1,14 @@
+from hdmf.data_utils import append_data
+from hdmf.testing import TestCase
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import zarr
+
+class TestAppendData(TestCase):
+
+    def test_append_data_zarr(self):
+        zarr_array = zarr.array([1,2,3])
+        new = append_data(zarr_array, 4)
+
+        assert_array_equal(new[:], np.array([1,2,3,4]))


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

This supports appending to zarr arrays. This does not cover the edge case for dataset of references. This has the base tests for append_data. There are more tests (TBD) in hdmf-zarr that incorporate the full IO process. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
