### PR TITLE
Slight refactor to Vector Index get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # HDMF Changelog
 
-## [Unreleased]
+## HDMF 4.0.1
+
+### Enhancements
+- Optimized `get` within `VectorIndex` to be more efficient when retrieving a dataset of references. @mavaylon1 [#1248](https://github.com/hdmf-dev/hdmf/pull/1248)
 
 ### Changed
 - `hdmf.monitor` is unused and undocumented. It has been deprecated and will be removed in HDMF 5.0. @rly [#1245](https://github.com/hdmf-dev/hdmf/pull/1245)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -203,7 +203,10 @@ class VectorIndex(VectorData):
                     arg = np.where(arg)[0]
                 indices = arg
             ret = list()
-            if len(indices) > 0: # This is for test_to_hierarchical_dataframe_empty_tables
+            if len(indices) > 0:
+                # Note: len(indices) == 0 for test_to_hierarchical_dataframe_empty_tables.
+                # This is an edge case test for to_hierarchical_dataframe() on empty tables.
+                # When len(indices) == 0, ret is expected to be an empty list, defiend above.
                 try:
                     data = self.target.get(slice(None),  **kwargs)
                     slices = [self.__get_slice(i) for i in indices]
@@ -213,7 +216,8 @@ class VectorIndex(VectorData):
                         ret = [data[s] for s in slices]
                 except IndexError:
                     """
-                    Note: TODO: test_to_hierarchical_dataframe_indexed_dtr_on_last_level
+                    Note: TODO: test_to_hierarchical_dataframe_indexed_dtr_on_last_level.
+                    This is the old way to get the data and not an untested feature.
                     """
                     for i in indices:
                         ret.append(self.__getitem_helper(i, **kwargs))

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -206,7 +206,7 @@ class VectorIndex(VectorData):
             if len(indices) > 0:
                 # Note: len(indices) == 0 for test_to_hierarchical_dataframe_empty_tables.
                 # This is an edge case test for to_hierarchical_dataframe() on empty tables.
-                # When len(indices) == 0, ret is expected to be an empty list, defiend above.
+                # When len(indices) == 0, ret is expected to be an empty list, defined above.
                 try:
                     data = self.target.get(slice(None),  **kwargs)
                     slices = [self.__get_slice(i) for i in indices]

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -160,6 +160,11 @@ class VectorIndex(VectorData):
         """
         self.add_vector(arg, **kwargs)
 
+    def __get_slice(self, arg, **kwargs):
+        start = 0 if arg == 0 else self.data[arg - 1]
+        end = self.data[arg]
+        return slice(start, end)
+
     def __getitem_helper(self, arg, **kwargs):
         """
         Internal helper function used by __getitem__ to retrieve a data value from self.target
@@ -199,8 +204,20 @@ class VectorIndex(VectorData):
                     arg = np.where(arg)[0]
                 indices = arg
             ret = list()
-            for i in indices:
-                ret.append(self.__getitem_helper(i, **kwargs))
+            if len(indices) > 0: # This is for test_to_hierarchical_dataframe_empty_tables
+                try:
+                    data = self.target.get(slice(None),  **kwargs)
+                    slices = [self.__get_slice(i) for i in indices]
+                    if isinstance(data, pd.DataFrame):
+                        ret = [data.iloc[s] for s in slices]
+                    else:
+                        ret = [data[s] for s in slices]
+                except IndexError:
+                    """
+                    Note: TODO: test_to_hierarchical_dataframe_indexed_dtr_on_last_level
+                    """
+                    for i in indices:
+                        ret.append(self.__getitem_helper(i, **kwargs))
             return ret
 
 
@@ -1440,7 +1457,6 @@ class DynamicTableRegion(VectorData):
             return ret
         elif isinstance(arg, (list, slice, np.ndarray)):
             idx = arg
-
             # get the data at the specified indices
             if isinstance(self.data, (tuple, list)) and isinstance(idx, (list, np.ndarray)):
                 ret = [self.data[i] for i in idx]

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -160,7 +160,7 @@ class VectorIndex(VectorData):
         """
         self.add_vector(arg, **kwargs)
 
-    def __get_slice(self, arg, **kwargs):
+    def __get_slice(self, arg):
         start = 0 if arg == 0 else self.data[arg - 1]
         end = self.data[arg]
         return slice(start, end)
@@ -173,9 +173,8 @@ class VectorIndex(VectorData):
         :param kwargs: any additional arguments to *get* method of the self.target VectorData
         :return: Scalar or list of values retrieved
         """
-        start = 0 if arg == 0 else self.data[arg - 1]
-        end = self.data[arg]
-        return self.target.get(slice(start, end), **kwargs)
+        slices = self.__get_slice(arg)
+        return self.target.get(slices, **kwargs)
 
     def __getitem__(self, arg):
         """

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -209,11 +209,6 @@ class VectorIndex(VectorData):
                 # When len(indices) == 0, ret is expected to be an empty list, defined above.
                 try:
                     data = self.target.get(slice(None),  **kwargs)
-                    slices = [self.__get_slice(i) for i in indices]
-                    if isinstance(data, pd.DataFrame):
-                        ret = [data.iloc[s] for s in slices]
-                    else:
-                        ret = [data[s] for s in slices]
                 except IndexError:
                     """
                     Note: TODO: test_to_hierarchical_dataframe_indexed_dtr_on_last_level.
@@ -221,6 +216,14 @@ class VectorIndex(VectorData):
                     """
                     for i in indices:
                         ret.append(self.__getitem_helper(i, **kwargs))
+
+                    return ret
+
+                slices = [self.__get_slice(i) for i in indices]
+                if isinstance(data, pd.DataFrame):
+                    ret = [data.iloc[s] for s in slices]
+                else:
+                    ret = [data[s] for s in slices]
             return ret
 
 


### PR DESCRIPTION
## Motivation

https://github.com/hdmf-dev/hdmf-zarr/issues/237
Using to_dataframe in Zarr is slower than HDF5, most likely due to how we handle references. The change is gathering all the data at once to resolve, rather than multiple I/O reads iteratively.


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
