### PR TITLE
Handle conflicts between core schema and extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Added
 - Added a check for a compound datatype that is not defined in the schema or spec. This is currently not supported. @mavaylon1 [#1276](https://github.com/hdmf-dev/hdmf/pull/1276)
+- Added checks when loading a namespace for link specification conflicts between extension and core schemas. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309) 
+
+### Changed
+- Changed error for attempting to overwrite an existing specification into a warning that any specification redefinitions will be ignored. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309)  
 
 
 ## HDMF 4.1.0 (May 28, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 
 ### Added
 - Added a check for a compound datatype that is not defined in the schema or spec. This is currently not supported. @mavaylon1 [#1276](https://github.com/hdmf-dev/hdmf/pull/1276)
-- Added checks when loading a namespace for link specification conflicts between extension and core schemas. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309) 
+- Added checks when loading a namespace for link specification conflicts between extension and core schemas. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309)
 
 ### Changed
-- Changed error for attempting to overwrite an existing specification into a warning that any specification redefinitions will be ignored. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309)  
+- Changed error for attempting to overwrite an existing specification into a warning that any specification redefinitions will be ignored. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309)
 
 
 ## HDMF 4.1.0 (May 28, 2025)

--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from collections import OrderedDict
 
 from .spec import BaseStorageSpec, GroupSpec
@@ -43,7 +44,12 @@ class SpecCatalog:
         type_name = ndt_def if ndt_def is not None else ndt
         if type_name in self.__specs:
             if self.__specs[type_name] != spec or self.__spec_source_files[type_name] != source_file:
-                raise ValueError("'%s' - cannot overwrite existing specification" % type_name)
+                warnings.warn(f"{source_file} defines a different specification for {type_name} than "
+                              f"the existing definition from {self.__spec_source_files[type_name]}. "
+                              f"Defaulting to the existing specification. Please update the extension "
+                              f"version if possible or contact the extension authors", UserWarning)
+                spec = self.__specs[type_name]
+                source_file = self.__spec_source_files[type_name]
         self.__specs[type_name] = spec
         self.__spec_source_files[type_name] = source_file
 

--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -46,8 +46,9 @@ class SpecCatalog:
             if self.__specs[type_name] != spec or self.__spec_source_files[type_name] != source_file:
                 warnings.warn(f"{source_file} defines a different specification for {type_name} than "
                               f"the existing definition from {self.__spec_source_files[type_name]}. "
-                              f"Defaulting to the existing specification. Please update the extension "
-                              f"version if possible or contact the extension authors", UserWarning)
+                              f"Defaulting to the existing specification, but compatibility issues "
+                              f"may be present. Please update the extension version if possible or "
+                              f"install an older version of the core schema that is compatible", UserWarning)
                 spec = self.__specs[type_name]
                 source_file = self.__spec_source_files[type_name]
         self.__specs[type_name] = spec

--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -46,9 +46,10 @@ class SpecCatalog:
             if self.__specs[type_name] != spec or self.__spec_source_files[type_name] != source_file:
                 warnings.warn(f"{source_file} defines a different specification for {type_name} than "
                               f"the existing definition from {self.__spec_source_files[type_name]}. "
-                              f"Defaulting to the existing specification, but compatibility issues "
-                              f"may be present. Please update the extension version if possible or "
-                              f"install an older version of the core schema that is compatible", UserWarning)
+                              f"Defaulting to the existing specification from "
+                              f"{self.__spec_source_files[type_name]}, but compatibility issues "
+                              f"may be present. Please update the extension version if possible.",
+                            UserWarning)
                 spec = self.__specs[type_name]
                 source_file = self.__spec_source_files[type_name]
         self.__specs[type_name] = spec

--- a/src/hdmf/spec/catalog.py
+++ b/src/hdmf/spec/catalog.py
@@ -49,7 +49,7 @@ class SpecCatalog:
                               f"Defaulting to the existing specification from "
                               f"{self.__spec_source_files[type_name]}, but compatibility issues "
                               f"may be present. Please update the extension version if possible.",
-                            UserWarning)
+                            UserWarning, stacklevel=3)
                 spec = self.__specs[type_name]
                 source_file = self.__spec_source_files[type_name]
         self.__specs[type_name] = spec

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -649,6 +649,25 @@ class NamespaceCatalog:
             self.__order_deps_aux(order, deps, subk)
         order.append(key)
 
