### PR TITLE
Pydantic Explore

### DIFF
--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -1,5 +1,6 @@
 import copy
 from collections import OrderedDict
+from pydantic import validate_call
 
 from .spec import BaseStorageSpec, GroupSpec
 from ..utils import docval, getargs

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -421,10 +421,20 @@ class NamespaceCatalog:
         """Replace instances of data_type_def/inc in spec_dict with new values from spec_cls."""
         # this is necessary because the def_key and inc_key may be different in each namespace
         # NOTE: this does not handle more than one custom set of keys
+        # breakpoint()
         if parent_cls.def_key() in spec_dict:
             spec_dict[spec_cls.def_key()] = spec_dict.pop(parent_cls.def_key())
         if parent_cls.inc_key() in spec_dict:
             spec_dict[spec_cls.inc_key()] = spec_dict.pop(parent_cls.inc_key())
+        # parent_def_key = parent_cls.__private_attributes__["_def_key"].get_default()
+        # if parent_def_key in spec_dict:
+        #     spec_def_key = spec_cls.__private_attributes__["_def_key"].get_default()
+        #     spec_dict[spec_def_key] = spec_dict.pop(parent_def_key)
+        #
+        # parent_inc_key = parent_cls.__private_attributes__["_inc_key"].get_default()
+        # if parent_inc_key in spec_dict:
+        #     spec_inc_key = spec_cls.__private_attributes__["_inc_key"].get_default()
+        #     spec_dict[spec_inc_key] = spec_dict.pop(parent_inc_key)
 
     def __resolve_includes(self, spec_cls, spec_dict, catalog):
         """Replace data type inc strings with the spec definition so the new spec is built with included fields.

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -525,7 +525,7 @@ class BaseStorageSpec(Spec):
     def data_type_inc(self):
         ''' The data type this specification inherits '''
         return self.get(self.inc_key())
-        
+
 
     @property
     def data_type_def(self):

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -2,6 +2,8 @@ import re
 from abc import ABCMeta
 from collections import OrderedDict
 from warnings import warn
+from pydantic import validate_call, BaseModel
+from typing import Optional, Self
 
 from ..utils import docval, getargs, popargs, get_docval
 
@@ -101,45 +103,13 @@ class ConstructableDict(dict, metaclass=ABCMeta):
         return cls(**kwargs)
 
 
-class Spec(ConstructableDict):
+class Spec(BaseModel):
     ''' A base specification class
     '''
-
-    @docval({'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},
-            {'name': 'name', 'type': str, 'doc': 'The name of this attribute', 'default': None},
-            {'name': 'required', 'type': bool, 'doc': 'whether or not this attribute is required', 'default': True},
-            {'name': 'parent', 'type': 'hdmf.spec.spec.Spec', 'doc': 'the parent of this spec', 'default': None})
-    def __init__(self, **kwargs):
-        name, doc, required, parent = getargs('name', 'doc', 'required', 'parent', kwargs)
-        super().__init__()
-        self['doc'] = doc
-        if name is not None:
-            self['name'] = name
-        if not required:
-            self['required'] = required
-        self._parent = parent
-
-    @property
-    def doc(self):
-        ''' Documentation on what this Spec is specifying '''
-        return self.get('doc', None)
-
-    @property
-    def name(self):
-        ''' The name of the object being specified '''
-        return self.get('name', None)
-
-    @property
-    def parent(self):
-        ''' The parent specification of this specification '''
-        return self._parent
-
-    @parent.setter
-    def parent(self, spec):
-        ''' Set the parent of this specification '''
-        if self._parent is not None:
-            raise AttributeError('Cannot re-assign parent.')
-        self._parent = spec
+    doc: str
+    name: Optional[str] = None
+    required: bool = True
+    parent: Optional[Self] = None
 
     @classmethod
     def build_const_args(cls, spec_dict):
@@ -167,6 +137,69 @@ class Spec(ConstructableDict):
 
 #    def __eq__(self, other):
 #        return id(self) == id(other)
+# class Spec(ConstructableDict):
+#     ''' A base specification class
+#     '''
+#
+#     @docval({'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},
+#             {'name': 'name', 'type': str, 'doc': 'The name of this attribute', 'default': None},
+#             {'name': 'required', 'type': bool, 'doc': 'whether or not this attribute is required', 'default': True},
+#             {'name': 'parent', 'type': 'hdmf.spec.spec.Spec', 'doc': 'the parent of this spec', 'default': None})
+#     def __init__(self, **kwargs):
+#         name, doc, required, parent = getargs('name', 'doc', 'required', 'parent', kwargs)
+#         super().__init__()
+#         self['doc'] = doc
+#         if name is not None:
+#             self['name'] = name
+#         if not required:
+#             self['required'] = required
+#         self._parent = parent
+#
+#     @property
+#     def doc(self):
+#         ''' Documentation on what this Spec is specifying '''
+#         return self.get('doc', None)
+#
+#     @property
+#     def name(self):
+#         ''' The name of the object being specified '''
+#         return self.get('name', None)
+#
+#     @property
+#     def parent(self):
+#         ''' The parent specification of this specification '''
+#         return self._parent
+#
+#     @parent.setter
+#     def parent(self, spec):
+#         ''' Set the parent of this specification '''
+#         if self._parent is not None:
+#             raise AttributeError('Cannot re-assign parent.')
+#         self._parent = spec
+#
+#     @classmethod
+#     def build_const_args(cls, spec_dict):
+#         ''' Build constructor arguments for this Spec class from a dictionary '''
+#         ret = super().build_const_args(spec_dict)
+#         return ret
+#
+#     def __hash__(self):
+#         return id(self)
+#
+#     @property
+#     def path(self):
+#         stack = list()
+#         tmp = self
+#         while tmp is not None:
+#             name = tmp.name
+#             if name is None:
+#                 name = tmp.data_type_def
+#                 if name is None:
+#                     name = tmp.data_type_inc
+#             stack.append(name)
+#             tmp = tmp.parent
+#         return "/".join(reversed(stack))
+
 
 
 _target_type_key = 'target_type'
@@ -301,10 +334,10 @@ _attrbl_args = [
 class BaseStorageSpec(Spec):
     ''' A specification for any object that can hold attributes. '''
 
-    __inc_key = 'data_type_inc'
-    __def_key = 'data_type_def'
-    __type_key = 'data_type'
-    __id_key = 'object_id'
+    inc_key = 'data_type_inc'
+    def_key = 'data_type_def'
+    type_key = 'data_type'
+    id_key = 'object_id'
 
     @docval(*_attrbl_args)
     def __init__(self, **kwargs):
@@ -460,44 +493,39 @@ class BaseStorageSpec(Spec):
         return self.get('linkable', True)
 
     @classmethod
-    def id_key(cls):
-        ''' Get the key used to store data ID on an instance
-
-        Override this method to use a different name for 'object_id'
+    def def_key(cls):
         '''
-        return cls.__id_key
-
-    @classmethod
-    def type_key(cls):
-        ''' Get the key used to store data type on an instance
-
-        Override this method to use a different name for 'data_type'. HDMF supports combining schema
-        that uses 'data_type' and at most one different name for 'data_type'.
+        Get the key used to define a data_type definition.
         '''
-        return cls.__type_key
+        # Directly access the class attribute to avoid method conflict
+        return cls.__dict__.get("def_key", "data_type_def")
 
     @classmethod
     def inc_key(cls):
-        ''' Get the key used to define a data_type include.
-
-        Override this method to use a different keyword for 'data_type_inc'. HDMF supports combining schema
-        that uses 'data_type_inc' and at most one different name for 'data_type_inc'.
         '''
-        return cls.__inc_key
+        Get the key used to define a data_type include.
+        '''
+        return cls.__dict__.get("inc_key", "data_type_inc")
 
     @classmethod
-    def def_key(cls):
-        ''' Get the key used to define a data_type definition.
-
-        Override this method to use a different keyword for 'data_type_def' HDMF supports combining schema
-        that uses 'data_type_def' and at most one different name for 'data_type_def'.
+    def type_key(cls):
         '''
-        return cls.__def_key
+        Get the key used to store data type on an instance.
+        '''
+        return cls.__dict__.get("type_key", "data_type")
+
+    @classmethod
+    def id_key(cls):
+        '''
+        Get the key used to store data ID on an instance.
+        '''
+        return cls.__dict__.get("id_key", "object_id")
 
     @property
     def data_type_inc(self):
         ''' The data type this specification inherits '''
         return self.get(self.inc_key())
+        
 
     @property
     def data_type_def(self):


### PR DESCRIPTION
This marks the initial investigation of pydantic integration as a full replacement to docval.

1. **Using existing Pydantic Tools**
- The idea is to convert classes to being a pydantic `model`. This will validate the arguments used to instantiate the class.
- Methods within the classes that have docval will replace docval with the pydantic `@validate_call` decorator. This will give type validation and run custom validators. The latter is needed to ensure the functionality of docval is covered completely. 

2. **Qwirks**
- In this PR, you will find the initial conversion of a class to the pydantic model. Pydantic takes private class variables and hides them away from the public schema. This changes the way we are able to access these variables. We currently have methods to "get" them, but the issue is the value returned is not the value of the variable, but an instance of `ModelPrivateAttr`. This is wrapped around the variable, making it difficult to fully access the variable. 

3. **Needed Features**
-  Pydantic's native support for NumPy arrays is limited, especially regarding validation of array shape and data type. The numpydantic library addresses this limitation by providing robust tools for specifying and validating NumPy arrays within Pydantic models. https://github.com/p2p-ld/numpydantic 
- There is a use case of enum validation in pynwb that appears once. This can be done in pydantic, but it might be easier to just do something local in that use case.