### PR TITLE
Add support to write multidimensional string arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - Added support to append to a dataset of references for HDMF-Zarr. @mavaylon1 [#1157](https://github.com/hdmf-dev/hdmf/pull/1157)
+- Added support to write multidimensional string arrays. @stephprince [#1173](https://github.com/hdmf-dev/hdmf/pull/1173)
 
 ## HDMF 3.14.3 (July 29, 2024)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1469,7 +1469,7 @@ class HDF5IO(HDMFIO):
             data_shape = io_settings.pop('shape')
         elif hasattr(data, 'shape'):
             data_shape = data.shape
-        elif isinstance(dtype, np.dtype):
+        elif isinstance(dtype, np.dtype) and len(dtype) > 1:  # check if compound dtype
             data_shape = (len(data),)
         else:
             data_shape = get_data_shape(data)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -617,7 +617,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     def string_type(x):
                         return x.isoformat()  # method works for both date and datetime
                 if string_type is not None:
-                    if spec.shape is not None or spec.dims is not None:
+                    if spec.shape is not None and len(spec.shape) > 1:
+                        ret = [[string_type(item) for item in sublist] for sublist in value]
+                    elif spec.shape is not None or spec.dims is not None:
                         ret = list(map(string_type, value))
                     else:
                         ret = string_type(value)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -598,11 +598,17 @@ class ObjectMapper(metaclass=ExtenderMeta):
 
     def __convert_string(self, value, spec):
         """Convert string types to the specified dtype."""
+        def __apply_string_type(value, string_type):
+            if isinstance(value, (list, tuple, np.ndarray, DataIO)):
+                return [__apply_string_type(item, string_type) for item in value]
+            else:
+                return string_type(value)
+
         ret = value
         if isinstance(spec, AttributeSpec):
             if 'text' in spec.dtype:
                 if spec.shape is not None or spec.dims is not None:
-                    ret = list(map(str, value))
+                    ret = __apply_string_type(value, str)
                 else:
                     ret = str(value)
         elif isinstance(spec, DatasetSpec):
@@ -617,10 +623,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     def string_type(x):
                         return x.isoformat()  # method works for both date and datetime
                 if string_type is not None:
-                    if spec.shape is not None and len(spec.shape) > 1:
-                        ret = [[string_type(item) for item in sublist] for sublist in value]
-                    elif spec.shape is not None or spec.dims is not None:
-                        ret = list(map(string_type, value))
+                    if spec.shape is not None or spec.dims is not None:
+                        ret = __apply_string_type(value, string_type)
                     else:
                         ret = string_type(value)
                     # copy over any I/O parameters if they were specified

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -180,10 +180,11 @@ class TestDynamicContainer(TestCase):
         baz_spec = GroupSpec('A test extension with no Container class',
                              data_type_def='Baz', data_type_inc=self.bar_spec,
                              attributes=[AttributeSpec('attr3', 'a float attribute', 'float'),
-                                         AttributeSpec('attr4', 'another float attribute', 'float')])
+                                         AttributeSpec('attr4', 'another float attribute', 'float'),
+                                         AttributeSpec('attr_array', 'an array attribute', 'text', shape=(None,)),])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
         cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
-        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'skip_post_init'}
+        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'attr_array', 'skip_post_init'}
         received_args = set()
 
         for x in get_docval(cls.__init__):
@@ -211,7 +212,7 @@ class TestDynamicContainer(TestCase):
                                          AttributeSpec('attr4', 'another float attribute', 'float')])
         self.spec_catalog.register_spec(baz_spec, 'extension.yaml')
         cls = self.type_map.get_dt_container_cls('Baz', CORE_NAMESPACE)
-        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'foo', 'skip_post_init'}
+        expected_args = {'name', 'data', 'attr1', 'attr2', 'attr3', 'attr4', 'attr_array', 'foo', 'skip_post_init'}
         received_args = set(map(lambda x: x['name'], get_docval(cls.__init__)))
         self.assertSetEqual(expected_args, received_args)
         self.assertEqual(cls.__name__, 'Baz')

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -24,7 +24,7 @@ class Bar(Container):
             {'name': 'attr_array', 'type': 'array_data', 'doc': 'another attribute', 'default': (1, 2, 3)},
             {'name': 'foo', 'type': 'Foo', 'doc': 'a group', 'default': None})
     def __init__(self, **kwargs):
