### PR TITLE
Delete src/hdmf/build/map.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Deprecations
 - The following classes have been deprecated and removed: Array, AbstractSortedArray, SortedArray, LinSpace, Query, RegionSlicer, ListSlicer, H5RegionSlicer, DataRegion, RegionBuilder. The following methods have been deprecated and removed: fmt_docval_args, call_docval_func, get_container_cls, add_child, set_dataio (now refactored as set_data_io). We have also removed all early development for region references. @mavaylon1, @rly [#1998](https://github.com/hdmf-dev/hdmf/pull/1198), [#1212](https://github.com/hdmf-dev/hdmf/pull/1212)
+- Importing from hdmf.build.map is no longer supported. Import from hdmf.build instead. @rly [#1221](https://github.com/hdmf-dev/hdmf/pull/1221)
 - Python 3.8 has been deprecated. Python 3.9 is the new minimum with support for Python 3.13. @mavaylon1 [#1209](https://github.com/hdmf-dev/hdmf/pull/1209)
 
 ### Enhancements

--- a/src/hdmf/build/map.py
+++ b/src/hdmf/build/map.py
@@ -1,7 +1,0 @@
-# this prevents breaking of code that imports these classes directly from map.py
-from .manager import Proxy, BuildManager, TypeSource, TypeMap  # noqa: F401
-from .objectmapper import ObjectMapper  # noqa: F401
-
-import warnings
-warnings.warn('Classes in map.py should be imported from hdmf.build. Importing from hdmf.build.map will be removed '
-              'in HDMF 3.0.', DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
## Motivation

Removing this is part of the HDMF 4.0 deprecations. 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
