### PR TITLE
Improve "already exists" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - Added support to append to a dataset of references for HDMF-Zarr. @mavaylon1 [#1157](https://github.com/hdmf-dev/hdmf/pull/1157)
+- Improved "already exists" error message when adding a container to a `MultiContainerInterface`. @rly [#1165](https://github.com/hdmf-dev/hdmf/pull/1165)
 
 ## HDMF 3.14.3 (July 29, 2024)
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1142,9 +1142,9 @@ class MultiContainerInterface(Container):
                     # still need to mark self as modified
                     self.set_modified()
                 if tmp.name in d:
-                    msg = (f"Cannot add {tmp.__class__} '{tmp.name}' to {cls} '{self.name}' in "
-                           f"attribute '{attr_name}'. {d[tmp.name].__class__} '{tmp.name}' "
-                           f"already exists in the attribute and has the same name.")
+                    msg = (f"Cannot add {tmp.__class__} '{tmp.name}' at 0x{id(tmp)} to dict attribute '{attr_name}' in "
+                           f"{cls} '{self.name}'. {d[tmp.name].__class__} '{tmp.name}' at 0x{id(d[tmp.name])} "
+                           f"already exists in '{attr_name}' and has the same name.")
                     raise ValueError(msg)
                 d[tmp.name] = tmp
             return container

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1142,7 +1142,9 @@ class MultiContainerInterface(Container):
                     # still need to mark self as modified
                     self.set_modified()
                 if tmp.name in d:
-                    msg = "'%s' already exists in %s '%s'" % (tmp.name, cls.__name__, self.name)
+                    msg = (f"Cannot add {tmp.__class__} '{tmp.name}' to {cls} '{self.name}' in "
+                           f"attribute '{attr_name}'. {d[tmp.name].__class__} '{tmp.name}' "
+                           f"already exists in the attribute and has the same name.")
                     raise ValueError(msg)
                 d[tmp.name] = tmp
             return container

--- a/tests/unit/test_multicontainerinterface.py
+++ b/tests/unit/test_multicontainerinterface.py
@@ -198,7 +198,10 @@ class TestBasic(TestCase):
         """Test that adding a container to the attribute dict correctly adds the container."""
         obj1 = Container('obj1')
         foo = Foo(obj1)
-        msg = "'obj1' already exists in Foo 'Foo'"
+        msg = (f"Cannot add <class 'hdmf.container.Container'> 'obj1' at 0x{id(obj1)} to dict attribute "
+               "'containers' in <class 'tests.unit.test_multicontainerinterface.Foo'> 'Foo'. "
+               f"<class 'hdmf.container.Container'> 'obj1' at 0x{id(obj1)} already exists in 'containers' "
+               "and has the same name.")
         with self.assertRaisesWith(ValueError, msg):
             foo.add_container(obj1)
 


### PR DESCRIPTION
## Motivation

The previous message was not very informative about why adding the container was not allowed.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