-        name, data, attr1, attr2, attr3, attr_array, foo = getargs('name', 'data', 'attr1', 'attr2', 'attr3', 
+        name, data, attr1, attr2, attr3, attr_array, foo = getargs('name', 'data', 'attr1', 'attr2', 'attr3',
                                                                    'attr_array', 'foo', kwargs)
         super().__init__(name=name)
         self.__data = data
@@ -401,7 +401,7 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text',
                                       shape=(None, None))],
         )
         type_map = self.customSetUp(bar_spec)
@@ -425,7 +425,7 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text',
                                       shape=(None, None, None))],
         )
         type_map = self.customSetUp(bar_spec)
@@ -449,7 +449,7 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text',
                                       shape=(None, None, None))],
         )
         type_map = self.customSetUp(bar_spec)

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -9,6 +9,7 @@ from hdmf.spec import (GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecN
 from hdmf.testing import TestCase
 from abc import ABCMeta, abstractmethod
 import unittest
+import numpy as np
 
 from tests.unit.helpers.utils import CORE_NAMESPACE, create_test_type_map
 
@@ -352,6 +353,48 @@ class TestMapStrings(TestCase):
         bar_inst = Bar('my_bar', ['a', 'b', 'c', 'd'], 'value1', 10)
         builder = type_map.build(bar_inst)
         self.assertEqual(builder.get('data').data, "['a', 'b', 'c', 'd']")
+
+    def test_build_2d_lol(self):
+        bar_spec = GroupSpec(
+            doc='A test group specification with a data type',
+            data_type_def='Bar',
+            datasets=[
+                DatasetSpec(
+                    doc='an example dataset',
+                    dtype='text',
+                    name='data',
+                    shape=(None, None),
+                    attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
+                )
+            ],
+            attributes=[AttributeSpec(name='attr1', doc='an example string attribute', dtype='text')],
+        )
+        type_map = self.customSetUp(bar_spec)
+        type_map.register_map(Bar, BarMapper)
+        bar_inst = Bar('my_bar', [['aa', 'bb'], ['cc', 'dd']], 'value1', 10)
+        builder = type_map.build(bar_inst)
+        self.assertEqual(builder.get('data').data, [['aa', 'bb'], ['cc', 'dd']])
+
+    def test_build_2d_ndarray(self):
+        bar_spec = GroupSpec(
+            doc='A test group specification with a data type',
+            data_type_def='Bar',
+            datasets=[
+                DatasetSpec(
+                    doc='an example dataset',
+                    dtype='text',
+                    name='data',
+                    shape=(None, None),
+                    attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
+                )
+            ],
+            attributes=[AttributeSpec(name='attr1', doc='an example string attribute', dtype='text')],
+        )
+        type_map = self.customSetUp(bar_spec)
+        type_map.register_map(Bar, BarMapper)
+        bar_inst = Bar('my_bar', np.array([['aa', 'bb'], ['cc', 'dd']]), 'value1', 10)
+        builder = type_map.build(bar_inst)
+        np.testing.assert_array_equal(builder.get('data').data, np.array([['aa', 'bb'], ['cc', 'dd']]))
 
     def test_build_dataio(self):
         bar_spec = GroupSpec('A test group specification with a data type',

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -24,7 +24,8 @@ class Bar(Container):
             {'name': 'attr_array', 'type': 'array_data', 'doc': 'another attribute', 'default': (1, 2, 3)},
             {'name': 'foo', 'type': 'Foo', 'doc': 'a group', 'default': None})
     def __init__(self, **kwargs):
-        name, data, attr1, attr2, attr3, attr_array, foo = getargs('name', 'data', 'attr1', 'attr2', 'attr3', 'attr_array', 'foo', kwargs)
+        name, data, attr1, attr2, attr3, attr_array, foo = getargs('name', 'data', 'attr1', 'attr2', 'attr3', 
+                                                                   'attr_array', 'foo', kwargs)
         super().__init__(name=name)
         self.__data = data
         self.__attr1 = attr1
@@ -400,7 +401,8 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', shape=(None, None))],
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+                                      shape=(None, None))],
         )
         type_map = self.customSetUp(bar_spec)
         type_map.register_map(Bar, BarMapper)
@@ -423,7 +425,8 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', shape=(None, None, None))],
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+                                      shape=(None, None, None))],
         )
         type_map = self.customSetUp(bar_spec)
         type_map.register_map(Bar, BarMapper)
@@ -446,7 +449,8 @@ class TestMapStrings(TestCase):
                     attributes=[AttributeSpec(name='attr2', doc='an example integer attribute', dtype='int')],
                 )
             ],