+    def _get_namespace_for_type(self, type_name: str, catalog: SpecCatalog) -> str:
+        """
+        Get the namespace name that contains the given type by looking up its source file.
+        
+        Args:
+            type_name: The name of the type to find the namespace for
+            catalog: The catalog containing the type
+            
+        Returns:
+            The namespace name containing the type, or None if not found
+        """
+        # Get the source file for this type
+        source_file = catalog.get_spec_source_file(type_name)
+        for ns_name, sources in self.__included_sources.items():
+            if source_file in sources:
+                return ns_name
+                
+        return None
+
     def _check_namespace_conflicts(self, extension_ns_name: str, extension_ns_source: str, catalog: SpecCatalog):
         """
         Check for conflicts between extension namespaces and core namespace.
@@ -668,21 +687,27 @@ class NamespaceCatalog:
 
             # Check if this extension type inherits from a core type
             if hasattr(extension_spec, 'data_type_inc') and extension_spec.data_type_inc is not None:
-                parent_type = extension_spec.data_type_inc
+                parent_types = self.get_hierarchy(extension_ns_name, type_name)
+
+                # Look for the first parent type in the hierarchy that exists in core namespaces
+                core_parent_type = None
+                core_namespace_name = None
                 
-                # Look for the parent type in core namespaces
-                # TODO - update to go recursively through the parent types
-                for core_namespace_name in self.__core_namespaces:
+                # Skip the first element (the type itself) and check each parent in the hierarchy
+                for parent_type in parent_types[1:]:
+                    parent_ns = self._get_namespace_for_type(parent_type, catalog)
+                    if parent_ns in self.__core_namespaces:
+                        core_parent_type = parent_type
+                        core_namespace_name = parent_ns
+                        break
+                
+                # If we found a core parent type, check for conflicts
+                if core_parent_type:
                     core_namespace = self.__namespaces[core_namespace_name]
-                    try:
-                        core_spec = core_namespace.get_spec(parent_type)
-                        # Check for conflicts between extension and inherited core spec
-                        conflict_msg = self._check_cross_type_conflicts(extension_ns_name, type_name, extension_spec, core_spec)
-                        if conflict_msg is not None:
-                            warning_msg.append(conflict_msg)
-                    except ValueError:
-                        # Parent type not found in this core namespace, continue to next
-                        continue
+                    core_spec = core_namespace.get_spec(core_parent_type)
+                    conflict_msg = self._check_cross_type_conflicts(extension_ns_name, type_name, extension_spec, core_spec)
+                    if conflict_msg is not None:
+                        warning_msg.append(conflict_msg)
         
         if len(warning_msg) > 0:
             warning_msg = "\n".join(warning_msg)
@@ -726,9 +751,8 @@ class NamespaceCatalog:
                     and core_link_spec.target_type != ext_link_spec.target_type
                     and not self.is_sub_data_type(extension_ns_name, ext_link_spec.target_type, core_link_spec.target_type)):
                     warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a link to {ext_link_spec.target_type} "
-                                   f"while the core schema defines it as a link to {core_link_spec.target_type}. ")
+                                   f"while the core schema defines it as a link to {core_link_spec.target_type}. {ext_link_spec.target_type} "
+                                   f"is not a subtype of {core_link_spec.target_type}. ")
                     return warning_msg
 
-        return None 
-
-
+        return None

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -722,6 +722,8 @@ class NamespaceCatalog:
     def _check_cross_type_conflicts(self, extension_ns_name, spec_name, extension_spec, core_spec):
         """
         Check for type conflicts between extension and core specs (e.g., attribute vs link).
+        
+        The extension spec data type should be a descendent of the core spec data type.
 
         Future type conflicts can be added here for other types within the core schema that are updated
         and/or added and are in conflict with published extensions.

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -705,9 +705,9 @@ class NamespaceCatalog:
                 if core_parent_type:
                     core_namespace = self.__namespaces[core_namespace_name]
                     core_spec = core_namespace.get_spec(core_parent_type)
