### PR TITLE
Allow Codec for compression for use with LINDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - Added support to append to a dataset of references for HDMF-Zarr. @mavaylon1 [#1157](https://github.com/hdmf-dev/hdmf/pull/1157)
+- Allow Codec for compression for use with LINDI
 
 ## HDMF 3.14.3 (July 29, 2024)
 


### PR DESCRIPTION
## Motivation

While hdf5 does not allow numcodecs.Codec for compression, [lindi](https://github.com/neurodatawithoutborders/lindi) does. Right now hdmf does type checking for the compression parameter and raises an exception if the type is not in (str, bool, int). This PR simply allows the Codec type to be passed through so that it can be used with lindi.

## How to test the behavior?

Here's an example that applies a custom compressor to filtered ephys data

https://github.com/NeurodataWithoutBorders/lindi/blob/lindi-tar/examples/DANDI/preprocess_ephys.py

You need to install the lindi-tar branch of lindi and `pip install qfc`. See https://github.com/magland/qfc

@oruebel @rly 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
