### PR TITLE
Add doc to H5DataIO.dataset setter

### DIFF
--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -551,8 +551,9 @@ class H5DataIO(DataIO):
 
     @dataset.setter
     def dataset(self, val):
-        """Cache an h5py.Dataset, which can be used to cache a written, empty dataset and fill it in later.
+        """Cache the h5py.Dataset written with the stored IO settings.
 
+        This attribute can be used to cache a written, empty dataset and fill it in later.
         This allows users to access the handle to the dataset *without* having to close and repoen a file.
 
         For example::

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -546,10 +546,29 @@ class H5DataIO(DataIO):
 
     @property
     def dataset(self):
+        """Get the cached h5py.Dataset."""
         return self.__dataset
 
     @dataset.setter
     def dataset(self, val):
+        """Cache an h5py.Dataset, which can be used to cache a written, empty dataset and fill it in later.
+
+        This allows users to access the handle to the dataset *without* having to close and repoen a file.
+
+        For example::
+
+            dataio = H5DataIO(shape=(5,), dtype=int)
+            foo = Foo('foo1', dataio, "I am foo1", 17, 3.14)
+            bucket = FooBucket('bucket1', [foo])
+            foofile = FooFile(buckets=[bucket])
+            
+            io = HDF5IO(self.path, manager=self.manager, mode='w')
+            # write the object to disk, including initializing an empty int dataset with shape (5,)
+            io.write(foofile)
+            
+            foo.my_data.dataset[:] = [0, 1, 2, 3, 4]
+            io.close()
+        """
         if self.__dataset is not None:
             raise ValueError("Cannot overwrite H5DataIO.dataset")
         self.__dataset = val

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -554,7 +554,8 @@ class H5DataIO(DataIO):
         """Cache the h5py.Dataset written with the stored IO settings.
 
         This attribute can be used to cache a written, empty dataset and fill it in later.
-        This allows users to access the handle to the dataset *without* having to close and repoen a file.
+        This allows users to access the handle to the dataset *without* having to close 
+        and reopen a file.
 
         For example::
 

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -561,11 +561,11 @@ class H5DataIO(DataIO):
             foo = Foo('foo1', dataio, "I am foo1", 17, 3.14)
             bucket = FooBucket('bucket1', [foo])
             foofile = FooFile(buckets=[bucket])
-            
+
             io = HDF5IO(self.path, manager=self.manager, mode='w')
             # write the object to disk, including initializing an empty int dataset with shape (5,)
             io.write(foofile)
-            
+
             foo.my_data.dataset[:] = [0, 1, 2, 3, 4]
             io.close()
         """

--- a/src/hdmf/backends/hdf5/h5_utils.py
+++ b/src/hdmf/backends/hdf5/h5_utils.py
@@ -554,7 +554,7 @@ class H5DataIO(DataIO):
         """Cache the h5py.Dataset written with the stored IO settings.
 
         This attribute can be used to cache a written, empty dataset and fill it in later.
-        This allows users to access the handle to the dataset *without* having to close 
+        This allows users to access the handle to the dataset *without* having to close
         and reopen a file.
 
         For example::


### PR DESCRIPTION
## Motivation

While reading through the code for `H5DataIO`, I was confused about the purpose of the `dataset` property and how it differs from `data` since it is not used locally: https://github.com/hdmf-dev/hdmf/blob/dfb1df79bce3e34c52af7996429c3f561d96390a/src/hdmf/backends/hdf5/h5_utils.py#L545-L555

It turns out `dataset` was added for a very specific use case where a user wants to create an empty hdf5 dataset, write it to disk, and have access to the handle to that dataset without having to close and reopen the file -- https://github.com/hdmf-dev/hdmf/pull/747

To prevent myself and others from retracing those steps to understand this code, I added a docstring.

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
