### PR TITLE
Fix copying of typemap and refactor TypeConfigurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # HDMF Changelog
 
-## HDMF 4.1.1 (Upcoming)
-### Enhancements
+## HDMF 4.1.1 (August 12, 2025)
+
+### Fixed
+- Fixed copying of `TypeMap` and `TypeConfigurator`. Previously, the same global `TypeConfigurator` instance was used in all copies of a `TypeMap`. @rly [#1302](https://github.com/hdmf-dev/hdmf/pull/1302)
+
+### Added
 - Added a check for a compound datatype that is not defined in the schema or spec. This is currently not supported. @mavaylon1 [#1276](https://github.com/hdmf-dev/hdmf/pull/1276)
+
 
 ## HDMF 4.1.0 (May 28, 2025)
 
@@ -24,6 +29,7 @@
 ### Fixed
 - Fixed `get_data_shape` returning the wrong shape for lists of Data objects. @rly [#1270](https://github.com/hdmf-dev/hdmf/pull/1270)
 - Added protection against complex numbers in arrays and other data types. @bendichter [#1279](https://github.com/hdmf-dev/hdmf/pull/1279)
+
 
 ## HDMF 4.0.0 (January 22, 2025)
 
@@ -47,6 +53,7 @@
 
 ### Fixed
 - Fixed issue with `DynamicTable.add_column` not allowing subclasses of `DynamicTableRegion` or `EnumData`. @rly [#1091](https://github.com/hdmf-dev/hdmf/pull/1091)
+
 
 ## HDMF 3.14.6 (December 20, 2024)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -431,7 +431,7 @@ class TypeMap:
         return self.__container_types
 
     def __copy__(self):
-        ret = TypeMap(copy(self.__ns_catalog), self.__default_mapper_cls, self.type_config)
+        ret = TypeMap(copy(self.__ns_catalog), self.__default_mapper_cls, TypeConfigurator(self.type_config.paths))
         ret.merge(self)
         return ret
 
@@ -464,6 +464,7 @@ class TypeMap:
         for custom_generators in reversed(type_map.__class_generator_manager.custom_generators):
             # iterate in reverse order because generators are stored internally as a stack
             self.register_generator(custom_generators)
+        # NOTE: the type config is not merged from the input type map to the new one. add if there is a clear use case
 
     @docval({"name": "generator", "type": type, "doc": "the CustomClassGenerator class to register"})
     def register_generator(self, **kwargs):

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -4,6 +4,7 @@ for reading and writing data in according to the HDMF-common specification
 import os.path
 from copy import deepcopy
 from collections.abc import Callable
+import warnings
 
 CORE_NAMESPACE = 'hdmf-common'
 EXP_NAMESPACE = 'hdmf-experimental'
@@ -26,11 +27,10 @@ global __TYPE_MAP
         is_method=False)
 def load_type_config(**kwargs):
     """
-    This method will either load the default config or the config provided by the path.
-    NOTE: This config is global and shared across all type maps.
+    This method will either load the config at the given path into either the global type map or a specific type map.
     """
     config_path = kwargs['config_path']
-    type_map = kwargs['type_map'] or get_type_map()
+    type_map = kwargs['type_map'] or __TYPE_MAP
 
     type_map.type_config.load_type_config(config_path)
 
@@ -38,23 +38,23 @@ def load_type_config(**kwargs):
         is_method=False)
 def get_loaded_type_config(**kwargs):
     """
-    This method returns the entire config file.
+    This method returns a dictionary with the configuration for each namespace and data type.
     """
-    type_map = kwargs['type_map'] or get_type_map()
+    type_map = kwargs['type_map'] or __TYPE_MAP
 
     if type_map.type_config.config is None:
         msg = "No configuration is loaded."
         raise ValueError(msg)
-    else:
-        return type_map.type_config.config
+
+    return type_map.type_config.config
 
 @docval({'name': 'type_map', 'type': TypeMap, 'doc': 'The TypeMap.', 'default': None},
         is_method=False)
 def unload_type_config(**kwargs):
     """
-    Unload the configuration file.
+    Unload all type configurations from the global type map or a specific type map.
     """
-    type_map = kwargs['type_map'] or get_type_map()
+    type_map = kwargs['type_map'] or __TYPE_MAP
 
     return type_map.type_config.unload_type_config()
 
@@ -183,6 +183,7 @@ def get_type_map(**kwargs):
     if extensions is None:
         type_map = deepcopy(__TYPE_MAP)
     else:
+        warnings.warn("The 'extensions' argument is deprecated and will be removed in HDMF 5.0", DeprecationWarning)
         if isinstance(extensions, TypeMap):
             type_map = extensions
         else:

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -92,6 +92,8 @@ class AbstractContainer(metaclass=ExtenderMeta):
         return setter
 
     def _get_type_map(self):
+        # TODO: refactor this so that it does not call get_type_map every time an attribute is set
+        # and there is non circular import
         from hdmf.common import get_type_map # circular import
         return get_type_map()
 
@@ -114,12 +116,13 @@ class AbstractContainer(metaclass=ExtenderMeta):
         """
         configurator = type_map.type_config
 
-        if len(configurator.path)>0:
-            # The type_map has a config always set; however, when toggled off, the config path is empty.
-            CUR_DIR = os.path.dirname(os.path.realpath(configurator.path[0]))
-            termset_config = configurator.config
-        else:
+        if not configurator.paths:
             return val
+
+        # The type_map has a config always set; however, when toggled off, the config path is empty.
+        # TODO account for more than one different configurator path
+        CUR_DIR = os.path.dirname(os.path.realpath(configurator.paths[0]))
+        termset_config = configurator.config
 
         # If the val has been manually wrapped then skip checking the config for the attr
         if isinstance(val, TermSetWrapper):
@@ -132,39 +135,39 @@ class AbstractContainer(metaclass=ExtenderMeta):
             msg = "%s not found within loaded configuration." % self.namespace
             warn(msg)
             return val
-        else:
-            # check to see that the container type is in the config under the namespace
-            config_namespace = termset_config['namespaces'][self.namespace]
-            data_type = self.data_type
 
-            if data_type not in config_namespace['data_types']:
-                msg = '%s not found within the configuration for %s' % (data_type, self.namespace)
-                warn(msg)
-                return val
-            else:
-                # Get the ObjectMapper
-                obj_mapper = type_map.get_map(self)
+        # check to see that the container type is in the config under the namespace
+        config_namespace = termset_config['namespaces'][self.namespace]
+        data_type = self.data_type
 
-                # Get the spec for the constructor arg
-                spec = obj_mapper.get_carg_spec(arg_name)
-                if spec is None:
-                    msg = "Spec not found for %s." % arg_name
-                    warn(msg)
-                    return val
+        if data_type not in config_namespace['data_types']:
+            msg = '%s not found within the configuration for %s' % (data_type, self.namespace)
+            warn(msg)
+            return val
 
-                # Get spec attr name
-                mapped_attr_name = obj_mapper.get_attribute(spec)
+        # Get the ObjectMapper
+        obj_mapper = type_map.get_map(self)
 
-                config_data_type = config_namespace['data_types'][data_type]
-                try:
-                    config_termset_path = config_data_type[mapped_attr_name]
-                except KeyError:
-                    return val
+        # Get the spec for the constructor arg
+        spec = obj_mapper.get_carg_spec(arg_name)
+        if spec is None:
+            msg = "Spec not found for %s." % arg_name
+            warn(msg)
+            return val
 
-                termset_path = os.path.join(CUR_DIR, config_termset_path['termset'])
-                termset = TermSet(term_schema_path=termset_path)
-                val = TermSetWrapper(value=val, termset=termset)
-                return val
+        # Get spec attr name
+        mapped_attr_name = obj_mapper.get_attribute(spec)
+
+        config_data_type = config_namespace['data_types'][data_type]
+        try:
+            config_termset_path = config_data_type[mapped_attr_name]
+        except KeyError:
+            return val
+
+        termset_path = os.path.join(CUR_DIR, config_termset_path['termset'])
+        termset = TermSet(term_schema_path=termset_path)
+        val = TermSetWrapper(value=val, termset=termset)
+        return val
 
     @classmethod
     def _getter(cls, field):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -130,19 +130,16 @@ class AbstractContainer(metaclass=ExtenderMeta):
             warn(msg)
             return val
 
-        # check to see that the namespace for the container is in the config
+        # return the value if the namespace for the container is not in the config
         if self.namespace not in termset_config['namespaces']:
-            msg = "%s not found within loaded configuration." % self.namespace
-            warn(msg)
             return val
 
         # check to see that the container type is in the config under the namespace
         config_namespace = termset_config['namespaces'][self.namespace]
         data_type = self.data_type
 
+        # return the value if the data type for the container is not in the config
         if data_type not in config_namespace['data_types']:
-            msg = '%s not found within the configuration for %s' % (data_type, self.namespace)
-            warn(msg)
             return val
 
         # Get the ObjectMapper

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -355,14 +355,13 @@ class TypeConfigurator:
     When toggled on, every instance of a configuration file supported data type will be validated
     according to the corresponding TermSet.
     """
-    @docval({'name': 'path', 'type': str, 'doc': 'Path to the configuration file.', 'default': None})
+    @docval({'name': 'paths', 'type': list, 'doc': 'Paths to configuration files.', 'default': None})
     def __init__(self, **kwargs):
         self.config = None
-        if kwargs['path'] is None:
-            self.path = []
-        else:
-            self.path = [kwargs['path']]
-            self.load_type_config(config_path=self.path[0])
+        self.paths = []
+        if kwargs["paths"]:
+            for p in kwargs["paths"]:
+                self.load_type_config(p)
 
     @docval({'name': 'data_type', 'type': str,
              'doc': 'The desired data type within the configuration file.'},
@@ -386,19 +385,19 @@ class TypeConfigurator:
             raise ValueError(msg)
 
     @docval({'name': 'config_path', 'type': str, 'doc': 'Path to the configuration file.'})
-    def load_type_config(self,config_path):
+    def load_type_config(self, config_path):
         """
         Load the configuration file for validation on the fields defined for the objects within the file.
         """
         with open(config_path, 'r') as config:
-            yaml=YAML(typ='safe')
+            yaml = YAML(typ='safe')
             termset_config = yaml.load(config)
             if self.config is None: # set the initial config/load after config has been unloaded
                 self.config = termset_config
-                if len(self.path)==0: # for loading after an unloaded config
-                    self.path.append(config_path)
+                if len(self.paths) == 0: # for loading after an unloaded config
+                    self.paths.append(config_path)
             else: # append/replace to the existing config
-                if config_path in self.path:
+                if config_path in self.paths:
                     msg = 'This configuration file path already exists within the configurator.'
                     raise ValueError(msg)
                 else:
@@ -415,12 +414,12 @@ class TypeConfigurator:
                                     new_config = termset_config['namespaces'][namespace]['data_types'][data_type]
                                     self.config['namespaces'][namespace]['data_types'][data_type] = new_config
 
-                    # append path to self.path
-                    self.path.append(config_path)
+                    # append path to self.paths
+                    self.paths.append(config_path)
 
     def unload_type_config(self):
         """
-        Remove validation according to termset configuration file.
+        Remove validation with all loaded termset configuration files. Effectively reset this instance.
         """
-        self.path = []
         self.config = None
+        self.paths = []

--- a/tests/unit/common/test_common.py
+++ b/tests/unit/common/test_common.py
@@ -5,6 +5,9 @@ from hdmf.testing import TestCase
 
 class TestCommonTypeMap(TestCase):
 
+    def tearDown(self):
+        unload_type_config()
+
     def test_base_types(self):
         tm = get_type_map()
         cls = tm.get_dt_container_cls('Container', 'hdmf-common')
@@ -24,5 +27,4 @@ class TestCommonTypeMap(TestCase):
                  {'ExtensionContainer': {'description': None}}}}}
 
         self.assertEqual(tm.type_config.config, config)
-        self.assertEqual(tm.type_config.path, [path])
-        unload_type_config()
+        self.assertEqual(tm.type_config.paths, [path])

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -1,7 +1,10 @@
 import os
 import numpy as np
 
+import pytest
+
 from hdmf import Container
+from hdmf.build import TypeMap
 from hdmf.term_set import TermSet, TermSetWrapper, TypeConfigurator
 from hdmf.testing import TestCase, remove_test_file
 from hdmf.common import (VectorData, unload_type_config,
@@ -234,37 +237,37 @@ class TestTypeConfig(TestCase):
 
     def test_config_path(self):
         path = 'tests/unit/hdmf_config.yaml'
-        tc = TypeConfigurator(path=path)
-        self.assertEqual(tc.path, [path])
+        tc = TypeConfigurator([path])
+        self.assertEqual(tc.paths, [path])
 
     def test_get_config(self):
         path = 'tests/unit/hdmf_config.yaml'
-        tc = TypeConfigurator(path=path)
+        tc = TypeConfigurator([path])
         self.assertEqual(tc.get_config('VectorData', 'hdmf-common'),
                                       {'description': {'termset': 'example_test_term_set.yaml'}})
 
     def test_get_config_namespace_error(self):
         path = 'tests/unit/hdmf_config.yaml'
-        tc = TypeConfigurator(path=path)
+        tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
             tc.get_config('VectorData', 'hdmf-common11')
 
     def test_get_config_container_error(self):
         path = 'tests/unit/hdmf_config.yaml'
-        tc = TypeConfigurator(path=path)
+        tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
             tc.get_config('VectorData11', 'hdmf-common')
 
     def test_already_loaded_path_error(self):
         path = 'tests/unit/hdmf_config.yaml'
-        tc = TypeConfigurator(path=path)
+        tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
             tc.load_type_config(config_path=path)
 
     def test_load_two_unique_configs(self):
         path = 'tests/unit/hdmf_config.yaml'
         path2 = 'tests/unit/hdmf_config2.yaml'
-        tc = TypeConfigurator(path=path)
+        tc = TypeConfigurator([path])
         tc.load_type_config(config_path=path2)
         config = {'namespaces': {'hdmf-common': {'version': '3.12.2',
                   'data_types': {'VectorData': {'name': None},
@@ -276,7 +279,7 @@ class TestTypeConfig(TestCase):
                   'namespace2': {'version': 0, 'data_types':
                   {'MythicData': {'description':
                   {'termset': 'example_test_term_set.yaml'}}}}}}
-        self.assertEqual(tc.path, [path, path2])
+        self.assertEqual(tc.paths, [path, path2])
         self.assertEqual(tc.config, config)
 
 
@@ -351,6 +354,26 @@ class TestGlobalTypeConfig(TestCase):
             ExtensionContainer(name='foo',
                                namespace='foo_namespace',
                                description='Homo sapiens')
+
+
+@pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
+class TestNonGlobalTypeConfig(TestCase):
+    def test_two_type_maps(self):
+        type_map1 = TypeMap()
+        load_type_config(config_path='tests/unit/hdmf_config.yaml', type_map=type_map1)
+
+        type_map2 = TypeMap()
+        load_type_config(config_path='tests/unit/hdmf_config2.yaml', type_map=type_map2)
+
+        assert type_map1.type_config is not type_map2.type_config
+        assert type_map1.type_config.paths == ['tests/unit/hdmf_config.yaml']
+        assert type_map2.type_config.paths == ['tests/unit/hdmf_config2.yaml']
+
+        unload_type_config(type_map1)
+        unload_type_config(type_map2)
+
+        assert type_map1.type_config.paths == []
+        assert type_map2.type_config.paths == []
 
 
 class TestOptionalDepsNotInstalled(TestCase):

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -324,18 +324,6 @@ class TestGlobalTypeConfig(TestCase):
         data = VectorData(name='foo', data=[0], description='Homo sapiens')
         self.assertEqual(data.description.value, 'Homo sapiens')
 
-    def test_namespace_warn(self):
-        with self.assertWarns(Warning):
-            ExtensionContainer(name='foo',
-                               namespace='foo',
-                               description='Homo sapiens')
-
-    def test_container_type_warn(self):
-        with self.assertWarns(Warning):
-            ExtensionContainer(name='foo',
-                               namespace='hdmf-common',
-                               description='Homo sapiens')
-
     def test_already_wrapped_warn(self):
         terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
         with self.assertWarns(Warning):


### PR DESCRIPTION
## Motivation

Fix #1301, work toward fixing https://github.com/NeurodataWithoutBorders/pynwb/issues/1958

Also deprecates calling `get_type_map` with any 'extensions' arguments, a use case I have never seen. IMO it's easy for the rare user to just call `load_namespaces` on the type map than us maintain all this extra convenience logic that even we don't use. 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
