### PR TITLE
Fix #1148 : Add passthrough on non-DCI H5DataIO to support its use in pynwb TimeSeries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # HDMF Changelog
 
+## HDMF 3.14.3 (TBD)
+
+### Enhancements
+
+### Bug fixes
+- Fix H5DataIO not exposing `maxshape` on non-dci dsets. @cboulay [#1149](https://github.com/hdmf-dev/hdmf/pull/1149)
+
 ## HDMF 3.14.2 (July 7, 2024)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@
 
 ### Bug fixes
 - Fixed issue where scalar datasets with a compound data type were being written as non-scalar datasets @stephprince [#1176](https://github.com/hdmf-dev/hdmf/pull/1176)
-
-### Bug fixes
-- Fix H5DataIO not exposing `maxshape` on non-dci dsets. @cboulay [#1149](https://github.com/hdmf-dev/hdmf/pull/1149)
+- Fixed H5DataIO not exposing `maxshape` on non-dci dsets. @cboulay [#1149](https://github.com/hdmf-dev/hdmf/pull/1149)
 
 ## HDMF 3.14.3 (July 29, 2024)
 

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -637,3 +637,13 @@ class H5DataIO(DataIO):
         if isinstance(self.data, Dataset) and not self.data.id.valid:
             return False
         return super().valid
+
+    @property
+    def maxshape(self):
+        if 'maxshape' in self.io_settings:
+            return self.io_settings['maxshape']
+        elif hasattr(self.data, 'maxshape'):
+            return self.data.maxshape
+        elif 'shape' in self.io_settings:
+            return self.io_settings['shape']
+        return None

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -21,7 +21,7 @@ from ...data_utils import DataIO, AbstractDataChunkIterator, append_data
 from ...query import HDMFDataset, ReferenceResolver, ContainerResolver, BuilderResolver
 from ...region import RegionSlicer
 from ...spec import SpecWriter, SpecReader
-from ...utils import docval, getargs, popargs, get_docval
+from ...utils import docval, getargs, popargs, get_docval, get_data_shape
 
 
 class HDF5IODataChunkIteratorQueue(deque):
@@ -681,6 +681,5 @@ class H5DataIO(DataIO):
             return self.data.maxshape
         elif hasattr(self, "shape"):
             return self.shape
-        elif 'shape' in self.io_settings:
-            return self.io_settings['shape']
-        return None
+        else:
+            return get_data_shape(self.data)

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -644,6 +644,8 @@ class H5DataIO(DataIO):
             return self.io_settings['maxshape']
         elif hasattr(self.data, 'maxshape'):
             return self.data.maxshape
+        elif hasattr(self, "shape"):
+            return self.shape
         elif 'shape' in self.io_settings:
             return self.io_settings['shape']
         return None

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -569,6 +569,12 @@ class H5IOTest(TestCase):
         dset = self.f["test_dataset"]
         self.assertEqual(dset.chunks, chunk_shape)
 
+    def test_pass_through_of_maxshape_on_h5dataset(self):
+        k = 10
+        self.io.write_dataset(self.f, DatasetBuilder('test_dataset', np.arange(k), attributes={}))
+        dset = H5DataIO(self.f['test_dataset'])
+        self.assertEqual(dset.maxshape, (k,))
+
     #############################################
     #  H5DataIO general
     #############################################

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -604,15 +604,15 @@ class H5IOTest(TestCase):
         dset = self.f["test_dataset"]
         self.assertEqual(dset.chunks, chunk_shape)
 
+    #############################################
+    #  H5DataIO general
+    #############################################
     def test_pass_through_of_maxshape_on_h5dataset(self):
         k = 10
         self.io.write_dataset(self.f, DatasetBuilder('test_dataset', np.arange(k), attributes={}))
         dset = H5DataIO(self.f['test_dataset'])
         self.assertEqual(dset.maxshape, (k,))
 
-    #############################################
-    #  H5DataIO general
-    #############################################
     def test_warning_on_non_gzip_compression(self):
         # Make sure no warning is issued when using gzip
         with warnings.catch_warnings(record=True) as w:
@@ -3768,6 +3768,14 @@ class H5DataIOTests(TestCase):
         dataio = H5DataIO(shape=(10, 10), dtype=int)
         with self.assertRaisesRegex(ValueError, "Setting data when dtype and shape are not None is not supported"):
             dataio.data = list()
+
+    def test_dataio_maxshape(self):
+        dataio = H5DataIO(data=np.arange(10), maxshape=(None,))
+        self.assertEqual(dataio.maxshape, (None,))
+
+    def test_dataio_maxshape_from_data(self):
+        dataio = H5DataIO(data=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.assertEqual(dataio.maxshape, (10,))
 
 
 def test_hdf5io_can_read():


### PR DESCRIPTION
Fix #1148 

## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

As explained in #1148 and [pynwb #1929](https://github.com/NeurodataWithoutBorders/pynwb/issues/1929), when a `pynwb.TimeSeries` object is created where (1) its `data` is a `H5DataIO` object that DOES NOT wrap a DataChunkIterator, AND (2) its `timestamps` are provided explicitly (vs `rate` and `starting_time`), then the `TimeSeries` object crashes because it cannot access the `maxshape` attribute on its `data` value.

With this change, the `H5DataIO` has a new `maxshape` property which passes through the correct maxshape if known (either set during `__init__` or inferred from the dataset) else `None`, and `pynwb.TimeSeries` no longer crashes.

## How to test the behavior?

I added a unit test in unit/test_io_hdf5_h5tools.py

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
