### PR TITLE
Adjust extensions workflow install order

### DIFF
--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -44,7 +44,6 @@
 
 name: Run NWB Extension Tests
 on:
-  pull_request:
   schedule:
     - cron: '0 6 * * *'  # once per day at 1 AM ET, offset from other daily workflows
   workflow_dispatch:

--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -44,6 +44,7 @@
 
 name: Run NWB Extension Tests
 on:
+  pull_request:
   schedule:
     - cron: '0 6 * * *'  # once per day at 1 AM ET, offset from other daily workflows
   workflow_dispatch:
@@ -121,8 +122,9 @@ jobs:
           # Install the latest pynwb and current branch of hdmf to ensure compatibility
           cd ..
           python -m pip uninstall -y hdmf pynwb  # uninstall the other version of hdmf and pynwb
+          python -m pip install pynwb  # install latest pynwb which will install hdmf from PyPI
+          python -m pip uninstall -y hdmf  # uninstall the PyPI version of hdmf
           python -m pip install .  # reinstall current branch of hdmf
-          python -m pip install pynwb  # install latest pynwb (should be compatible with current hdmf)
           python -m pip list
           python -m pip check
 


### PR DESCRIPTION
## Motivation

Fix https://github.com/hdmf-dev/hdmf/pull/1319#discussion_r2395899972

No need to update CHANGELOG for this minor change to #1319.

## How to test the behavior?
```
n/a
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
