### PR TITLE
Fix broken zarr intersphinx, limit zarr to < 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The following classes have been deprecated and removed: Array, AbstractSortedArray, SortedArray, LinSpace, Query, RegionSlicer, ListSlicer, H5RegionSlicer, DataRegion, RegionBuilder. The following methods have been deprecated and removed: fmt_docval_args, call_docval_func, get_container_cls, add_child, set_dataio (now refactored as set_data_io). We have also removed all early development for region references. @mavaylon1, @rly [#1998](https://github.com/hdmf-dev/hdmf/pull/1198), [#1212](https://github.com/hdmf-dev/hdmf/pull/1212)
 - Importing from hdmf.build.map is no longer supported. Import from hdmf.build instead. @rly [#1221](https://github.com/hdmf-dev/hdmf/pull/1221)
 - Python 3.8 has reached end of life. Drop support for Python 3.8 and add support for Python 3.13. @mavaylon1 [#1209](https://github.com/hdmf-dev/hdmf/pull/1209)
+- Support for Zarr is limited to versions < 3. @rly [#1229](https://github.com/hdmf-dev/hdmf/pull/1229)
 
 ### Bug fixes
 - Added checks to ensure that group and dataset spec names and default names do not contain slashes. @bendichter [#1219](https://github.com/hdmf-dev/hdmf/pull/1219)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "h5py": ("https://docs.h5py.org/en/latest/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "zarr": ("https://zarr.readthedocs.io/en/stable/", None),
+    "zarr": ("https://zarr.readthedocs.io/en/v2.18.4/", None), # TODO - update when hdmf-zarr supports Zarr 3.0
 }
 
 # these links cannot be checked in github actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,13 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tqdm = ["tqdm>=4.41.0"]
-zarr = ["zarr>=2.12.0"]
-termset = ["linkml-runtime>=1.5.5",
-           "schemasheets>=0.1.23",
-           "oaklib>=0.5.12",
-           "pyyaml>=6.0.1"]
+zarr = ["zarr>=2.12.0,<3"]
+termset = [
+    "linkml-runtime>=1.5.5",
+    "schemasheets>=0.1.23",
+    "oaklib>=0.5.12",
+    "pyyaml>=6.0.1",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/hdmf-dev/hdmf"

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,6 +1,6 @@
 # pinned dependencies that are optional. used to reproduce an entire development environment to use HDMF
 tqdm==4.66.4
-zarr==2.18.2
+zarr==2.18.4
 linkml-runtime==1.7.7
 schemasheets==0.2.1
 oaklib==0.6.10


### PR DESCRIPTION
## Motivation

Zarr intersphinx links are broken because of the recent update to Zarr v3. Fix the links and limit zarr version to < 3 until hdmf-zarr and hdmf support zarr v3.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
