### PR TITLE
[perf] Increase test performance by 274% with this one weird trick...

### DIFF
--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -1,7 +1,6 @@
 import re
 from abc import ABCMeta
 from collections import OrderedDict
-from copy import deepcopy
 from warnings import warn
 
 from ..utils import docval, getargs, popargs, get_docval
@@ -84,7 +83,7 @@ class ConstructableDict(dict, metaclass=ABCMeta):
     def build_const_args(cls, spec_dict):
         ''' Build constructor arguments for this ConstructableDict class from a dictionary '''
         # main use cases are when spec_dict is a ConstructableDict or a spec dict read from a file
-        return deepcopy(spec_dict)
+        return spec_dict
 
     @classmethod
     def build_spec(cls, spec_dict):

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -101,6 +101,8 @@ class ConstructableDict(dict, metaclass=ABCMeta):
             warn(f'Unexpected keys {unused_vargs} in spec {spec_dict}')
         return cls(**kwargs)
 
+    def __hash__(self):
+        return hash(str(self))
 
 class Spec(ConstructableDict):
     ''' A base specification class
@@ -147,9 +149,6 @@ class Spec(ConstructableDict):
         ''' Build constructor arguments for this Spec class from a dictionary '''
         ret = super().build_const_args(spec_dict)
         return ret
-
-    def __hash__(self):
-        return id(self)
 
     @property
     def path(self):


### PR DESCRIPTION
## Motivation

- pynwb tests take half an hour to run
- importing pynwb takes a long time because it has to load namespaces on import (see https://github.com/NeurodataWithoutBorders/pynwb/pull/1931 )

## How to test the behavior?

```python
import pynwb
```

(run the nwb unit tests)

## Description

Profiling the pynwb tests, it turns out that a single `deepcopy` call accounted for almost 2/3 of the run time - the one within `hdmf.spec.spec.ConstructableDict.build_const_args`.

This method is called in three places:
- https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/spec/spec.py#L93
- https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/spec/spec.py#L149
- https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/spec/spec.py#L630

When running the tests, I inserted an `inspect` call to capture the stack traces to see what the higher-order things that call this were, and the only methods that call this one are:

- `NamespaceCatalog.__load_namespace`: https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/spec/namespace.py#L433
- `NamespaceToBuilderHelper.__copy_spec`: https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/backends/utils.py#L83

`load_namespace` is only called when specs are loaded from a file, so a deepcopy is unnecessary here: the deepcopy protects the object being copy from mutation downstream, but the upstream object is discarded immediately and comes from a file (which is not mutated)

the call tree above `__copy_spec` is linear with one fork at the end:
- `NamespaceToBuilderHelper.convert_namespace`
- `HDF5IO.__cache_spec`
  - `HDF5IO.export`
  - `HDF5IO.write`

neither of which mutate the object after the `deepcopy` operation should get called, as far as I can tell.

The thing that we would want to protect is some downstream consumer of the spec from mutating the spec (ie. it should always be a veridical reflect the spec source), but the deepcopy doesn't protect from that since it's only called when instantiating these spec objects.

When running the tests, however, i got a bunch of errors that i couldn't quite understand, but it seemed like it must be some confused equality comparison, and I noticed that the `Spec.__hash__` method was set as being just the `id` of the object - usually dicts aren't hashable bc they are mutable, but that's usually not a problem, except it is here because it seems like these Spec objects are often used as keys in a dictionary.

it seems like the primary thing that `deepcopy` was doing is giving the object a new `id` - which is confirmed by simply using `copy` instead of `deepcopy` or `hash(str(self))` as the `__hash__` function. So it seems like in some places we are forwarding the objects around and getting "hash collisions" or "hash misses" when using `id`. 

SO i tried replacing it with the cheapest hash function money can buy, the aforementioned `hash(str(self))` (which is not ideal lol because it violates the *other* requirement of `__hash__`), but just as a demo of what the problem is and what a potential solution is bc y'all know better how these classes are used...

## Results

So anyway, when running pynwb tests we go from this:

<img width="716" alt="Screenshot 2024-07-15 at 11 28 32 PM" src="https://github.com/user-attachments/assets/a67cc6cb-6eda-49c4-95dd-6b99dd755123">

to this:

<img width="742" alt="Screenshot 2024-07-15 at 10 56 52 PM" src="https://github.com/user-attachments/assets/ab002737-035e-47cf-a924-ddc0ad08b231">

which is fun. (the errors are because i didn't have pytest installed)

this impact is way more dramatic in something like pynwb where we are loading a ton of complex specs over and over again than it is in the hdmf tests, but it is a pretty dramatic perf improvement for basically free, thought y'all woudl be interested.

## Checklist

I have to run out the door rn but i'll return later to finish up any quality checks, but anyway mostly just a "hey here's free perf" pull request as a question bc i figure there are reasons this is not good to do (or you might want a "real hash function")

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?


ttyl xoxo <3