### PR TITLE
Cleaning up Extension Documentation and ClassGenerator Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 - Optimized `get` within `VectorIndex` to be more efficient when retrieving a dataset of references. @mavaylon1 [#1248](https://github.com/hdmf-dev/hdmf/pull/1248)
 - Improved error messages when optional requirements are not installed. @rly [#1263](https://github.com/hdmf-dev/hdmf/pull/1263)
+- Updated Extension documentation. Renamed `ClassGenerator` to `ClassGeneratorManager`. @mavaylon1[#1268](https://github.com/hdmf-dev/hdmf/pull/1268)
 
 ### Changed
 - Removed `requirements-min.txt` in favor of the `min-reqs` optional dependency group in `pyproject.toml`. @rly [#1246](https://github.com/hdmf-dev/hdmf/pull/1246)

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -251,13 +251,27 @@ that represents it.
 If you do not have an :py:class:`~hdmf.container.Container` subclass to associate with your extension specification,
 a dynamically created class is created by default.
 
-To use the dynamic class, you will need to retrieve the class object using the function :py:func:`~hdmf.common.get_class`.
+To use a dynamic class, retrieve the class object using :py:func:~hdmf.common.get_class, which takes the name of
+the data type and its associated namespace as arguments. This function creates the class's __init__ method,
+initializing instance variables for each attribute defined in the specification. It also automatically generates
+corresponding getters and setters for those attributes.
+
+You are never able to see or directly alter the class. You are able to provide a method to be executed after
+`__init__` as the parameter within :py:func:~hdmf.common.get_class.
+
 Once you have retrieved the class object, you can use it just like you would a statically defined class.
 
 .. code-block:: python
 
     from hdmf.common import get_class
-    MyExtensionContainer = get_class('my_namespace', 'MyExtension')
+
+    def post_init_method(self, **kwargs):
+            attr1 = kwargs['attr1']
+            if attr1<10:
+                msg = "attr1 should be >=10"
+                warn(msg)
+
+    MyExtensionContainer = get_class('MyExtensionContainer', 'my_namespace', post_init_method)
     my_ext_inst = MyExtensionContainer(...)
 
 

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -320,8 +320,7 @@ If your :py:class:`~hdmf.container.Container` extension requires custom mapping 
 
 Documenting Extensions
 ----------------------
-Please refer to the following on the documenting extensions:
-.. _Documenting an Extension Tutorial: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
+Please refer to the following on the documenting extensions: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
 
 Further Reading
 ---------------

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -251,9 +251,9 @@ If you do not have an :py:class:`~hdmf.container.Container` subclass to associat
 a dynamically created class is created by default.
 
 To use a dynamic class, retrieve the class object using :py:func:~hdmf.common.get_class, which takes the name of
-the data type and its associated namespace as arguments. This function creates the class's `__init__` method,
+the data type and its associated namespace as arguments. This function creates the class `__init__` method,
 initializing instance variables for each attribute defined in the specification. It also automatically generates
-corresponding getters and setters for those attributes.
+corresponding getters and setters for those attributes by populating the `__fields__` dict.
 
 You are never able to see or directly alter the class. You are able to provide a method to be executed after
 `__init__` as the parameter within :py:func:~hdmf.common.get_class.

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -159,8 +159,8 @@ Create a new namespace with extensions
 
     # create a builder for the namespace
     ns_builder = NamespaceBuilder(
-        doc="Extension for use in my laboratory", 
-        name="mylab", 
+        doc="Extension for use in my laboratory",
+        name="mylab",
         version="0.1.0",
         ...
     )

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -46,7 +46,7 @@ Specifying datasets is done with :py:class:`~hdmf.spec.spec.DatasetSpec`.
 Using datasets to specify tables
 ++++++++++++++++++++++++++++++++
 
-Tables can be specified using :py:class:`~hdmf.spec.spec.DtypeSpec`. To specify a row based table, provide a
+Row-based tables can be specified using :py:class:`~hdmf.spec.spec.DtypeSpec`. To specify a table, provide a
 list of :py:class:`~hdmf.spec.spec.DtypeSpec` objects to the *dtype* argument.
 
 .. code-block:: python

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -189,7 +189,6 @@ Create a new namespace with extensions
     export_spec(ns_builder, new_data_types, output_dir)
 
 
-.. tip::
 
     Using the API to generate extensions (rather than writing YAML sources directly) helps avoid errors in the specification
     (e.g., due to missing required keys or invalid values) and ensure compliance of the extension definition with the
@@ -308,7 +307,6 @@ If your :py:class:`~hdmf.container.Container` extension requires custom mapping 
 
     register_map(MyExtensionContainer, MyExtensionMapper)
 
-.. tip::
 
     ObjectMappers allow you to customize how objects in the spec are mapped to attributes of your Container in
     Python. This is useful, e.g., in cases where you want to customize the default mapping.
@@ -318,9 +316,9 @@ If your :py:class:`~hdmf.container.Container` extension requires custom mapping 
 
 .. _documenting-extensions:
 
-Documenting Extensions
+NWB
 ----------------------
-Please refer to the following on the documenting extensions: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
+To see how to extend the NWB format and how to best document extensions, refer to NWB Overview: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
 
 Further Reading
 ---------------

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -158,37 +158,36 @@ Create a new namespace with extensions
     from hdmf.spec import GroupSpec, NamespaceBuilder
 
     # create a builder for the namespace
-    ns_builder = NamespaceBuilder("Extension for use in my laboratory", "mylab", ...)
+    ns_builder = NamespaceBuilder(
+        doc="Extension for use in my laboratory", 
+        name="mylab", 
+        version="0.1.0",
+        ...
+    )
+
+    # include an existing namespace - this will include all specifications in that namespace
+    ns_builder.include_namespace('collab_ns')
 
     # create extensions
-    ext1 = GroupSpec('A custom SpikeEventSeries interface',
+    ext1 = GroupSpec(doc='A custom SpikeEventSeries interface',
                         attributes=[...]
                         datasets=[...],
                         groups=[...],
                         data_type_inc='SpikeEventSeries',
                         data_type_def='MyExtendedSpikeEventSeries')
 
-    ext2 = GroupSpec('A custom EventDetection interface',
+    ext2 = GroupSpec(doc='A custom EventDetection interface',
                         attributes=[...]
                         datasets=[...],
                         groups=[...],
                         data_type_inc='EventDetection',
                         data_type_def='MyExtendedEventDetection')
 
-
-    # add the extension
-    ext_source = 'mylab.specs.yaml'
-    ns_builder.add_spec(ext_source, ext1)
-    ns_builder.add_spec(ext_source, ext2)
-
-    # include an existing namespace - this will include all specifications in that namespace
-    ns_builder.include_namespace('collab_ns')
-
     output_dir = './spec' # path to folder to store generated YAML schemas.
     new_data_types = [ext1, ext2]
     export_spec(ns_builder, new_data_types, output_dir)
 
-
+.. tip::
 
     Using the API to generate extensions (rather than writing YAML sources directly) helps avoid errors in the specification
     (e.g., due to missing required keys or invalid values) and ensure compliance of the extension definition with the
@@ -251,12 +250,13 @@ If you do not have an :py:class:`~hdmf.container.Container` subclass to associat
 a dynamically created class is created by default.
 
 To use a dynamic class, retrieve the class object using :py:func:~hdmf.common.get_class, which takes the name of
-the data type and its associated namespace as arguments. This function creates the class `__init__` method,
+the data type and its associated namespace as arguments. This function creates the class ``__init__`` method,
 initializing instance variables for each attribute defined in the specification. It also automatically generates
-corresponding getters and setters for those attributes by populating the `__fields__` dict.
+corresponding getters and setters for those attributes by populating the ``__fields__`` dict.
 
-You are never able to see or directly alter the class. You are able to provide a method to be executed after
-`__init__` as the parameter within :py:func:~hdmf.common.get_class.
+The source code for the class is not written to disk and so you cannot easily inspect or modify the class code.
+However, you are able to provide a method to be executed after
+``__init__`` as an argument for :py:func:~hdmf.common.get_class.
 
 Once you have retrieved the class object, you can use it just like you would a statically defined class.
 
@@ -270,7 +270,7 @@ Once you have retrieved the class object, you can use it just like you would a s
                 msg = "attr1 should be >=10"
                 warn(msg)
 
-    MyExtensionContainer = get_class('MyExtensionContainer', 'my_namespace', post_init_method)
+    MyExtensionContainer = get_class('MyExtensionContainer', 'my_namespace', post_init_method=post_init_method)
     my_ext_inst = MyExtensionContainer(...)
 
 
@@ -317,7 +317,7 @@ If your :py:class:`~hdmf.container.Container` extension requires custom mapping 
 .. _documenting-extensions:
 
 NWB
-----------------------
+---
 To see how to extend the NWB format and how to best document extensions, refer to NWB Overview: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
 
 Further Reading

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -46,7 +46,7 @@ Specifying datasets is done with :py:class:`~hdmf.spec.spec.DatasetSpec`.
 Using datasets to specify tables
 ++++++++++++++++++++++++++++++++
 
-Tables can be specified using :py:class:`~hdmf.spec.spec.DtypeSpec`. To specify a table, provide a
+Tables can be specified using :py:class:`~hdmf.spec.spec.DtypeSpec`. To specify a row based table, provide a
 list of :py:class:`~hdmf.spec.spec.DtypeSpec` objects to the *dtype* argument.
 
 .. code-block:: python
@@ -184,9 +184,9 @@ Create a new namespace with extensions
     # include an existing namespace - this will include all specifications in that namespace
     ns_builder.include_namespace('collab_ns')
 
-    # save the namespace and extensions
-    ns_path = 'mylab.namespace.yaml'
-    ns_builder.export(ns_path)
+    output_dir = './spec' # path to folder to store generated YAML schemas.
+    new_data_types = [ext1, ext2]
+    export_spec(ns_builder, new_data_types, output_dir)
 
 
 .. tip::
@@ -252,7 +252,7 @@ If you do not have an :py:class:`~hdmf.container.Container` subclass to associat
 a dynamically created class is created by default.
 
 To use a dynamic class, retrieve the class object using :py:func:~hdmf.common.get_class, which takes the name of
-the data type and its associated namespace as arguments. This function creates the class's __init__ method,
+the data type and its associated namespace as arguments. This function creates the class's `__init__` method,
 initializing instance variables for each attribute defined in the specification. It also automatically generates
 corresponding getters and setters for those attributes.
 
@@ -320,8 +320,8 @@ If your :py:class:`~hdmf.container.Container` extension requires custom mapping 
 
 Documenting Extensions
 ----------------------
-
-Coming soon!
+Please refer to the following on the documenting extensions:
+.. _Documenting an Extension Tutorial: https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/6_documenting_extension.html
 
 Further Reading
 ---------------

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -70,8 +70,9 @@ class ClassGeneratorManager:
                 for class_generator in self.__custom_generators:  # pragma: no branch
                     # each generator can update classdict and docval_args
                     if class_generator.apply_generator_to_field(field_spec, bases, type_map):
-                        # process_field_spec extracts field metadata (name, type, doc, shape, default, constraints) from the schema spec and adds it to classdict
-                        # under __fields__ for later use in generating dynamic properties.
+                        # process_field_spec extracts field metadata (name, type, doc, shape, default, constraints)
+                        # from the schema spec and adds it to classdict under __fields__ for later use in
+                        # generating dynamic properties.
                         # Also creates a corresponding docval argument for the class constructor.
                         class_generator.process_field_spec(classdict, docval_args, parent_cls, attr_name,
                                                            not_inherited_fields, type_map, spec)

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -10,7 +10,7 @@ from ..spec.spec import BaseStorageSpec, ZERO_OR_MANY, ONE_OR_MANY
 from ..utils import docval, getargs, ExtenderMeta, get_docval, popargs, AllowPositional
 
 
-class ClassGenerator:
+class ClassGeneratorManager:
 
     def __init__(self):
         self.__custom_generators = []
@@ -21,7 +21,7 @@ class ClassGenerator:
 
     @docval({'name': 'generator', 'type': type, 'doc': 'the CustomClassGenerator class to register'})
     def register_generator(self, **kwargs):
-        """Add a custom class generator to this ClassGenerator.
+        """Add a custom class generator to this ClassGeneratorManager.
 
         Generators added later are run first. Duplicates are moved to the top of the list.
         """

--- a/src/hdmf/build/classgenerator.py
+++ b/src/hdmf/build/classgenerator.py
@@ -33,9 +33,9 @@ class ClassGeneratorManager:
         self.__custom_generators.insert(0, generator)
 
     @docval({'name': 'data_type', 'type': str, 'doc': 'the data type to create a AbstractContainer class for'},
-            {'name': 'spec', 'type': BaseStorageSpec, 'doc': ''},
-            {'name': 'parent_cls', 'type': type, 'doc': ''},
-            {'name': 'attr_names', 'type': dict, 'doc': ''},
+            {'name': 'spec', 'type': BaseStorageSpec, 'doc': 'The spec for the class to be generated.'},
+            {'name': 'parent_cls', 'type': type, 'doc': 'Parent class used for docval ancestor args.'},
+            {'name': 'attr_names', 'type': dict, 'doc': 'The names of the attributes from the spec.'},
             {'name': 'post_init_method', 'type': Callable, 'default': None,
              'doc': 'The function used as a post_init method to validate the class generation.'},
             {'name': 'type_map', 'type': 'hdmf.build.manager.TypeMap', 'doc': ''},
@@ -52,6 +52,9 @@ class ClassGeneratorManager:
 
         not_inherited_fields = dict()
         for k, field_spec in attr_names.items():
+            """
+            Collect new fields that are actually part of this spec, not its ancestors.
+            """
             if k == 'help':  # pragma: no cover
                 # (legacy) do not add field named 'help' to any part of class object
                 continue
@@ -67,6 +70,9 @@ class ClassGeneratorManager:
                 for class_generator in self.__custom_generators:  # pragma: no branch
                     # each generator can update classdict and docval_args
                     if class_generator.apply_generator_to_field(field_spec, bases, type_map):
+                        # process_field_spec extracts field metadata (name, type, doc, shape, default, constraints) from the schema spec and adds it to classdict
+                        # under __fields__ for later use in generating dynamic properties.
+                        # Also creates a corresponding docval argument for the class constructor.
                         class_generator.process_field_spec(classdict, docval_args, parent_cls, attr_name,
                                                            not_inherited_fields, type_map, spec)
                         break  # each field_spec should be processed by only one generator

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -416,7 +416,7 @@ class TypeMap:
         self.__container_types = OrderedDict()
         self.__data_types = dict()
         self.__default_mapper_cls = mapper_cls
-        self.__class_generator = ClassGeneratorManager()
+        self.__class_generator_manager = ClassGeneratorManager()
         self.type_config = type_config
 
         self.register_generator(CustomClassGenerator)
@@ -461,7 +461,7 @@ class TypeMap:
                 self.register_container_type(namespace, data_type, container_cls)
         for container_cls in type_map.__mapper_cls:
             self.register_map(container_cls, type_map.__mapper_cls[container_cls])
-        for custom_generators in reversed(type_map.__class_generator.custom_generators):
+        for custom_generators in reversed(type_map.__class_generator_manager.custom_generators):
             # iterate in reverse order because generators are stored internally as a stack
             self.register_generator(custom_generators)
 
@@ -469,7 +469,7 @@ class TypeMap:
     def register_generator(self, **kwargs):
         """Add a custom class generator."""
         generator = getargs('generator', kwargs)
-        self.__class_generator.register_generator(generator)
+        self.__class_generator_manager.register_generator(generator)
 
     @docval(*get_docval(NamespaceCatalog.load_namespaces),
             returns="the namespaces loaded from the given file", rtype=dict)
@@ -525,7 +525,7 @@ class TypeMap:
             self.__check_dependent_types(spec, namespace)
             parent_cls = self.__get_parent_cls(namespace, data_type, spec)
             attr_names = self.__default_mapper_cls.get_attr_names(spec)
-            cls = self.__class_generator.generate_class(data_type=data_type,
+            cls = self.__class_generator_manager.generate_class(data_type=data_type,
                                                         spec=spec,
                                                         parent_cls=parent_cls,
                                                         attr_names=attr_names,

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -4,7 +4,7 @@ from copy import copy
 from collections.abc import Callable
 
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, BaseBuilder
-from .classgenerator import ClassGenerator, CustomClassGenerator, MCIClassGenerator
+from .classgenerator import ClassGeneratorManager, CustomClassGenerator, MCIClassGenerator
 from ..container import AbstractContainer, Container, Data
 from ..term_set import TypeConfigurator
 from ..spec import DatasetSpec, GroupSpec, NamespaceCatalog, RefSpec
@@ -416,7 +416,7 @@ class TypeMap:
         self.__container_types = OrderedDict()
         self.__data_types = dict()
         self.__default_mapper_cls = mapper_cls
-        self.__class_generator = ClassGenerator()
+        self.__class_generator = ClassGeneratorManager()
         self.type_config = type_config
 
         self.register_generator(CustomClassGenerator)

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -149,16 +149,16 @@ def available_namespaces():
         is_method=False)
 def get_class(**kwargs):
     """Get the class object of the Container subclass corresponding to a given neurdata_type.
+    
     For developers:
-    Get class can eventually lead to the ClassGeneratorManager.
-
-    get_class -> get_dt_container_cls
-    -- get_dt_container_cls will get the container class from data type specification. If it is None,
+    get_class can eventually lead to the ClassGeneratorManager.
+    
+    1. get_class calls get_dt_container_cls.
+    2. get_dt_container_cls will get the container class from data type specification. If it is None,
        then one will be generated.
-    Generation:
-    -- spec is pulled from the catalog
-    -- parent clas and attr_names are pulled from the spec
-    -- generate_class is called from the ClassGeneratorManager
+    3. if one is generated, then the spec is pulled from the catalog
+    4. the parent class and attr_names are pulled from the spec
+    5. generate_class is called from the ClassGeneratorManager
 
     Remember that the generation of a class means the __init__ is being created for you. You don't ever see it.
     The generation also builds the docval for the __init__ and prepares the __fields__ dict for creating

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -149,6 +149,20 @@ def available_namespaces():
         is_method=False)
 def get_class(**kwargs):
     """Get the class object of the Container subclass corresponding to a given neurdata_type.
+    For developers:
+    Get class can eventually lead to the ClassGeneratorManager.
+
+    get_class -> get_dt_container_cls
+    -- get_dt_container_cls will get the container class from data type specification. If it is None,
+       then one will be generated.
+    Generation:
+    -- spec is pulled from the catalog
+    -- parent clas and attr_names are pulled from the spec
+    -- generate_class is called from the ClassGeneratorManager
+
+    Remember that the generation of a class means the __init__ is being created for you. You don't ever see it.
+    The generation also builds the docval for the __init__ and prepares the __fields__ dict for creating
+    setters, which are handled in AbstractContainer.
     """
     data_type, namespace, post_init_method = getargs('data_type', 'namespace', 'post_init_method', kwargs)
     return __TYPE_MAP.get_dt_container_cls(data_type, namespace, post_init_method)

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -149,10 +149,10 @@ def available_namespaces():
         is_method=False)
 def get_class(**kwargs):
     """Get the class object of the Container subclass corresponding to a given neurdata_type.
-    
+
     For developers:
     get_class can eventually lead to the ClassGeneratorManager.
-    
+
     1. get_class calls get_dt_container_cls.
     2. get_dt_container_cls will get the container class from data type specification. If it is None,
        then one will be generated.

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -5,7 +5,7 @@ import tempfile
 from warnings import warn
 
 from hdmf.build import TypeMap, CustomClassGenerator
-from hdmf.build.classgenerator import ClassGenerator, MCIClassGenerator
+from hdmf.build.classgenerator import ClassGeneratorManager, MCIClassGenerator
 from hdmf.container import Container, Data, MultiContainerInterface, AbstractContainer
 from hdmf.spec import (
     GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, LinkSpec, RefSpec
@@ -17,10 +17,10 @@ from .test_io_map import Bar
 from tests.unit.helpers.utils import CORE_NAMESPACE, create_test_type_map, create_load_namespace_yaml
 
 
-class TestClassGenerator(TestCase):
+class TestClassGeneratorManager(TestCase):
 
     def test_register_generator(self):
-        """Test TypeMap.register_generator and ClassGenerator.register_generator."""
+        """Test TypeMap.register_generator and ClassGeneratorManager.register_generator."""
 
         class MyClassGenerator(CustomClassGenerator):
 
@@ -77,8 +77,8 @@ class TestClassGenerator(TestCase):
             type_map.register_generator(NotACustomClassGenerator)
 
     def test_no_generators(self):
-        """Test that a ClassGenerator without registered generators does nothing."""
-        cg = ClassGenerator()
+        """Test that a ClassGeneratorManager without registered generators does nothing."""
+        cg = ClassGeneratorManager()
         spec = GroupSpec(doc='A test group spec with a data type', data_type_def='Baz')
         cls = cg.generate_class(data_type='Baz', spec=spec, parent_cls=Container, attr_names={}, type_map=TypeMap())
         self.assertEqual(cls.__mro__, (cls, Container, AbstractContainer, object))
@@ -707,7 +707,7 @@ class TestGetClassSeparateNamespace(TestCase):
         self.assertTrue(issubclass(cls, Bar))
 
     def _build_separate_namespaces(self):
-        # create an empty extension to test ClassGenerator._get_container_type resolution
+        # create an empty extension to test ClassGeneratorManager._get_container_type resolution
         # the Bar class has not been mapped yet to the bar spec
         qux_spec = DatasetSpec(
             doc='A test extension',


### PR DESCRIPTION
Clean up and synchronize documentation regarding extensions and class generation.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
