### PR TITLE
Fix get_data_shape to use Data.data.shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # HDMF Changelog
 
-## HDMF 4.1.1 (August 12, 2025)
+## HDMF 4.1.1 (Upcoming)
 
 ### Fixed
 - Fixed copying of `TypeMap` and `TypeConfigurator`. Previously, the same global `TypeConfigurator` instance was used in all copies of a `TypeMap`. @rly [#1302](https://github.com/hdmf-dev/hdmf/pull/1302)
+- Fixed `get_data_shape` to use `Data.data.shape` instead of `Data.shape`, which may be overridden by subclasses. @rly [#1311](https://github.com/hdmf-dev/hdmf/pull/1311)
 
 ### Added
 - Added a check for a compound datatype that is not defined in the schema or spec. This is currently not supported. @mavaylon1 [#1276](https://github.com/hdmf-dev/hdmf/pull/1276)

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -824,6 +824,11 @@ def get_data_shape(data, strict_no_data_load=False):
                     shape.extend(__get_shape_helper(el))
         return tuple(shape)
 
+    # Get the shape of the underlying data if this is a Data object. Some Data subclasses may override the shape
+    # property to improve user-friendliness, but we want the actual shape of the data here.
+    if isinstance(data, Data):
+        data = data.data
+
     # NOTE: data.maxshape will fail on empty h5py.Dataset without shape or maxshape. this will be fixed in h5py 3.0
     if hasattr(data, 'maxshape'):
         return data.maxshape

--- a/tests/unit/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/utils_test/test_core_ShapeValidator.py
@@ -1,5 +1,4 @@
 import numpy as np
-from hdmf.common.table import DynamicTable, DynamicTableRegion, VectorData
 from hdmf.data_utils import ShapeValidatorResult, DataChunkIterator, assertEqualShape
 from hdmf.testing import TestCase
 
@@ -165,29 +164,6 @@ class ShapeValidatorTests(TestCase):
         self.assertTupleEqual(res.shape2, (2, 5))
         self.assertTupleEqual(res.axes1, (0, 1))
         self.assertTupleEqual(res.axes2, (0, 1))
-
-    def test_DynamicTableRegion_shape_validation(self):
-        # Create a test DynamicTable
-        dt_spec = [
-            {'name': 'foo', 'description': 'foo column'},
-            {'name': 'bar', 'description': 'bar column'},
-            {'name': 'baz', 'description': 'baz column'},
-        ]
-        dt_data = [
-            [1, 2, 3, 4, 5],
-            [10.0, 20.0, 30.0, 40.0, 50.0],
-            ['cat', 'dog', 'bird', 'fish', 'lizard']
-        ]
-        columns = [
-            VectorData(name=s['name'], description=s['description'], data=d)
-            for s, d in zip(dt_spec, dt_data)
-        ]
-        dt = DynamicTable(name="with_columns_and_data", description="a test table", columns=columns)
-        # Create test DynamicTableRegion
-        dtr = DynamicTableRegion(name='dtr', data=[1, 2, 2], description='desc', table=dt)
-        # Confirm that the shapes match
-        res = assertEqualShape(dtr, np.arange(9).reshape(3, 3))
-        self.assertTrue(res.result)
 
 
 class ShapeValidatorResultTests(TestCase):

--- a/tests/unit/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/utils_test/test_core_ShapeValidator.py
@@ -1,4 +1,5 @@
 import numpy as np
+from hdmf.container import Data
 from hdmf.data_utils import ShapeValidatorResult, DataChunkIterator, assertEqualShape
 from hdmf.testing import TestCase
 
@@ -164,6 +165,18 @@ class ShapeValidatorTests(TestCase):
         self.assertTupleEqual(res.shape2, (2, 5))
         self.assertTupleEqual(res.axes1, (0, 1))
         self.assertTupleEqual(res.axes2, (0, 1))
+
+    def test_custom_shape_definition(self):
+        class MyData(Data):
+            def __init__(self, name, data):
+                super().__init__(name, data)
+
+            @property
+            def shape(self):
+                return (3, 3)  # custom override of shape should be ignored by assertEqualShape / get_data_shape
+
+        data = MyData(name="my_data", data=np.arange(10).reshape(2, 5))
+        assertEqualShape(data, (2, 5))
 
 
 class ShapeValidatorResultTests(TestCase):


### PR DESCRIPTION
## Motivation

Fix #1317. Close #1320 (an alternate approach).

## How to test the behavior?
```
pytest
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
