### PR TITLE
Enhance dataset representation to handle LINDI

### DIFF
--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1555,7 +1555,7 @@ class HDF5IO(HDMFIO):
 
             if hasattr(dataset, "id") and hasattr(dataset.id, "get_storage_size"):
                 compressed_size = dataset.id.get_storage_size()
-                
+
                 # get info from hdf5 dataset
                 if hasattr(dataset, "nbytes"):
                     uncompressed_size = dataset.nbytes

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1538,23 +1538,40 @@ class HDF5IO(HDMFIO):
         """Generates an html representation for a dataset for the HDF5IO class"""
 
         array_info_dict = get_basic_array_info(dataset)
-        if isinstance(dataset, h5py.Dataset):
+        if isinstance(dataset, str):
+            dataset_type = "String data"
+            # For string data from LINDI, add basic info about the string
+            string_info_dict = {
+                "Size": len(dataset),
+                "Type": "string"
+            }
+            array_info_dict.update(string_info_dict)
+        elif isinstance(dataset, h5py.Dataset):
             dataset_type = "HDF5 dataset"
-            # get info from hdf5 dataset
-            compressed_size = dataset.id.get_storage_size()
-            if hasattr(dataset, "nbytes"):  # TODO: Remove this after h5py minimal version is larger than 3.0
-                uncompressed_size = dataset.nbytes
-            else:
-                uncompressed_size = dataset.size * dataset.dtype.itemsize
-            compression_ratio = uncompressed_size / compressed_size if compressed_size != 0 else "undefined"
 
-            hdf5_info_dict = {
-                            "Chunk shape": dataset.chunks,
-                            "Compression": dataset.compression,
-                            "Compression opts": dataset.compression_opts,
-                            "Compression ratio": compression_ratio,
-                            }
-            array_info_dict.update(hdf5_info_dict)
+            array_info_dict.update({
+                "Chunk shape": dataset.chunks,
+            })
+
+            if hasattr(dataset, "id") and hasattr(dataset.id, "get_storage_size"):
+                compressed_size = dataset.id.get_storage_size()
+                
+                # get info from hdf5 dataset
+                if hasattr(dataset, "nbytes"):
+                    uncompressed_size = dataset.nbytes
+                else:
+                    uncompressed_size = dataset.size * dataset.dtype.itemsize
+                compression_ratio = uncompressed_size / compressed_size if compressed_size != 0 else "undefined"
+                array_info_dict.update({"Compression ratio": compression_ratio})
+
+            try:
+                array_info_dict.update({
+                    "Compression": dataset.compression,
+                    "Compression opts": dataset.compression_opts,
+                })
+            except:
+                pass  # doesn't work for LINDI
+
 
         elif isinstance(dataset, np.ndarray):
             dataset_type = "NumPy array"

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -929,7 +929,7 @@ def generate_array_html_repr(array_info_dict, array, dataset_type=None):
     # Heuristic for displaying data
     array_is_small = array_size_bytes < 1024 * 0.1 # 10 % a kilobyte to display the array
     if array_is_small:
-        repr_html += "<br>" + str(np.asarray(array))
+        repr_html += "<br>" + str(array[()])
 
     return repr_html
 


### PR DESCRIPTION
in HDF5IO and update array display logic in generate_array_html_repr to handle LINDI datasets

## Motivation

fix #1266 

## How to test the behavior?
```python
import pynwb
import lindi

# Load https://api.dandiarchive.org/api/assets/2b9e441b-56bc-4be2-893e-0e02d22d239d/download/
f = lindi.LindiH5pyFile.from_lindi_file("https://lindi.neurosift.org/dandi/dandisets/000582/assets/2b9e441b-56bc-4be2-893e-0e02d22d239d/nwb.lindi.json")
nwb = pynwb.NWBHDF5IO(file=f, mode='r').read()

nwb
```

I am not sure how to test this behavior, as it depends on LINDI, which we would not want as a dependency