-                    conflict_msg = self._check_cross_type_conflicts(extension_ns_name, 
-                                                                    type_name, 
-                                                                    extension_spec, 
+                    conflict_msg = self._check_cross_type_conflicts(extension_ns_name,
+                                                                    type_name,
+                                                                    extension_spec,
                                                                     core_spec)
                     if conflict_msg is not None:
                         warning_msg.append(conflict_msg)
@@ -753,8 +753,8 @@ class NamespaceCatalog:
 
                 if (core_link_spec is not None
                     and core_link_spec.target_type != ext_link_spec.target_type
-                    and not self.is_sub_data_type(extension_ns_name, 
-                                                  ext_link_spec.target_type, 
+                    and not self.is_sub_data_type(extension_ns_name,
+                                                  ext_link_spec.target_type,
                                                   core_link_spec.target_type)):
                     warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a "
                                    f"link to {ext_link_spec.target_type} while the core schema defines it as "

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -682,7 +682,7 @@ class NamespaceCatalog:
 
         # check all types in the extension namespace for conflicts with types in core namespaces
         # that the extension types extend. for example, `ExcitationSource` is a `DeviceInstance` that
-        # extends `Device` to have a "model" link. a later version of the core namespace defines 
+        # extends `Device` to have a "model" link. a later version of the core namespace defines
         # `Device` to have a "model" link that conflicts with `DeviceInstance.model` in its target type.
         # Therefore both `DeviceInstance` and `ExcitationSource` have conflicts and will raise warnings
         # in the code below.
@@ -727,7 +727,7 @@ class NamespaceCatalog:
     def _check_cross_type_conflicts(self, extension_ns_name, spec_name, extension_spec, core_spec):
         """
         Check for type conflicts between extension and core specs (e.g., attribute vs link).
-        
+
         The extension spec data type should be a descendent of the core spec data type.
 
         Future type conflicts can be added here for other types within the core schema that are updated

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -680,7 +680,12 @@ class NamespaceCatalog:
         extension_types = [reg_type for reg_type in catalog.get_registered_types() if
                            catalog.get_spec_source_file(reg_type) == extension_ns_source]
 
-        # check all types in the extension namespace for conflicts with core namespaces
+        # check all types in the extension namespace for conflicts with types in core namespaces
+        # that the extension types extend. for example, `ExcitationSource` is a `DeviceInstance` that
+        # extends `Device` to have a "model" link. a later version of the core namespace defines 
+        # `Device` to have a "model" link that conflicts with `DeviceInstance.model` in its target type.
+        # Therefore both `DeviceInstance` and `ExcitationSource` have conflicts and will raise warnings
+        # in the code below.
         warning_msg = []
         for type_name in extension_types:
             extension_spec = catalog.get_spec(type_name)

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -711,7 +711,6 @@ class NamespaceCatalog:
                     core_namespace = self.__namespaces[core_namespace_name]
                     core_spec = core_namespace.get_spec(core_parent_type)
                     conflict_msg = self._check_cross_type_conflicts(extension_ns_name,
-                                                                    type_name,
                                                                     extension_spec,
                                                                     core_spec)
                     if conflict_msg is not None:
@@ -724,7 +723,7 @@ class NamespaceCatalog:
                  f"install an older version of the core schema that is compatible.",
                  category=UserWarning, stacklevel=2)
 
-    def _check_cross_type_conflicts(self, extension_ns_name, spec_name, extension_spec, core_spec):
+    def _check_cross_type_conflicts(self, extension_ns_name, extension_spec, core_spec):
         """
         Check for type conflicts between extension and core specs (e.g., attribute vs link).
 
@@ -744,7 +743,7 @@ class NamespaceCatalog:
                         break
 
                 if core_link is not None:
-                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an "
+                    warning_msg = (f"{extension_ns_name} defines {extension_spec.data_type_def}.{attr_spec.name} as an "
                                    f"attribute (dtype: {attr_spec.dtype}) while the core schema defines "
                                    f"it as a link to {core_link.target_type}.")
                     return warning_msg
@@ -763,7 +762,7 @@ class NamespaceCatalog:
                     and not self.is_sub_data_type(extension_ns_name,
                                                   ext_link_spec.target_type,
                                                   core_link_spec.target_type)):
-                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a "
+                    warning_msg = (f"{extension_ns_name} defines {extension_spec.data_type_def}.{ext_link_spec.name} as a "
                                    f"link to {ext_link_spec.target_type} while the core schema defines it as "
                                    f"a link to {core_link_spec.target_type}. {ext_link_spec.target_type} "
                                    f"is not a subtype of {core_link_spec.target_type}. ")

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -474,16 +474,16 @@ class NamespaceCatalog:
                 included_types[s['namespace']] = tuple(sorted(registered_types))
             else:
                 raise ValueError("Spec '%s' schema must have either 'source' or 'namespace' key" % ns_name)
-    
+
+        # construct namespace
+        ns = self.__spec_namespace_cls.build_namespace(catalog=catalog, **namespace)
+        self.__namespaces[ns_name] = ns
+
         # check for conflicts between core and extension namespaces
         if ns_name not in self.__core_namespaces:
             self._check_namespace_conflicts(extension_ns_name=ns_name, 
                                             extension_ns_source=s.get('source'),
                                             catalog=catalog) 
-
-        # construct namespace
-        ns = self.__spec_namespace_cls.build_namespace(catalog=catalog, **namespace)
-        self.__namespaces[ns_name] = ns
         return included_types
 
     def __register_type(self, ndt, inc_ns, catalog, registered_types):
@@ -671,6 +671,7 @@ class NamespaceCatalog:
                 parent_type = extension_spec.data_type_inc
                 
                 # Look for the parent type in core namespaces
+                # TODO - update to go recursively through the parent types
                 for core_namespace_name in self.__core_namespaces:
                     core_namespace = self.__namespaces[core_namespace_name]
                     try:
@@ -686,7 +687,7 @@ class NamespaceCatalog:
         if len(warning_msg) > 0:
             warning_msg = "\n".join(warning_msg)
             warn(f"Schema conflict(s) detected in namespace '{extension_ns_name}': \n {warning_msg} \n"    
-                 f"This may cause compatibility issues. Please contact the extension authors to update the extension or  "
+                 f"This may cause compatibility issues. Please update the extension version if possible or "
                  f"install an older version of the core schema that is compatible.", 
                  category=UserWarning, stacklevel=2)
             
@@ -710,6 +711,22 @@ class NamespaceCatalog:
                 if core_link is not None:
                     warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an attribute (dtype: {attr_spec.dtype}) "
                                    f"while the core schema defines it as a link to {core_link.target_type}. ")
