### PR TITLE
Fix DtypeError message for reference validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Enhancements
 - Added support for expandable datasets of references for untyped and compound data types. @stephprince [#1188](https://github.com/hdmf-dev/hdmf/pull/1188)
 
+### Bug fixes
+- Fixed inaccurate error message when validating reference data types. @stephprince [#1199](https://github.com/hdmf-dev/hdmf/pull/1199)
+
 ## HDMF 3.14.5 (October 6, 2024)
 
 ### Enhancements

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -436,7 +436,11 @@ class DatasetValidator(BaseStorageValidator):
             try:
                 dtype, string_format = get_type(data, builder.dtype)
                 if not check_type(self.spec.dtype, dtype, string_format):
-                    ret.append(DtypeError(self.get_spec_loc(self.spec), self.spec.dtype, dtype,
+                    if isinstance(self.spec.dtype, RefSpec):
+                        expected = f'{self.spec.dtype.reftype} reference'
+                    else:
+                        expected = self.spec.dtype
+                    ret.append(DtypeError(self.get_spec_loc(self.spec), expected, dtype,
                                           location=self.get_builder_loc(builder)))
             except EmptyArrayError:
                 # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -524,6 +524,39 @@ class TestDtypeValidation(TestCase):
         results = self.vmap.validate(bar_builder)
         self.assertEqual(len(results), 0)
 
+class TestReferenceValidation(ValidatorTestBase):
+    def getSpecs(self):
+        qux_spec = DatasetSpec(
+            doc='a simple scalar dataset',
+            data_type_def='Qux',
+            dtype='int',
+            shape=None
+        )
+        bar_spec = GroupSpec('A test group specification with a reference dataset',
+                         data_type_def='Bar',
+                         datasets=[DatasetSpec('an example dataset',
+                                               dtype=RefSpec('Qux', reftype='object'),
+                                               name='data',
+                                               shape=(None, ))],
+                         attributes=[AttributeSpec('attr1',
+                                                   'an example attribute',
+                                                   dtype=RefSpec('Qux', reftype='object'),
+                                                   shape=(None, ))])
+        return (qux_spec, bar_spec)
+
+    def test_invalid_reference(self):
+        # setup spec
+        """Test that validator does not allow another data type where a reference is specified."""
+        value = np.array([1.0, 2.0, 3.0])
+        bar_builder = GroupBuilder('my_bar',
+                                    attributes={'data_type': 'Bar', 'attr1': value},
+                                    datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        result_strings = set([str(s) for s in results])
+        expected_errors = {"Bar/attr1 (my_bar.attr1): incorrect type - expected 'object reference', got 'float64'",
+                           "Bar/data (my_bar/data): incorrect type - expected 'object reference', got 'float64'"}
+        self.assertEqual(result_strings, expected_errors)
+
 class Test1DArrayValidation(TestCase):
 
     def set_up_spec(self, dtype):

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -545,7 +545,6 @@ class TestReferenceValidation(ValidatorTestBase):
         return (qux_spec, bar_spec)
 
     def test_invalid_reference(self):
-        # setup spec
         """Test that validator does not allow another data type where a reference is specified."""
         value = np.array([1.0, 2.0, 3.0])
         bar_builder = GroupBuilder('my_bar',


### PR DESCRIPTION
## Motivation

Fix https://github.com/hdmf-dev/hdmf/issues/1055. When validating a reference, the RefSpec input to the DtypeError message initialization was causing an inaccurate error message.


## How to test the behavior?
See example file shared in the original matnwb issue.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
