### PR TITLE
Make YamlSpecWriter.sort_keys a static method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `hdmf.monitor` is unused and undocumented. It has been deprecated and will be removed in HDMF 5.0. @rly [#1245](https://github.com/hdmf-dev/hdmf/pull/1245)
 - Restricted numcodecs dependency to <0.16 due to incompatibility with the latest zarr<3 version. @rly [#1257](https://github.com/hdmf-dev/hdmf/pull/1257)
 - Increased minimum requirement for optional schemasheets dependency to 0.4.0rc1 due to incompatibility with linkml-runtime. @rly [#1263](https://github.com/hdmf-dev/hdmf/pull/1263)
+- Refactored `YamlSpecWriter.sort_keys` to be a static method so that it can be cleanly used elsewhere. @rly [#1274](https://github.com/hdmf-dev/hdmf/pull/1274)
 
 ### Fixed
 - Fixed `get_data_shape` returning the wrong shape for lists of Data objects. @rly [#1270](https://github.com/hdmf-dev/hdmf/pull/1270)

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -92,12 +92,12 @@ class YAMLSpecWriter(SpecWriter):
                 keys.remove('name')
                 keys.insert(0, 'name')
             return yaml.comments.CommentedMap(
-                yaml.compat.ordereddict([(k, sort_keys(obj[k])) for k in keys])
+                yaml.compat.ordereddict([(k, YAMLSpecWriter.sort_keys(obj[k])) for k in keys])
             )
         elif isinstance(obj, list):
-            return [sort_keys(v) for v in obj]
+            return [YAMLSpecWriter.sort_keys(v) for v in obj]
         elif isinstance(obj, tuple):
-            return (sort_keys(v) for v in obj)
+            return (YAMLSpecWriter.sort_keys(v) for v in obj)
         else:
             return obj
 

--- a/src/hdmf/spec/write.py
+++ b/src/hdmf/spec/write.py
@@ -70,7 +70,8 @@ class YAMLSpecWriter(SpecWriter):
             data = yaml_obj.load(fd_read)
         self.write_spec(data, path)
 
-    def sort_keys(self, obj):
+    @staticmethod
+    def sort_keys(obj):
         # Represent None as null
         def my_represent_none(self, data):
             return self.represent_scalar(u'tag:yaml.org,2002:null', u'null')
@@ -91,12 +92,12 @@ class YAMLSpecWriter(SpecWriter):
                 keys.remove('name')
                 keys.insert(0, 'name')
             return yaml.comments.CommentedMap(
-                yaml.compat.ordereddict([(k, self.sort_keys(obj[k])) for k in keys])
+                yaml.compat.ordereddict([(k, sort_keys(obj[k])) for k in keys])
             )
         elif isinstance(obj, list):
-            return [self.sort_keys(v) for v in obj]
+            return [sort_keys(v) for v in obj]
         elif isinstance(obj, tuple):
-            return (self.sort_keys(v) for v in obj)
+            return (sort_keys(v) for v in obj)
         else:
             return obj
 

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -340,8 +340,6 @@ groups:
 
     def test_sort_keys(self):
         """Test that sort_keys correctly orders dictionary keys according to the predefined order."""
-        writer = YAMLSpecWriter()
-
         # Test basic ordering with predefined keys
         input_dict = {
             'doc': 'documentation',
@@ -351,7 +349,7 @@ groups:
             'datasets': [2],
             'groups': [3]
         }
-        result = writer.sort_keys(input_dict)
+        result = YAMLSpecWriter.sort_keys(input_dict)
 
         # Check that the keys are in the correct order
         expected_order = ['name', 'dtype', 'doc', 'attributes', 'datasets', 'groups']
@@ -364,7 +362,7 @@ groups:
             'neurodata_type_def': 'MyType',
             'attributes': [1]
         }
-        result = writer.sort_keys(input_dict)
+        result = YAMLSpecWriter.sort_keys(input_dict)
         self.assertEqual(list(result.keys())[0], 'neurodata_type_def')
 
         # Test nested dictionary ordering
@@ -377,7 +375,7 @@ groups:
                 'attributes': [2]
             }
         }
-        result = writer.sort_keys(input_dict)
+        result = YAMLSpecWriter.sort_keys(input_dict)
         self.assertEqual(list(result['nested'].keys()), ['name', 'dtype', 'attributes', 'groups'])
 
         # Test list handling
@@ -387,7 +385,7 @@ groups:
                 {'doc': 'attr2', 'name': 'attr2_name', 'dtype': 'float'}
             ]
         }
-        result = writer.sort_keys(input_dict)
+        result = YAMLSpecWriter.sort_keys(input_dict)
         for attr in result['attributes']:
             self.assertEqual(list(attr.keys()), ['name', 'dtype', 'doc'])
 
@@ -396,7 +394,7 @@ groups:
             {'doc': 'item1', 'name': 'name1', 'dtype': 'int'},
             {'doc': 'item2', 'name': 'name2', 'dtype': 'float'}
         )
-        result = writer.sort_keys(input_tuple)
+        result = YAMLSpecWriter.sort_keys(input_tuple)
         # Convert generator to list for testing
         result_list = list(result)
         for item in result_list:


### PR DESCRIPTION
## Motivation

Cleaning up code. Follow up to https://github.com/hdmf-dev/hdmf-docutils/pull/92#issuecomment-2867883285

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