+                    return warning_msg
+
+        # Check all links in extension spec against links in core spec for target_type conflicts
+        if hasattr(extension_spec, 'links') and hasattr(core_spec, 'links'):
+            for ext_link_spec in extension_spec.links:
+                core_link_spec = None
+                for link_spec in core_spec.links:
+                    if link_spec.name == ext_link_spec.name:
+                        core_link_spec = link_spec
+                        break
+                
+                if (core_link_spec is not None 
+                    and core_link_spec.target_type != ext_link_spec.target_type
+                    and not self.is_sub_data_type(extension_ns_name, ext_link_spec.target_type, core_link_spec.target_type)):
+                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a link to {ext_link_spec.target_type} "
+                                   f"while the core schema defines it as a link to {core_link_spec.target_type}. ")
                     return warning_msg
 
         return None 

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -474,6 +474,13 @@ class NamespaceCatalog:
                 included_types[s['namespace']] = tuple(sorted(registered_types))
             else:
                 raise ValueError("Spec '%s' schema must have either 'source' or 'namespace' key" % ns_name)
+    
+        # check for conflicts between core and extension namespaces
+        if ns_name not in self.__core_namespaces:
+            self._check_namespace_conflicts(extension_ns_name=ns_name, 
+                                            extension_ns_source=s.get('source'),
+                                            catalog=catalog) 
+
         # construct namespace
         ns = self.__spec_namespace_cls.build_namespace(catalog=catalog, **namespace)
         self.__namespaces[ns_name] = ns
@@ -641,3 +648,70 @@ class NamespaceCatalog:
         for subk in subdeps:
             self.__order_deps_aux(order, deps, subk)
         order.append(key)
+
+    def _check_namespace_conflicts(self, extension_ns_name: str, extension_ns_source: str, catalog: SpecCatalog):
+        """
+        Check for conflicts between extension namespaces and core namespace.
+
+        Note that detection of conflicts in which the same type_name is defined in both the extension and core
+        are detected by the SpecCatalog when registering the spec.
+        """
+        
+        # get all the types in the catalog that are from the extension namespace
+        extension_types = [reg_type for reg_type in catalog.get_registered_types() if
+                           catalog.get_spec_source_file(reg_type) == extension_ns_source]
+
+        # check all types in the extension namespace for conflicts with core namespaces
+        warning_msg = []
+        for type_name in extension_types:
+            extension_spec = catalog.get_spec(type_name)
+
+            # Check if this extension type inherits from a core type
+            if hasattr(extension_spec, 'data_type_inc') and extension_spec.data_type_inc is not None:
+                parent_type = extension_spec.data_type_inc
+                
+                # Look for the parent type in core namespaces
+                for core_namespace_name in self.__core_namespaces:
+                    core_namespace = self.__namespaces[core_namespace_name]
+                    try:
+                        core_spec = core_namespace.get_spec(parent_type)
+                        # Check for conflicts between extension and inherited core spec
+                        conflict_msg = self._check_cross_type_conflicts(extension_ns_name, type_name, extension_spec, core_spec)
+                        if conflict_msg is not None:
+                            warning_msg.append(conflict_msg)
+                    except ValueError:
+                        # Parent type not found in this core namespace, continue to next
+                        continue
+        
+        if len(warning_msg) > 0:
+            warning_msg = "\n".join(warning_msg)
+            warn(f"Schema conflict(s) detected in namespace '{extension_ns_name}': \n {warning_msg} \n"    
+                 f"This may cause compatibility issues. Please contact the extension authors to update the extension or  "
+                 f"install an older version of the core schema that is compatible.", 
+                 category=UserWarning, stacklevel=2)
+            
+    def _check_cross_type_conflicts(self, extension_ns_name, spec_name, extension_spec, core_spec):
+        """
+        Check for type conflicts between extension and core specs (e.g., attribute vs link).
+
+        Future type conflicts can be added here for other types within the core schema that are updated 
+        and/or added and are in conflict with published extensions.
+        """
+        
+        # Check all attributes in extension spec against links in core spec
+        if hasattr(extension_spec, 'attributes') and hasattr(core_spec, 'links'):
+            for attr_spec in extension_spec.attributes:            
+                core_link = None
+                for link_spec in core_spec.links:
+                    if link_spec.name == attr_spec.name:
+                        core_link = link_spec
+                        break
+                        
+                if core_link is not None:
+                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an attribute (dtype: {attr_spec.dtype}) "
+                                   f"while the core schema defines it as a link to {core_link.target_type}. ")
+                    return warning_msg
+
+        return None 
+
+

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -762,8 +762,8 @@ class NamespaceCatalog:
                     and not self.is_sub_data_type(extension_ns_name,
                                                   ext_link_spec.target_type,
                                                   core_link_spec.target_type)):
