### PR TITLE
Fix scalar dataset with compound dtype for export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 3.14.5 (Upcoming)
+
+### Bug fixes
+- Fixed export of scalar datasets with a compound data type. @stephprince [#1185](https://github.com/hdmf-dev/hdmf/pull/1185)
+
 ## HDMF 3.14.4 (August 22, 2024)
 
 ### Enhancements

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -700,6 +700,10 @@ class HDF5IO(HDMFIO):
                 kwargs['dtype'] = d.dtype
             elif h5obj.dtype.kind == 'V':  # scalar compound data type
                 kwargs['data'] = np.array(scalar, dtype=h5obj.dtype)
+                cpd_dt = h5obj.dtype
+                ref_cols = [check_dtype(ref=cpd_dt[i]) or check_dtype(vlen=cpd_dt[i]) for i in range(len(cpd_dt))]
+                d = BuilderH5TableDataset(h5obj, self, ref_cols)
+                kwargs['dtype'] = HDF5IO.__compound_dtype_to_list(h5obj.dtype, d.dtype)
             else:
                 kwargs["data"] = scalar
         else:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -147,7 +147,7 @@ def get_type(data, builder_dtype=None):
     # Case for h5py.Dataset and other I/O specific array types
     else:
         # Compound dtype
-        if builder_dtype and len(builder_dtype) > 1:
+        if builder_dtype and isinstance(builder_dtype, list):
             dtypes = []
             string_formats = []
             for i in range(len(builder_dtype)):
@@ -441,7 +441,7 @@ class DatasetValidator(BaseStorageValidator):
             except EmptyArrayError:
                 # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
                 pass
-        if builder.dtype is not None and len(builder.dtype) > 1 and len(np.shape(builder.data)) == 0:
+        if isinstance(builder.dtype, list) and len(np.shape(builder.data)) == 0:
             shape = ()  # scalar compound dataset
         elif isinstance(builder.dtype, list):
             shape = (len(builder.data), )  # only 1D datasets with compound types are supported


### PR DESCRIPTION
## Motivation

This is a follow up to https://github.com/hdmf-dev/hdmf/pull/1176.

The pynwb roundtrip export tests for `ElectrodeGroupIO` were failing for the scalar compound dataset because on export
`options[‘dtype’]` was a `<class 'numpy.dtype[void]'>` and not a list: 

https://github.com/hdmf-dev/hdmf/blob/1abb8ec6a28bc2419099e4cca975e006ee79bd23/src/hdmf/backends/hdf5/h5tools.py#L1195-L1196

Converting the dtype to a list like the non-scalar compound datatypes fixes this and also allows me to revert some changes I had made in the previous PR to the validator. 

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
