### PR TITLE
[WIP] Fix building datetime datasets with data_type_inc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
 - Fixed reading a `DynamicTable` that contains a named link to a `VectorData` (e.g., `MeaningsTable.target`). The link target was being picked up as an extra column, causing a `"Columns must be the same length"` error when the target column's row count differed from the table's own row count. @rly [#1445](https://github.com/hdmf-dev/hdmf/pull/1445)
+- Fixed building datasets with `dtype: isodatetime` when the spec uses `data_type_inc` (e.g., `VectorData`-extending columns). `datetime`/`date` values are now converted to ISO strings before dtype resolution instead of failing with `"Expected unicode or ascii string"`. @rly [#1314](https://github.com/hdmf-dev/hdmf/pull/1314)
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -628,7 +628,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 attr_val = attr_val.value
             if attr_val is not None:
                 if not isinstance(attr_val, Data):
-                    # NOTE: Do not process Data objects here
+                    # Data containers are unwrapped and string-converted later in build(),
+                    # after the Data sub-builder is created. Converting here would operate
+                    # on the Data wrapper itself and produce the wrong result.
                     attr_val = self.__convert_string(attr_val, spec)
                 spec_dt = self.__get_data_type(spec)
                 if spec_dt is not None:

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -627,7 +627,9 @@ class ObjectMapper(metaclass=ExtenderMeta):
             if isinstance(attr_val, TermSetWrapper):
                 attr_val = attr_val.value
             if attr_val is not None:
-                attr_val = self.__convert_string(attr_val, spec)
+                if not isinstance(attr_val, Data):
+                    # NOTE: Do not process Data objects here
+                    attr_val = self.__convert_string(attr_val, spec)
                 spec_dt = self.__get_data_type(spec)
                 if spec_dt is not None:
                     try:
@@ -660,6 +662,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # NOTE: if a user passes a h5py.Dataset that is not wrapped with a hdmf.utils.StrDataset,
             # then this conversion may not be correct. Users should unpack their string h5py.Datasets
             # into a numpy array (or wrap them in StrDataset) before passing them to a container object.
+            # NOTE: this will convert datasets and arrays to lists of lists.
             if hasattr(value, '__iter__') and not isinstance(value, (str, bytes)):
                 return [__apply_string_type(item, string_type) for item in value]
             else:
@@ -673,8 +676,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 else:
                     ret = str(value)
         elif isinstance(spec, DatasetSpec):
-            # TODO: make sure we can handle specs with data_type_inc set
-            if spec.data_type_inc is None and spec.dtype is not None:
+            if spec.dtype is not None:
                 string_type = None
                 if 'text' in spec.dtype:
                     string_type = str
@@ -849,6 +851,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                                 data = container.data.value
                             else:
                                 data = container.data
+                            data = self.__convert_string(data, spec)
                             bldr_data, dtype = self.convert_dtype(spec, data, spec_dtype=spec_dtype)
                         except Exception as ex:
                             msg = f"could not resolve dtype for {type(container).__name__} '{container.name}'"

--- a/tests/unit/build_tests/mapper_tests/test_build_datetime.py
+++ b/tests/unit/build_tests/mapper_tests/test_build_datetime.py
@@ -141,3 +141,29 @@ class TestBuildDatasetDateTime(TestCase):
         ret = builder.get('data')
         assert ret.data == [b'2023-07-09T00:00:00', b'2023-07-10T00:00:00']
         assert ret.dtype == 'ascii'
+
+    def test_date_array_ext_spec(self):
+        # This mirrors the traceback in issue #1311, which used datetime.date on a VectorData extension.
+        column_spec = DatasetSpec(data_type_def='Column', doc='an example dataset', dims=(None,))
+        bar_spec = GroupSpec(
+            doc='A test group specification with a data type',
+            data_type_def='Bar',
+            datasets=[
+                DatasetSpec(
+                    data_type_inc='Column',
+                    doc='an example dataset',
+                    name='data',
+                    dtype='isodatetime',
+                ),
+            ],
+        )
+        type_map = create_test_type_map([bar_spec, column_spec], {'Bar': BarWithColumnData, 'Column': Column})
+
+        bar_inst = BarWithColumnData(
+            name='my_bar',
+            data=Column(name='data', data=[date(2023, 7, 9), date(2023, 7, 10)]),
+        )
+        builder = type_map.build(bar_inst)
+        ret = builder.get('data')
+        assert ret.data == [b'2023-07-09', b'2023-07-10']
+        assert ret.dtype == 'ascii'

--- a/tests/unit/build_tests/mapper_tests/test_build_datetime.py
+++ b/tests/unit/build_tests/mapper_tests/test_build_datetime.py
@@ -1,5 +1,5 @@
 from hdmf.utils import docval, getargs
-from hdmf import Container
+from hdmf import Container, Data
 from hdmf.spec import GroupSpec, DatasetSpec
 from hdmf.testing import TestCase
 from datetime import datetime, date
@@ -15,6 +15,38 @@ class Bar(Container):
         name, data = getargs('name', 'data', kwargs)
         super().__init__(name=name)
         self.__data = data
+
+    @property
+    def data_type(self):
+        return 'Bar'
+
+    @property
+    def data(self):
+        return self.__data
+
+
+class Column(Data):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this Column'},
+            {'name': 'data', 'type': ('data', 'array_data'), 'doc': 'some data'})
+    def __init__(self, **kwargs):
+        name, data = getargs('name', 'data', kwargs)
+        super().__init__(name=name, data=data)
+
+    @property
+    def data_type(self):
+        return 'Column'
+
+
+class BarWithColumnData(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this Bar'},
+            {'name': 'data', 'type': Column, 'doc': 'some data'})
+    def __init__(self, **kwargs):
+        name, data = getargs('name', 'data', kwargs)
+        super().__init__(name=name)
+        self.__data = data
+        data.parent = self
 
     @property
     def data_type(self):
@@ -82,4 +114,30 @@ class TestBuildDatasetDateTime(TestCase):
         builder = type_map.build(bar_inst)
         ret = builder.get('data')
         assert ret.data == [b'2023-07-09', b'2023-07-10']
+        assert ret.dtype == 'ascii'
+
+
+    def test_datetime_array_ext_spec(self):
+        column_spec = DatasetSpec(data_type_def='Column', doc='an example dataset', dims=(None,))
+        bar_spec = GroupSpec(
+            doc='A test group specification with a data type',
+            data_type_def='Bar',
+            datasets=[
+                DatasetSpec(
+                    data_type_inc='Column',
+                    doc='an example dataset',
+                    name='data',
+                    dtype='isodatetime',
+                ),
+            ],
+        )
+        type_map = create_test_type_map([bar_spec, column_spec], {'Bar': BarWithColumnData, 'Column': Column})
+
+        bar_inst = BarWithColumnData(
+            name='my_bar',
+            data=Column(name='data', data=[datetime(2023, 7, 9), datetime(2023, 7, 10)]),
+        )
+        builder = type_map.build(bar_inst)
+        ret = builder.get('data')
+        assert ret.data == [b'2023-07-09T00:00:00', b'2023-07-10T00:00:00']
         assert ret.dtype == 'ascii'


### PR DESCRIPTION
## Motivation

Fix #1311. Building a dataset whose spec uses `data_type_inc` (e.g., a `VectorData`-extending column) with `dtype: isodatetime` fails with:

```
Exception: could not resolve dtype for VectorData 'date_of_birth':
    Expected unicode or ascii string, got <class 'datetime.date'>
```

The same path is taken by any extension that declares a datetime-typed column on a `DynamicTable` or subclasses `VectorData`/`Data` with `dtype: isodatetime`. Before this PR the only workaround was to declare the column as `dtype: text` and convert to/from `datetime` in user code.

Root cause: `ObjectMapper.__convert_string` guarded its datetime/string conversion behind `spec.data_type_inc is None`, so extension specs skipped the conversion and datetime objects were passed straight to `convert_dtype`, which expects strings. Additionally, when the container's data attribute is itself a `Data` instance, the conversion needs to happen on the unwrapped data inside the `Data` container's own `build()` call, not on the `Data` wrapper.

## What changed

- `ObjectMapper.__get_attr_value`: skip `__convert_string` when `attr_val` is a `Data` container. The inner data is string-converted later in the `Data` container's own `build()` call, after unwrapping. Converting the wrapper here would produce the wrong result.
- `ObjectMapper.build`: for `Data` containers, call `__convert_string` on the unwrapped data before `convert_dtype`, so datetime values are formatted before dtype resolution.
- `ObjectMapper.__convert_string`: remove the `spec.data_type_inc is None` guard so string/datetime conversion also runs for extension specs (`data_type_inc` set).

### Note on scope

Removing the `data_type_inc is None` guard broadens `__convert_string` to run for all extension-spec `DatasetSpec`s with a dtype, not only `isodatetime`. This is a no-op for `text`/`ascii` (string passthrough via `str(...)`) and short-circuits for numeric dtypes (no matching `string_type`). The effective behavior change is only for datetime extension columns, but the code path is broader than the title suggests.

### Scope: write-side only

This PR fixes the write/build path only. The related read-side issues from #429 remain open and are addressed in #1313:

- Reading datetime-dtype datasets back into `datetime` objects still requires a custom `constructor_arg`; the read-back `data` attribute will be a string, not a `datetime`.
- Scalar datetime *attributes* on extension specs still fail in the `convert_dtype` scalar branch.
- `get_class`-generated classes still type `data` as `str` rather than accepting `datetime`.

Users writing datetime extension columns after this PR can write files successfully but will still need workarounds for reading until #1313 lands.

## How to test

```python
from datetime import date
from pynwb import NWBFile, NWBHDF5IO
from pynwb.file import Subject

# With an extension that declares VectorData-extending column with dtype: isodatetime
# (see https://github.com/nehatk17/ndx-multisubjects/issues/4 for a real reproducer)
subject = Subject(subject_id="s1", date_of_birth=date(2020, 1, 1))
nwbfile = NWBFile(...)
nwbfile.subject = subject
with NWBHDF5IO("test.nwb", "w") as io:
    io.write(nwbfile)  # previously raised, now succeeds
```

The unit tests in `tests/unit/build_tests/mapper_tests/test_build_datetime.py` cover:
- scalar and array `datetime`/`date` on plain `DatasetSpec` (regression),
- `datetime` and `date` arrays through a `Data`-extending class with `data_type_inc` (the fixed case, mirroring #1311's traceback).

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?