-                    warning_msg = (f"{extension_ns_name} defines {extension_spec.data_type_def}.{ext_link_spec.name} as a "
-                                   f"link to {ext_link_spec.target_type} while the core schema defines it as "
+                    warning_msg = (f"{extension_ns_name} defines {extension_spec.data_type_def}.{ext_link_spec.name} "
+                                   f"as a link to {ext_link_spec.target_type} while the core schema defines it as "
                                    f"a link to {core_link_spec.target_type}. {ext_link_spec.target_type} "
                                    f"is not a subtype of {core_link_spec.target_type}. ")
                     return warning_msg

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -705,7 +705,10 @@ class NamespaceCatalog:
                 if core_parent_type:
                     core_namespace = self.__namespaces[core_namespace_name]
                     core_spec = core_namespace.get_spec(core_parent_type)
-                    conflict_msg = self._check_cross_type_conflicts(extension_ns_name, type_name, extension_spec, core_spec)
+                    conflict_msg = self._check_cross_type_conflicts(extension_ns_name, 
+                                                                    type_name, 
+                                                                    extension_spec, 
+                                                                    core_spec)
                     if conflict_msg is not None:
                         warning_msg.append(conflict_msg)
 
@@ -734,8 +737,9 @@ class NamespaceCatalog:
                         break
 
                 if core_link is not None:
-                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an attribute (dtype: {attr_spec.dtype}) "
-                                   f"while the core schema defines it as a link to {core_link.target_type}. ")
+                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an "
+                                   f"attribute (dtype: {attr_spec.dtype}) while the core schema defines "
+                                   f"it as a link to {core_link.target_type}.")
                     return warning_msg
 
         # Check all links in extension spec against links in core spec for target_type conflicts
@@ -749,9 +753,12 @@ class NamespaceCatalog:
 
                 if (core_link_spec is not None
                     and core_link_spec.target_type != ext_link_spec.target_type
-                    and not self.is_sub_data_type(extension_ns_name, ext_link_spec.target_type, core_link_spec.target_type)):
-                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a link to {ext_link_spec.target_type} "
-                                   f"while the core schema defines it as a link to {core_link_spec.target_type}. {ext_link_spec.target_type} "
+                    and not self.is_sub_data_type(extension_ns_name, 
+                                                  ext_link_spec.target_type, 
+                                                  core_link_spec.target_type)):
+                    warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a "
+                                   f"link to {ext_link_spec.target_type} while the core schema defines it as "
+                                   f"a link to {core_link_spec.target_type}. {ext_link_spec.target_type} "
                                    f"is not a subtype of {core_link_spec.target_type}. ")
                     return warning_msg
 

--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -481,9 +481,9 @@ class NamespaceCatalog:
 
         # check for conflicts between core and extension namespaces
         if ns_name not in self.__core_namespaces:
-            self._check_namespace_conflicts(extension_ns_name=ns_name, 
+            self._check_namespace_conflicts(extension_ns_name=ns_name,
                                             extension_ns_source=s.get('source'),
-                                            catalog=catalog) 
+                                            catalog=catalog)
         return included_types
 
     def __register_type(self, ndt, inc_ns, catalog, registered_types):
@@ -652,11 +652,11 @@ class NamespaceCatalog:
     def _get_namespace_for_type(self, type_name: str, catalog: SpecCatalog) -> str:
         """
         Get the namespace name that contains the given type by looking up its source file.
-        
+
         Args:
             type_name: The name of the type to find the namespace for
             catalog: The catalog containing the type
-            
+
         Returns:
             The namespace name containing the type, or None if not found
         """
@@ -665,7 +665,7 @@ class NamespaceCatalog:
         for ns_name, sources in self.__included_sources.items():
             if source_file in sources:
                 return ns_name
