### PR TITLE
Modification to Fix conversion of Zarr string dataset to HDF5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Improved "already exists" error message when adding a container to a `MultiContainerInterface`. @rly [#1165](https://github.com/hdmf-dev/hdmf/pull/1165)
 
 ### Bug fixes
-- Fixed bug when converting string datasets from Zarr to HDF5. @oruebel [#1171](https://github.com/hdmf-dev/hdmf/pull/1171)
+- Fixed bug when converting string datasets from Zarr to HDF5. @oruebel @rly [#1171](https://github.com/hdmf-dev/hdmf/pull/1171)
 
 ## HDMF 3.14.3 (July 29, 2024)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -22,6 +22,13 @@ from ...spec import RefSpec, DtypeSpec, NamespaceCatalog
 from ...utils import docval, getargs, popargs, get_data_shape, get_docval, StrDataset
 from ..utils import NamespaceToBuilderHelper, WriteStatusTracker
 
+# try:
+#     from zarr import Array as ZarrArray
+#     import numcodecs
+#     ZARR_INSTALLED = True
+# except ImportError:
+#     ZARR_INSTALLED = False
+
 ROOT_NAME = 'root'
 SPEC_LOC_ATTR = '.specloc'
 H5_TEXT = special_dtype(vlen=str)
@@ -32,6 +39,10 @@ H5_REGREF = special_dtype(ref=RegionReference)
 RDCC_NBYTES = 32*2**20  # set raw data chunk cache size = 32 MiB
 
 H5PY_3 = h5py.__version__.startswith('3')
+
+
+# def _is_zarr_array(value):
+#     return ZARR_INSTALLED and isinstance(value, ZarrArray)
 
 
 class HDF5IO(HDMFIO):
@@ -924,10 +935,13 @@ class HDF5IO(HDMFIO):
         # binary
         # number
 
-        # Use text dtype for Zarr datasets of strings. Zarr stores variable length strings
-        # as objects, so we need to detect this special case here
-        if hasattr(data, 'attrs') and 'zarr_dtype' in data.attrs and data.attrs['zarr_dtype'] == 'str':
-            return cls.__dtypes['text']
+        # # Use text dtype for Zarr datasets of strings. Zarr stores variable length strings
+        # # as objects, so we need to detect this special case here
+        # if _is_zarr_array(data) and data.filters:
+        #     if numcodecs.VLenUTF8() in data.filters:
+        #         return cls.__dtypes['text']
+        #     elif numcodecs.VLenBytes() in data.filters:
+        #         return cls.__dtypes['ascii']
 
         dtype = cls.__resolve_dtype_helper__(dtype)
         if dtype is None:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -22,12 +22,6 @@ from ...spec import RefSpec, DtypeSpec, NamespaceCatalog
 from ...utils import docval, getargs, popargs, get_data_shape, get_docval, StrDataset
 from ..utils import NamespaceToBuilderHelper, WriteStatusTracker
 
-# try:
-#     from zarr import Array as ZarrArray
-#     import numcodecs
-#     ZARR_INSTALLED = True
-# except ImportError:
-#     ZARR_INSTALLED = False
 
 ROOT_NAME = 'root'
 SPEC_LOC_ATTR = '.specloc'
@@ -39,10 +33,6 @@ H5_REGREF = special_dtype(ref=RegionReference)
 RDCC_NBYTES = 32*2**20  # set raw data chunk cache size = 32 MiB
 
 H5PY_3 = h5py.__version__.startswith('3')
-
-
-# def _is_zarr_array(value):
-#     return ZARR_INSTALLED and isinstance(value, ZarrArray)
 
 
 class HDF5IO(HDMFIO):
@@ -934,14 +924,6 @@ class HDF5IO(HDMFIO):
         # TODO: These values exist, but I haven't solved them yet
         # binary
         # number
-
-        # # Use text dtype for Zarr datasets of strings. Zarr stores variable length strings
-        # # as objects, so we need to detect this special case here
-        # if _is_zarr_array(data) and data.filters:
-        #     if numcodecs.VLenUTF8() in data.filters:
-        #         return cls.__dtypes['text']
-        #     elif numcodecs.VLenBytes() in data.filters:
-        #         return cls.__dtypes['ascii']
 
         dtype = cls.__resolve_dtype_helper__(dtype)
         if dtype is None:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -20,8 +20,7 @@ from ...container import Container
 from ...data_utils import AbstractDataChunkIterator
 from ...spec import RefSpec, DtypeSpec, NamespaceCatalog
 from ...utils import docval, getargs, popargs, get_data_shape, get_docval, StrDataset
-from ..utils import NamespaceToBuilderHelper, WriteStatusTracker
-
+from ..utils import NamespaceToBuilderHelper, WriteStatusTracker, is_zarr_array
 
 ROOT_NAME = 'root'
 SPEC_LOC_ATTR = '.specloc'
@@ -924,6 +923,11 @@ class HDF5IO(HDMFIO):
         # TODO: These values exist, but I haven't solved them yet
         # binary
         # number
+
+        # Use text dtype for Zarr datasets of strings. Zarr stores variable length strings
+        # as objects, so we need to detect this special case here
+        if is_zarr_array(data) and 'zarr_dtype' in data.attrs and data.attrs['zarr_dtype'] == 'str':
+            return cls.__dtypes['text']
 
         dtype = cls.__resolve_dtype_helper__(dtype)
         if dtype is None:

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -19,8 +19,8 @@ from ...build import (Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildM
 from ...container import Container
 from ...data_utils import AbstractDataChunkIterator
 from ...spec import RefSpec, DtypeSpec, NamespaceCatalog
-from ...utils import docval, getargs, popargs, get_data_shape, get_docval, StrDataset
-from ..utils import NamespaceToBuilderHelper, WriteStatusTracker, is_zarr_array
+from ...utils import docval, getargs, popargs, get_data_shape, get_docval, is_zarr_array, StrDataset
+from ..utils import NamespaceToBuilderHelper, WriteStatusTracker
 
 ROOT_NAME = 'root'
 SPEC_LOC_ATTR = '.specloc'

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -18,17 +18,8 @@ from ..data_utils import DataIO, AbstractDataChunkIterator
 from ..query import ReferenceResolver
 from ..spec import Spec, AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, RefSpec
 from ..spec.spec import BaseStorageSpec
-from ..utils import docval, getargs, ExtenderMeta, get_docval, get_data_shape
+from ..utils import docval, getargs, ExtenderMeta, get_docval, get_data_shape, is_zarr_array, StrDataset
 
-try:
-    from zarr import Array as ZarrArray
-    ZARR_INSTALLED = True
-except ImportError:
-    ZARR_INSTALLED = False
-
-
-def _is_zarr_array(value):
-    return ZARR_INSTALLED and isinstance(value, ZarrArray)
 
 _const_arg = '__constructor_arg'
 
@@ -219,20 +210,31 @@ class ObjectMapper(metaclass=ExtenderMeta):
         # NOTE: Numpy < 2.0 has only fixed-length strings.
         # Numpy 2.0 introduces variable-length strings (dtype=np.dtypes.StringDType()).
         # HDMF does not yet do any special handling of numpy arrays with variable-length strings.
-        if isinstance(value, np.ndarray) or _is_zarr_array(value):
+        if is_zarr_array(value):
             if spec_dtype_type is _unicode:
-                if _is_zarr_array(value):
-                    # Zarr stores strings as objects, so we cannot convert to unicode dtype
+                # Zarr stores strings as objects, so we cannot convert to unicode dtype
+                ret = value
+                ret_dtype = "utf8"
+            elif spec_dtype_type is _ascii:
+                # Zarr stores strings as objects, so we cannot convert to ascii dtype
+                ret = value
+                ret_dtype = "ascii"
+            else:
+                dtype_func, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
+                if value.dtype == dtype_func:
+                    ret = value
+                else:
+                    ret = value.astype(dtype_func)
+                ret_dtype = ret.dtype.type
+        elif isinstance(value, np.ndarray):
+            if spec_dtype_type is _unicode:
+                if isinstance(value, StrDataset):
                     ret = value
                 else:
                     ret = value.astype('U')
                 ret_dtype = "utf8"
             elif spec_dtype_type is _ascii:
-                if _is_zarr_array(value):
-                    # Zarr stores strings as objects, so we cannot convert to unicode dtype
-                    ret = value
-                else:
-                    ret = value.astype('S')
+                ret = value.astype('S')
                 ret_dtype = "ascii"
             else:
                 dtype_func, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -16,11 +16,18 @@ __macros = {
 }
 
 try:
-    # optionally accept zarr.Array as array data to support conversion of data from Zarr to HDMF
-    import zarr
-    __macros['array_data'].append(zarr.Array)
+    from zarr import Array as ZarrArray
+    ZARR_INSTALLED = True
 except ImportError:
-    pass
+    ZARR_INSTALLED = False
+
+
+def is_zarr_array(value):
+    return ZARR_INSTALLED and isinstance(value, ZarrArray)
+
+if ZARR_INSTALLED:
+    # optionally accept zarr.Array as array data to support conversion of data from Zarr to HDMF
+    __macros['array_data'].append(ZarrArray)
 
 
 # code to signify how to handle positional arguments in docval

--- a/tests/unit/build_tests/test_convert_dtype.py
+++ b/tests/unit/build_tests/test_convert_dtype.py
@@ -7,13 +7,7 @@ from hdmf.build import ObjectMapper
 from hdmf.data_utils import DataChunkIterator
 from hdmf.spec import DatasetSpec, RefSpec, DtypeSpec
 from hdmf.testing import TestCase
-
-try:
-    import zarr
-    import numcodecs
-    SKIP_ZARR_TESTS = False
-except ImportError:
-    SKIP_ZARR_TESTS = True
+from hdmf.utils import ZARR_INSTALLED
 
 
 class TestConvertDtype(TestCase):
@@ -560,10 +554,13 @@ class TestConvertDtype(TestCase):
         self.assertIs(type(ret), bytes)
         self.assertEqual(ret_dtype, 'ascii')
 
-    @unittest.skipIf(SKIP_ZARR_TESTS, "Zarr is not installed")
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_zarr_array_spec_vlen_utf8(self):
         """Test that converting a zarr array with utf8 dtype for a variable length utf8 dtype spec
         returns the same object with a utf8 ret_dtype."""
+        import zarr
+        import numcodecs
+
         spec = DatasetSpec('an example dataset', 'text', name='data')
 
         value = zarr.array(['a', 'b'])  # fixed length unicode (dtype = <U1)
@@ -580,10 +577,13 @@ class TestConvertDtype(TestCase):
         self.assertIs(ret.dtype.type, np.object_)
         self.assertEqual(ret_dtype, 'utf8')
 
-    @unittest.skipIf(SKIP_ZARR_TESTS, "Zarr is not installed")
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_zarr_array_spec_vlen_ascii(self):
         """Test that converting a zarr array with fixed length utf8 dtype for a variable length ascii dtype spec
         returns the same object with a ascii ret_dtype."""
+        import zarr
+        import numcodecs
+
         spec = DatasetSpec('an example dataset', 'ascii', name='data')
 
         value = zarr.array(['a', 'b'])  # fixed length unicode (dtype = <U1)


### PR DESCRIPTION
Proposed changes to #1171.

It would be nice if `HDF5IO` and the `ObjectMapper` can accept any Zarr array just like it accepts any Numpy array, instead of accepting only Zarr arrays that have been written with hdmf-zarr.