### PR TITLE
Move scipy to optional requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 4.0.0 (Upcoming)
+
+### Breaking changes
+- Scipy is no longer a required dependency. Users using the `CSRMatrix` data type should install `scipy` separately. @rly [#1140](https://github.com/hdmf-dev/hdmf/pull/1140)
+
 ## HDMF 3.14.2 (Upcoming)
 
 ### Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     'numpy>=1.18, <2.0', # pin below 2.0 until HDMF supports numpy 2.0
     "pandas>=1.0.5",
     "ruamel.yaml>=0.16",
-    "scipy>=1.4",
     "zarr >= 2.12.0",
     "importlib-resources; python_version < '3.9'",  # TODO: remove when minimum python version is 3.9
 ]

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -4,3 +4,5 @@ zarr==2.17.1
 linkml-runtime==1.7.4; python_version >= "3.9"
 schemasheets==0.2.1; python_version >= "3.9"
 oaklib==0.5.32; python_version >= "3.9"
+scipy==1.14.0; python_version >= "3.10"  # scipy is used only in CSRMatrix data type
+scipy==1.11.3; python_version < "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ jsonschema==4.19.1
 numpy==1.26.1
 pandas==2.1.2
 ruamel.yaml==0.18.2
-scipy==1.11.3

--- a/src/hdmf/common/sparse.py
+++ b/src/hdmf/common/sparse.py
@@ -1,4 +1,11 @@
-import scipy.sparse as sps
+try:
+    from scipy.sparse import csr_matrix
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
+    class csr_matrix:  # dummy class to prevent import errors
+        pass
+
 from . import register_class
 from ..container import Container
 from ..utils import docval, popargs, to_uint_array,  get_data_shape, AllowPositional
@@ -7,7 +14,7 @@ from ..utils import docval, popargs, to_uint_array,  get_data_shape, AllowPositi
 @register_class('CSRMatrix')
 class CSRMatrix(Container):
 
-    @docval({'name': 'data', 'type': (sps.csr_matrix, 'array_data'),
+    @docval({'name': 'data', 'type': (csr_matrix, 'array_data'),
              'doc': 'the data to use for this CSRMatrix or CSR data array.'
                     'If passing CSR data array, *indices*, *indptr*, and *shape* must also be provided'},
             {'name': 'indices', 'type': 'array_data', 'doc': 'CSR index array', 'default': None},
@@ -16,13 +23,17 @@ class CSRMatrix(Container):
             {'name': 'name', 'type': str, 'doc': 'the name to use for this when storing', 'default': 'csr_matrix'},
             allow_positional=AllowPositional.WARNING)
     def __init__(self, **kwargs):
+        if not SCIPY_INSTALLED:
+            raise ImportError(
+                "scipy must be installed to use CSRMatrix. Please install scipy using `pip install scipy`."
+            )
         data, indices, indptr, shape = popargs('data', 'indices', 'indptr', 'shape', kwargs)
         super().__init__(**kwargs)
-        if not isinstance(data, sps.csr_matrix):
+        if not isinstance(data, csr_matrix):
             temp_shape = get_data_shape(data)
             temp_ndim = len(temp_shape)
             if temp_ndim == 2:
-                data = sps.csr_matrix(data)
+                data = csr_matrix(data)
             elif temp_ndim == 1:
                 if any(_ is None for _ in (indptr, indices, shape)):
                     raise ValueError("Must specify 'indptr', 'indices', and 'shape' arguments when passing data array.")
@@ -31,9 +42,10 @@ class CSRMatrix(Container):
                 shape = self.__check_arr(shape, 'shape')
                 if len(shape) != 2:
                     raise ValueError("'shape' argument must specify two and only two dimensions.")
-                data = sps.csr_matrix((data, indices, indptr), shape=shape)
+                data = csr_matrix((data, indices, indptr), shape=shape)
             else:
                 raise ValueError("'data' argument cannot be ndarray of dimensionality > 2.")
+        # self.__data is a scipy.sparse.csr_matrix
         self.__data = data
 
     @staticmethod

--- a/tests/unit/common/test_sparse.py
+++ b/tests/unit/common/test_sparse.py
@@ -10,6 +10,14 @@ except ImportError:
     SCIPY_INSTALLED = False
 
 
+class TestCSRMatrixNoScipy(TestCase):
+
+    def test_import_error(self):
+        data = np.array([[1, 0, 2], [0, 0, 3], [4, 5, 6]])
+        with self.assertRaises(ImportError):
+            CSRMatrix(data=data)
+
+
 @unittest.skipIf(not SCIPY_INSTALLED, "scipy is not installed")
 class TestCSRMatrix(TestCase):
 

--- a/tests/unit/common/test_sparse.py
+++ b/tests/unit/common/test_sparse.py
@@ -10,6 +10,7 @@ except ImportError:
     SCIPY_INSTALLED = False
 
 
+@unittest.skipIf(SCIPY_INSTALLED, "scipy is installed")
 class TestCSRMatrixNoScipy(TestCase):
 
     def test_import_error(self):

--- a/tests/unit/common/test_sparse.py
+++ b/tests/unit/common/test_sparse.py
@@ -1,10 +1,16 @@
 from hdmf.common import CSRMatrix
 from hdmf.testing import TestCase, H5RoundTripMixin
-
-import scipy.sparse as sps
 import numpy as np
+import unittest
+
+try:
+    import scipy.sparse as sps
+    SCIPY_INSTALLED = True
+except ImportError:
+    SCIPY_INSTALLED = False
 
 
+@unittest.skipIf(not SCIPY_INSTALLED, "scipy is not installed")
 class TestCSRMatrix(TestCase):
 
     def test_from_sparse_matrix(self):
@@ -18,6 +24,7 @@ class TestCSRMatrix(TestCase):
         received = CSRMatrix(data=sps_mat)
         self.assertContainerEqual(received, expected, ignore_hdmf_attrs=True)
 
+    @unittest.skipIf(not SCIPY_INSTALLED, "scipy is not installed")
     def test_2d_data(self):
         data = np.array([[1, 0, 2], [0, 0, 3], [4, 5, 6]])
         csr_mat = CSRMatrix(data=data)
@@ -153,7 +160,7 @@ class TestCSRMatrix(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             CSRMatrix(data=data, indices=indices, indptr=indptr, shape=shape)
 
-
+@unittest.skipIf(not SCIPY_INSTALLED, "scipy is not installed")
 class TestCSRMatrixRoundTrip(H5RoundTripMixin, TestCase):
 
     def setUpContainer(self):
@@ -164,6 +171,7 @@ class TestCSRMatrixRoundTrip(H5RoundTripMixin, TestCase):
         return CSRMatrix(data=data, indices=indices, indptr=indptr, shape=shape)
 
 
+@unittest.skipIf(not SCIPY_INSTALLED, "scipy is not installed")
 class TestCSRMatrixRoundTripFromLists(H5RoundTripMixin, TestCase):
     """Test that CSRMatrix works with lists as well"""
 


### PR DESCRIPTION
## Motivation

`scipy` is used only by the `CSRMatrix` data type, which is currently rarely used. To reduce the chance of dependency conflicts and reduce the install time, I propose we make `scipy` an optional requirement.

This is a breaking change since users using the `CSRMatrix` type will need to install `scipy` separately.

Merging into new `hdmf_4.0` branch.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