-                
+
         return None
 
     def _check_namespace_conflicts(self, extension_ns_name: str, extension_ns_source: str, catalog: SpecCatalog):
@@ -675,7 +675,7 @@ class NamespaceCatalog:
         Note that detection of conflicts in which the same type_name is defined in both the extension and core
         are detected by the SpecCatalog when registering the spec.
         """
-        
+
         # get all the types in the catalog that are from the extension namespace
         extension_types = [reg_type for reg_type in catalog.get_registered_types() if
                            catalog.get_spec_source_file(reg_type) == extension_ns_source]
@@ -692,7 +692,7 @@ class NamespaceCatalog:
                 # Look for the first parent type in the hierarchy that exists in core namespaces
                 core_parent_type = None
                 core_namespace_name = None
-                
+
                 # Skip the first element (the type itself) and check each parent in the hierarchy
                 for parent_type in parent_types[1:]:
                     parent_ns = self._get_namespace_for_type(parent_type, catalog)
@@ -700,7 +700,7 @@ class NamespaceCatalog:
                         core_parent_type = parent_type
                         core_namespace_name = parent_ns
                         break
-                
+
                 # If we found a core parent type, check for conflicts
                 if core_parent_type:
                     core_namespace = self.__namespaces[core_namespace_name]
@@ -708,31 +708,31 @@ class NamespaceCatalog:
                     conflict_msg = self._check_cross_type_conflicts(extension_ns_name, type_name, extension_spec, core_spec)
                     if conflict_msg is not None:
                         warning_msg.append(conflict_msg)
-        
+
         if len(warning_msg) > 0:
             warning_msg = "\n".join(warning_msg)
-            warn(f"Schema conflict(s) detected in namespace '{extension_ns_name}': \n {warning_msg} \n"    
+            warn(f"Schema conflict(s) detected in namespace '{extension_ns_name}': \n {warning_msg} \n"
                  f"This may cause compatibility issues. Please update the extension version if possible or "
-                 f"install an older version of the core schema that is compatible.", 
+                 f"install an older version of the core schema that is compatible.",
                  category=UserWarning, stacklevel=2)
-            
+
     def _check_cross_type_conflicts(self, extension_ns_name, spec_name, extension_spec, core_spec):
         """
         Check for type conflicts between extension and core specs (e.g., attribute vs link).
 
