### PR TITLE
Adjust append for appending to Array with multi-dim arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # HDMF Changelog
 
-## HDMF 4.0.1
+## HDMF 4.0.1 (Upcoming)
 
 ### Enhancements
 - Optimized `get` within `VectorIndex` to be more efficient when retrieving a dataset of references. @mavaylon1 [#1248](https://github.com/hdmf-dev/hdmf/pull/1248)
+- Added support in append for same dimensional args for numpy arrays. @mavaylon1 [#1261](https://github.com/hdmf-dev/hdmf/pull/1261)
 
 ### Changed
 - Removed `requirements-min.txt` in favor of the `min-reqs` optional dependency group in `pyproject.toml`. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -738,7 +738,7 @@ class DynamicTable(Container):
             if row_id in self.id:
                 raise ValueError("id %i already in the table" % row_id)
         self.id.append(row_id)
-        breakpoint()
+
         for colname, colnum in self.__colids.items():
             if colname not in data:
                 raise ValueError("column '%s' missing" % colname)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -738,16 +738,16 @@ class DynamicTable(Container):
             if row_id in self.id:
                 raise ValueError("id %i already in the table" % row_id)
         self.id.append(row_id)
-
+        breakpoint()
         for colname, colnum in self.__colids.items():
             if colname not in data:
                 raise ValueError("column '%s' missing" % colname)
-            c = self.__df_cols[colnum]
-            if isinstance(c, VectorIndex):
-                c.add_vector(data[colname])
+            col = self.__df_cols[colnum]
+            if isinstance(col, VectorIndex):
+                col.add_vector(data[colname])
             else:
-                c.add_row(data[colname])
-                if check_ragged and is_ragged(c.data):
+                col.add_row(data[colname])
+                if check_ragged and is_ragged(col.data):
                     warn(("Data has elements with different lengths and therefore cannot be coerced into an "
                           "N-dimensional array. Use the 'index' argument when creating a column to add rows "
                           "with different lengths."),

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -26,12 +26,13 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
+        breakpoint()
         if len(data.dtype)>0: # data is a structured array
             return np.append(data, arg)
         elif np.ndim(arg) < np.ndim(data): # arg is a scalar or row vector
-            result = np.append(data, np.expand_dims(arg, axis=0), axis=0)
+            return np.append(data, np.expand_dims(arg, axis=0), axis=0)
         else: # arg already has the same dimension as data
-            result = np.append(data, arg, axis=0)
+            return np.append(data, arg, axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -31,7 +31,7 @@ def append_data(data, arg):
         elif np.ndim(arg) < np.ndim(data):
             # arg is a scalar or row vector
             # This can be used for shape validation on append, but now the validated dim
-            # needs to match the expected logic here. 
+            # needs to match the expected logic here.
             return np.append(data, np.expand_dims(arg, axis=0), axis=0)
         else:
             # arg already has the same dimension as data

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -28,8 +28,10 @@ def append_data(data, arg):
     elif isinstance(data, np.ndarray):
         if len(data.dtype)>0: # data is a structured array
             return np.append(data, arg)
-        else: # arg is a scalar or row vector
-            return np.append(data,  np.expand_dims(arg, axis=0), axis=0)
+        elif np.ndim(arg) < np.ndim(data): # arg is a scalar or row vector
+            result = np.append(data, np.expand_dims(arg, axis=0), axis=0)
+        else: # arg already has the same dimension as data
+            result = np.append(data, arg, axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += 1

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -26,7 +26,6 @@ def append_data(data, arg):
         data.append(arg)
         return data
     elif isinstance(data, np.ndarray):
-        breakpoint()
         if len(data.dtype)>0: # data is a structured array
             return np.append(data, arg)
         elif np.ndim(arg) < np.ndim(data): # arg is a scalar or row vector

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -28,9 +28,15 @@ def append_data(data, arg):
     elif isinstance(data, np.ndarray):
         if len(data.dtype)>0: # data is a structured array
             return np.append(data, arg)
-        elif np.ndim(arg) < np.ndim(data): # arg is a scalar or row vector
+        elif np.ndim(arg) < np.ndim(data):
+            # arg is a scalar or row vector
+            # This can be used for shape validation on append, but now the validated dim
+            # needs to match the expected logic here. 
             return np.append(data, np.expand_dims(arg, axis=0), axis=0)
-        else: # arg already has the same dimension as data
+        else:
+            # arg already has the same dimension as data
+            # This allows users to use shape validation in the docval (for append) where the input
+            # dim matches the schema dim for the dataset.
             return np.append(data, arg, axis=0)
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)

--- a/tests/unit/utils_test/test_data_utils.py
+++ b/tests/unit/utils_test/test_data_utils.py
@@ -22,13 +22,18 @@ class TestAppendData(TestCase):
         with self.assertRaises(ValueError):
             append_data(data, 4)
 
+    def test_append_same_dim_array_arg(self):
+        data = np.array([[1, 2], [3, 4]])
+        arg = np.array([[5, 6]])
+        new = append_data(data, arg)
+        assert_array_equal(new, np.array([[1, 2],
+                                       [3, 4],
+                                       [5, 6]]))
 
 class TestZarrAppendData(TestCase):
-
     def setUp(self):
         if not ZARR_INSTALLED:
             self.skipTest("optional Zarr package is not installed")
-
 
     def test_append_data_zarr(self):
         zarr_array = zarr.array([1,2,3])

--- a/tests/unit/utils_test/test_data_utils.py
+++ b/tests/unit/utils_test/test_data_utils.py
@@ -22,6 +22,14 @@ class TestAppendData(TestCase):
         with self.assertRaises(ValueError):
             append_data(data, 4)
 
+    def test_append_1D_to_2D(self):
+        data = np.array([[1, 2], [3, 4]])
+        arg = np.array([5, 6])
+        new = append_data(data, arg)
+        assert_array_equal(new, np.array([[1, 2],
+                                       [3, 4],
+                                       [5, 6]]))
+
     def test_append_same_dim_array_arg(self):
         data = np.array([[1, 2], [3, 4]])
         arg = np.array([[5, 6]])


### PR DESCRIPTION
## Motivation

In pynwb there is a case for appending to an array that is neither a scalar or a row vector. The arg matches the dim of the data and need essentially a vstack.



## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
