### PR TITLE
Deprecate monitor.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## [Unreleased]
+
+### Changed
+- `hdmf.monitor` is unused and undocumented. It has been deprecated and will be removed in HDMF 5.0. @rly [#1245](https://github.com/hdmf-dev/hdmf/pull/1245)
+
 ## HDMF 4.0.0 (January 22, 2025)
 
 ### Breaking changes

--- a/src/hdmf/monitor.py
+++ b/src/hdmf/monitor.py
@@ -1,7 +1,15 @@
 from abc import ABCMeta, abstractmethod
+import warnings
 
 from .data_utils import AbstractDataChunkIterator, DataChunkIterator, DataChunk
 from .utils import docval, getargs
+
+warnings.warn(
+    "The hdmf.monitor module is deprecated and will be removed in HDMF 5.0. If you are using this module, "
+    "please copy this module to your codebase or raise an issue in the HDMF repository: "
+    "https://github.com/hdmf-dev/hdmf/issues"
+    DeprecationWarning,
+)
 
 
 class NotYetExhausted(Exception):

--- a/src/hdmf/monitor.py
+++ b/src/hdmf/monitor.py
@@ -7,7 +7,7 @@ from .utils import docval, getargs
 warnings.warn(
     "The hdmf.monitor module is deprecated and will be removed in HDMF 5.0. If you are using this module, "
     "please copy this module to your codebase or raise an issue in the HDMF repository: "
-    "https://github.com/hdmf-dev/hdmf/issues"
+    "https://github.com/hdmf-dev/hdmf/issues",
     DeprecationWarning,
 )
 

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        import hdmf.monitor  # noqa: F401


### PR DESCRIPTION
## Motivation

`monitor.py` is not used and was ported over from the beginning of HDMF. It looks to contain an abstract utility class for monitoring the progress of processing `DataChunkIterator` objects, and it contains an example of such a class. Neither is used or documented. To improve maintainability of HDMF, I propose we deprecate the module and remove it in HDMF 5.0.

Related: https://github.com/hdmf-dev/hdmf/issues/766

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