-        Future type conflicts can be added here for other types within the core schema that are updated 
+        Future type conflicts can be added here for other types within the core schema that are updated
         and/or added and are in conflict with published extensions.
         """
-        
+
         # Check all attributes in extension spec against links in core spec
         if hasattr(extension_spec, 'attributes') and hasattr(core_spec, 'links'):
-            for attr_spec in extension_spec.attributes:            
+            for attr_spec in extension_spec.attributes:
                 core_link = None
                 for link_spec in core_spec.links:
                     if link_spec.name == attr_spec.name:
                         core_link = link_spec
                         break
-                        
+
                 if core_link is not None:
                     warning_msg = (f"{extension_ns_name} defines {spec_name}.{attr_spec.name} as an attribute (dtype: {attr_spec.dtype}) "
                                    f"while the core schema defines it as a link to {core_link.target_type}. ")
@@ -746,8 +746,8 @@ class NamespaceCatalog:
                     if link_spec.name == ext_link_spec.name:
                         core_link_spec = link_spec
                         break
-                
-                if (core_link_spec is not None 
+
+                if (core_link_spec is not None
                     and core_link_spec.target_type != ext_link_spec.target_type
                     and not self.is_sub_data_type(extension_ns_name, ext_link_spec.target_type, core_link_spec.target_type)):
                     warning_msg = (f"{extension_ns_name} defines {spec_name}.{ext_link_spec.name} as a link to {ext_link_spec.target_type} "

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -446,7 +446,7 @@ class TestCoreExtensionConflicts(TestCase):
             links=[
                 LinkSpec(name='device_model_link', doc='Link to device', target_type='DeviceModel')
             ]
-        )        
+        )
         core_ns_builder = NamespaceBuilder('Core namespace', 'core', version='1.0.0')
         core_ns_builder.add_spec(self.core_source, device_model_spec)
         core_ns_builder.add_spec(self.core_source, core_spec)
@@ -488,7 +488,7 @@ class TestCoreExtensionConflicts(TestCase):
             self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ext_ns_path))
 
     def test_link_target_type_conflict(self):
-        """Test detection of link target type conflicts between extension and core."""        
+        """Test detection of link target type conflicts between extension and core."""
         # Create extension that inherits from core but defines equipment_link with different target
         device_spec = GroupSpec('A device', data_type_def='Device')
         ext_spec = GroupSpec(
@@ -520,10 +520,10 @@ class TestCoreExtensionConflicts(TestCase):
     def test_link_target_subtype_no_conflict(self):
         """Test that link target type conflicts are not reported when extension uses subtype."""
         # Create minimal ExtDevice spec for testing
-        ext_device_model_spec = GroupSpec('A test extension device', 
+        ext_device_model_spec = GroupSpec('A test extension device',
                                           data_type_def='ExtDeviceModel',
                                           data_type_inc='DeviceModel',)
-        
+
         # Create extension that properly extends core without conflicts
         ext_spec = GroupSpec(
             'An extension data type',
@@ -544,7 +544,7 @@ class TestCoreExtensionConflicts(TestCase):
         # Load extension namespace and check no warnings about conflicts
         with warnings.catch_warnings(record=True) as ws:
             self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ext_ns_path))
-        
+
         for w in ws:
             self.assertNotIn("Schema conflict(s) detected in namespace 'extension'",
                              str(w.message))

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -5,7 +5,7 @@ from tempfile import gettempdir
 import warnings
 
 from hdmf.common import get_type_map
-from hdmf.spec import AttributeSpec, DatasetSpec, GroupSpec, SpecNamespace, NamespaceCatalog, NamespaceBuilder
+from hdmf.spec import AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, SpecNamespace, NamespaceCatalog, NamespaceBuilder
 from hdmf.testing import TestCase, remove_test_file
 
 from tests.unit.helpers.utils import CustomGroupSpec, CustomDatasetSpec, CustomSpecNamespace
@@ -427,3 +427,124 @@ class TestCustomSpecClasses(TestCase):
         namespace_deps1 = self.ns_catalog.load_namespaces(namespace_path)
         namespace_deps2 = self.ns_catalog.load_namespaces(namespace_path)
         self.assertDictEqual(namespace_deps1, namespace_deps2)
+
+class TestCoreExtensionConflicts(TestCase):
+    """Test detection of conflicts between core and extension namespaces."""
+
+    def setUp(self):
+        self.tempdir = gettempdir()
+        self.core_source = 'core.yaml'
+        self.core_ns_path = 'core_namespace.yaml'
+        self.ext_source = 'extension.yaml'
+        self.ext_ns_path = 'extension_namespace.yaml'
+
+        # setup minimal core spec and namespace for testing
+        device_model_spec = GroupSpec('A device model', data_type_def='DeviceModel')
+        core_spec = GroupSpec(
+            'A core data type',
+            data_type_def='CoreType',
+            links=[
+                LinkSpec(name='device_model_link', doc='Link to device', target_type='DeviceModel')
+            ]
+        )        
+        core_ns_builder = NamespaceBuilder('Core namespace', 'core', version='1.0.0')
+        core_ns_builder.add_spec(self.core_source, device_model_spec)
+        core_ns_builder.add_spec(self.core_source, core_spec)
+        core_ns_builder.export(self.core_ns_path, outdir=self.tempdir)
+
+        # load core namespace
+        self.ns_catalog = NamespaceCatalog(core_namespaces=['core'])
+        self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.core_ns_path))
+
+    def tearDown(self):
+        for f in (self.core_source, self.core_ns_path, self.ext_source, self.ext_ns_path):
+            remove_test_file(os.path.join(self.tempdir, f))
+
+    def test_attribute_vs_link_conflict(self):
+        """Test detection of attribute vs link conflicts between extension and core."""
+        # Create extension that inherits from core but defines device_model_link as attribute
+        ext_spec = GroupSpec(
+            'An extension data type',
+            data_type_def='ExtensionType',
+            data_type_inc='CoreType',
+            attributes=[
+                AttributeSpec(name='device_model_link', doc='Device model as attribute', dtype='text')
+            ]
+        )
+
+        # Build and save extension namespace
+        ext_ns_builder = NamespaceBuilder('Extension namespace', 'extension', version='1.0.0')
+        ext_ns_builder.include_namespace('core')
+        ext_ns_builder.add_spec(self.ext_source, ext_spec)
+        ext_ns_builder.export(self.ext_ns_path, outdir=self.tempdir)
+
+        # Load the extension namespace and assert warning is raised
+        expected_msg = ("Schema conflict(s) detected in namespace 'extension': \n"
+                       " extension defines ExtensionType.device_model_link as an attribute (dtype: text) "
+                       "while the core schema defines it as a link to DeviceModel. \n"
+                       "This may cause compatibility issues. Please update the extension version if possible or "
+                       "install an older version of the core schema that is compatible.")
+        with self.assertWarnsWith(UserWarning, expected_msg):
+            self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ext_ns_path))
+
+    def test_link_target_type_conflict(self):
+        """Test detection of link target type conflicts between extension and core."""        
+        # Create extension that inherits from core but defines equipment_link with different target
+        device_spec = GroupSpec('A device', data_type_def='Device')
+        ext_spec = GroupSpec(
+            'An extension data type',
+            data_type_def='ExtensionType',
+            data_type_inc='CoreType',
+            links=[
+                LinkSpec(name='device_model_link', doc='Link to device', target_type='Device')
+            ]
+        )
+
+        # Build and save extension namespace
+        ext_ns_builder = NamespaceBuilder('Extension namespace', 'extension', version='1.0.0')
+        ext_ns_builder.include_namespace('core')
+        ext_ns_builder.add_spec(self.ext_source, device_spec)
+        ext_ns_builder.add_spec(self.ext_source, ext_spec)
+        ext_ns_builder.export(self.ext_ns_path, outdir=self.tempdir)
+
+        # Load extension namespace and expect warning
+        expected_msg = ("Schema conflict(s) detected in namespace 'extension': \n"
+                       " extension defines ExtensionType.device_model_link as a link to Device "
+                       "while the core schema defines it as a link to DeviceModel. "
+                       "Device is not a subtype of DeviceModel.  \n"
+                       "This may cause compatibility issues. Please update the extension version if possible or "
+                       "install an older version of the core schema that is compatible.")
+        with self.assertWarnsWith(UserWarning, expected_msg):
+            self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ext_ns_path))
+
+    def test_link_target_subtype_no_conflict(self):
+        """Test that link target type conflicts are not reported when extension uses subtype."""
+        # Create minimal ExtDevice spec for testing
+        ext_device_model_spec = GroupSpec('A test extension device', 
+                                          data_type_def='ExtDeviceModel',
+                                          data_type_inc='DeviceModel',)
+        
+        # Create extension that properly extends core without conflicts
+        ext_spec = GroupSpec(
+            'An extension data type',
+            data_type_def='ExtensionType',
+            data_type_inc='CoreType',
+            links=[
+                LinkSpec('Link to extension device model', 'ExtDeviceModel', name='ext_link')
+            ]
+        )
+
+        # Build and save extension namespace
+        ext_ns_builder = NamespaceBuilder('Extension namespace', 'extension', version='1.0.0')
+        ext_ns_builder.include_namespace('core')
+        ext_ns_builder.add_spec(self.ext_source, ext_device_model_spec)
+        ext_ns_builder.add_spec(self.ext_source, ext_spec)
+        ext_ns_builder.export(self.ext_ns_path, outdir=self.tempdir)
+
+        # Load extension namespace and check no warnings about conflicts
+        with warnings.catch_warnings(record=True) as ws:
+            self.ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ext_ns_path))
+        
+        for w in ws:
+            self.assertNotIn("Schema conflict(s) detected in namespace 'extension'",
+                             str(w.message))

--- a/tests/unit/spec_tests/test_spec_catalog.py
+++ b/tests/unit/spec_tests/test_spec_catalog.py
@@ -208,8 +208,10 @@ class SpecCatalogTest(TestCase):
         )
         source = 'test_extension.yaml'
         self.catalog.register_spec(spec1, source)
-        msg = "'Group1' - cannot overwrite existing specification"
-        with self.assertRaisesWith(ValueError, msg):
+        msg = (f"{source} defines a different specification for Group1 than the existing definition "
+               f"from {source}. Defaulting to the existing specification from {source}, but "
+               "compatibility issues may be present. Please update the extension version if possible.")
+        with self.assertWarnsWith(UserWarning, msg):
             self.catalog.register_spec(spec2, source)
 
     def test_catch_duplicate_spec_different_source(self):
@@ -224,6 +226,8 @@ class SpecCatalogTest(TestCase):
         source1 = 'test_extension1.yaml'
         source2 = 'test_extension2.yaml'
         self.catalog.register_spec(spec1, source1)
-        msg = "'Group1' - cannot overwrite existing specification"
-        with self.assertRaisesWith(ValueError, msg):
+        msg = (f"{source2} defines a different specification for Group1 than the existing definition "
+               f"from {source1}. Defaulting to the existing specification from {source1}, but "
+               "compatibility issues may be present. Please update the extension version if possible.")
+        with self.assertWarnsWith(UserWarning, msg):
             self.catalog.register_spec(spec2, source2)


### PR DESCRIPTION
## Motivation

First step towards fixing https://github.com/NeurodataWithoutBorders/pynwb/issues/2108, which will also require remapping Device objects during read in pynwb.

Check for conflicts between the core and extension schemas. These changes check for pretty specific link/attribute conflicts from the `Device` / `DeviceModel` changes in NWB Schema 2.9.0. @rly and I discussed that ideally these checks would be more generalized in the future, but until then additional conflicts could be added to the `check_cross_type_conflicts` function.


todo: 
- [x] add tests


## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
