### PR TITLE
Fix numpy 2 deprecation warning in test

### DIFF
--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -1847,7 +1847,7 @@ class H5DataIOValid(TestCase):
             self.assertTrue(self.foo2.my_data.valid)  # test valid
             self.assertEqual(len(self.foo2.my_data), 5)  # test len
             self.assertEqual(self.foo2.my_data.shape, (5,))  # test getattr with shape
-            self.assertTrue(np.array_equal(np.array(self.foo2.my_data), [1, 2, 3, 4, 5]))  # test array conversion
+            np.testing.assert_array_equal(self.foo2.my_data, [1, 2, 3, 4, 5])  # test array conversion
 
             # test loop through iterable
             match = [1, 2, 3, 4, 5]


### PR DESCRIPTION
There is one deprecation warning when running the HDMF tests:

```
_______________________________________________________________________ H5DataIOValid.test_link ________________________________________________________________________

self = <tests.unit.test_io_hdf5_h5tools.H5DataIOValid testMethod=test_link>

    def test_link(self):
        """Test that wrapping of linked data within H5DataIO """
        with HDF5IO(self.paths[0], manager=get_foo_buildmanager(), mode='r') as io:
            read_foofile1 = io.read()
    
            self.foo2 = Foo('foo2', H5DataIO(data=read_foofile1.buckets['bucket1'].foos['foo1'].my_data),
                            "I am foo2", 17, 3.14)
            bucket2 = FooBucket('bucket2', [self.foo2])
            foofile2 = FooFile(buckets=[bucket2])
    
            self.paths.append(get_temp_filepath())
    
            with HDF5IO(self.paths[1], manager=get_foo_buildmanager(), mode='w') as io:
                io.write(foofile2)
    
            self.assertTrue(self.foo2.my_data.valid)  # test valid
            self.assertEqual(len(self.foo2.my_data), 5)  # test len
            self.assertEqual(self.foo2.my_data.shape, (5,))  # test getattr with shape
>           self.assertTrue(np.array_equal(np.array(self.foo2.my_data), [1, 2, 3, 4, 5]))  # test array conversion
E           DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
```

This PR fixes the issue.