-            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', shape=(None, None, None))],
+            attributes=[AttributeSpec(name='attr_array', doc='an example array attribute', dtype='text', 
+                                      shape=(None, None, None))],
         )
         type_map = self.customSetUp(bar_spec)
         type_map.register_map(Bar, BarMapper)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -164,6 +164,14 @@ class H5IOTest(TestCase):
         dset = self.f['test_dataset']
         self.assertTrue(np.all(dset[:] == a))
 
+    def test_write_dataset_lol_strings(self):
+        a = [['aa', 'bb'], ['cc', 'dd']]
+        self.io.write_dataset(self.f, DatasetBuilder('test_dataset', a, attributes={}))
+        dset = self.f['test_dataset']
+        decoded_dset = [[item.decode('utf-8') for item in sublist if isinstance(item, bytes)]
+                        for sublist in dset[:]]
+        self.assertTrue(decoded_dset == a)
+
     def test_write_dataset_list_compress_gzip(self):
         a = H5DataIO(np.arange(30).reshape(5, 2, 3),
                      compression='gzip',

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -24,7 +24,7 @@ from hdmf import Data, docval
 from hdmf.data_utils import DataChunkIterator, GenericDataChunkIterator, InvalidDataIOError
 from hdmf.spec.catalog import SpecCatalog
 from hdmf.spec.namespace import NamespaceCatalog, SpecNamespace
-from hdmf.spec.spec import GroupSpec
+from hdmf.spec.spec import GroupSpec, DtypeSpec
 from hdmf.testing import TestCase, remove_test_file
 from hdmf.common.resources import HERD
 from hdmf.term_set import TermSet, TermSetWrapper
@@ -171,6 +171,22 @@ class H5IOTest(TestCase):
         decoded_dset = [[item.decode('utf-8') if isinstance(item, bytes) else item for item in sublist]
                         for sublist in dset[:]]
         self.assertTrue(decoded_dset == a)
+
+    def test_write_dataset_list_compound_datatype(self):
+        a = np.array([(1, 2, 0.5), (3, 4, 0.5)], dtype=[('x', 'int'), ('y', 'int'), ('z', 'float')])
+        dset_builder = DatasetBuilder(
+                    name='test_dataset',
+                    data=a.tolist(),
+                    attributes={},
+                    dtype=[
+                        DtypeSpec('x', doc='x', dtype='int'),
+                        DtypeSpec('y', doc='y', dtype='int'),
+                        DtypeSpec('z', doc='z', dtype='float'),
+                    ],
+                )
+        self.io.write_dataset(self.f, dset_builder)
+        dset = self.f['test_dataset']
+        self.assertTrue(np.all(dset[:] == a))
 
     def test_write_dataset_list_compress_gzip(self):
         a = H5DataIO(np.arange(30).reshape(5, 2, 3),

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -186,7 +186,8 @@ class H5IOTest(TestCase):
                 )
         self.io.write_dataset(self.f, dset_builder)
         dset = self.f['test_dataset']
-        self.assertTrue(np.all(dset[:] == a))
+        for field in a.dtype.names:
+            self.assertTrue(np.all(dset[field][:] == a[field]))
 
     def test_write_dataset_list_compress_gzip(self):
         a = H5DataIO(np.arange(30).reshape(5, 2, 3),

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -168,7 +168,7 @@ class H5IOTest(TestCase):
         a = [['aa', 'bb'], ['cc', 'dd']]
         self.io.write_dataset(self.f, DatasetBuilder('test_dataset', a, attributes={}))
         dset = self.f['test_dataset']
-        decoded_dset = [[item.decode('utf-8') for item in sublist if isinstance(item, bytes)]
+        decoded_dset = [[item.decode('utf-8') if isinstance(item, bytes) else item for item in sublist]
                         for sublist in dset[:]]
         self.assertTrue(decoded_dset == a)
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/hdmf-dev/hdmf/issues/1137 and fixes https://github.com/hdmf-dev/hdmf/issues/1096. 

On build, multidimensional string lists/arrays were being converted into 1-D lists/arrays:

`[['aa', 'bb'], ['cc', 'dd']] -> ["['aa', 'bb']", "['cc', 'dd']"]`.

On write, the shape of a multidimensional string dataset was being defined incorrectly and so the dataset could not be written. The data shape definition was being caught by this conditional that I believe is intended to check for structured arrays / compound data types:

https://github.com/hdmf-dev/hdmf/blob/7426275cacc769a10ffca89836765df1355ba9db/src/hdmf/backends/hdf5/h5tools.py#L1472-L1473

 I updated the conditional and `get_data_shape` is now used to set the shape of the dataset for multidimensional string lists/arrays.



## How to test the behavior?

This came up in https://github.com/NeurodataWithoutBorders/pynwb/pull/1924. 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
