### PR TITLE
Restrict numcodecs dependency to <0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed `requirements-min.txt` in favor of the `min-reqs` optional dependency group in `pyproject.toml`. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)
 - Updated GitHub actions and ruff configuration. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)
 - `hdmf.monitor` is unused and undocumented. It has been deprecated and will be removed in HDMF 5.0. @rly [#1245](https://github.com/hdmf-dev/hdmf/pull/1245)
+- Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly
 
 ## HDMF 4.0.0 (January 22, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Removed `requirements-min.txt` in favor of the `min-reqs` optional dependency group in `pyproject.toml`. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)
 - Updated GitHub actions and ruff configuration. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)
 - `hdmf.monitor` is unused and undocumented. It has been deprecated and will be removed in HDMF 5.0. @rly [#1245](https://github.com/hdmf-dev/hdmf/pull/1245)
-- Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly
+- Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly [#1257](https://github.com/hdmf-dev/hdmf/pull/1257)
 
 ## HDMF 4.0.0 (January 22, 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = ["version"]
 tqdm = ["tqdm>=4.41.0"]
 zarr = [
     "zarr>=2.12.0,<3",
-    "numcodecs<0.16.0",
+    "numcodecs<0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
 ]
 sparse = ["scipy>=1.7"]
 termset = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # make sure to update min-reqs dependencies below when these lower bounds change
 tqdm = ["tqdm>=4.41.0"]
-zarr = ["zarr>=2.12.0,<3"]
+zarr = [
+    "zarr>=2.12.0,<3",
+    "numcodecs<0.16.0",
+]
 sparse = ["scipy>=1.7"]
 termset = [
     "linkml-runtime>=1.5.5",


### PR DESCRIPTION
## Motivation

Fix https://github.com/hdmf-dev/hdmf-zarr/issues/269 if users run `pip install hdmf[zarr]`

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
