### PR TITLE
Deprecate unused, superfluous methods in spec module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Cross-namespace resolution: The system can now resolve specs that include types from different namespaces
   - `dtype`, `shape`, `dims`, `value`, and `default_value` in `DatasetSpec` and `AttributeSpec` are now inherited and validated from the parent data type spec
 - If `dims` are not provided in a `DatasetSpec` or `AttributeSpec`, but `shape` is provided, `dims` will be set to a list of dummy dimension names, e.g., "dim_0", "dim_1", etc. @rly [#1312](https://github.com/hdmf-dev/hdmf/pull/1312)
+- Deprecated `BaseStorageSpec.add_attribute`, `GroupSpec.add_group`, `GroupSpec.add_dataset`, and `GroupSpec.add_link`. Use `set_attribute`, `set_group`, `set_dataset`, and `set_link` instead. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
+- Deprecated unused `BaseStorageSpec.get_data_type_spec` and `BaseStorageSpec.get_namespace_spec`. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
 
 ### Added
 - Warning when `data_type_def` and `data_type_inc` are the same in a spec. @rly [#1312](https://github.com/hdmf-dev/hdmf/pull/1312)

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -611,10 +611,12 @@ class BaseStorageSpec(Spec):
 
     @classmethod
     def get_data_type_spec(cls, data_type_def):  # unused
+        warn("get_data_type_spec is deprecated and will be removed in HDMF 6.0.", DeprecationWarning)
         return AttributeSpec(cls.type_key(), 'the data type of this object', 'text', value=data_type_def)
 
     @classmethod
     def get_namespace_spec(cls):  # unused
+        warn("get_namespace_spec is deprecated and will be removed in HDMF 6.0.", DeprecationWarning)
         return AttributeSpec('namespace', 'the namespace for the data type of this object', 'text', required=False)
 
     @property
@@ -685,6 +687,8 @@ class BaseStorageSpec(Spec):
     @docval(*_attr_args)
     def add_attribute(self, **kwargs):
         ''' Add an attribute to this specification '''
+        warn("BaseStorageSpec.add_attribute is deprecated. Use BaseStorageSpec.set_attribute instead",
+             DeprecationWarning, stacklevel=2)
         spec = AttributeSpec(**kwargs)
         self.set_attribute(spec)
         return spec
@@ -1491,6 +1495,8 @@ class GroupSpec(BaseStorageSpec):
     @docval(*_dataset_args)
     def add_dataset(self, **kwargs):
         ''' Add a new specification for a dataset to this group specification '''
+        warn("GroupSpec.add_dataset is deprecated and will be removed in HDMF 6.0. Use GroupSpec.set_dataset instead.",
+             DeprecationWarning, stacklevel=2)
         spec = self.dataset_spec_cls()(**kwargs)
         self.set_dataset(spec)
         return spec
@@ -1524,6 +1530,8 @@ class GroupSpec(BaseStorageSpec):
     @docval(*_link_args)
     def add_link(self, **kwargs):
         ''' Add a new specification for a link to this group specification '''
+        warn("GroupSpec.add_link is deprecated and will be removed in HDMF 6.0. Use GroupSpec.set_link instead.",
+             DeprecationWarning, stacklevel=2)
         spec = self.link_spec_cls()(**kwargs)
         self.set_link(spec)
         return spec

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -687,7 +687,8 @@ class BaseStorageSpec(Spec):
     @docval(*_attr_args)
     def add_attribute(self, **kwargs):
         ''' Add an attribute to this specification '''
-        warn("BaseStorageSpec.add_attribute is deprecated. Use BaseStorageSpec.set_attribute instead",
+        warn("BaseStorageSpec.add_attribute is deprecated and will be removed in HDMF 6.0. "
+             "Use BaseStorageSpec.set_attribute instead.",
              DeprecationWarning, stacklevel=2)
         spec = AttributeSpec(**kwargs)
         self.set_attribute(spec)
@@ -1462,6 +1463,8 @@ class GroupSpec(BaseStorageSpec):
     @docval(*_group_args)
     def add_group(self, **kwargs):
         ''' Add a new specification for a subgroup to this group specification '''
+        warn("GroupSpec.add_group is deprecated and will be removed in HDMF 6.0. Use GroupSpec.set_group instead.",
+             DeprecationWarning, stacklevel=2)
         spec = self.__class__(**kwargs)
         self.set_group(spec)
         return spec

--- a/tests/unit/helpers/utils.py
+++ b/tests/unit/helpers/utils.py
@@ -628,19 +628,6 @@ class CustomGroupSpec(BaseStorageOverride, GroupSpec):
     def dataset_spec_cls(cls):
         return CustomDatasetSpec
 
-    @docval(*deepcopy(swap_inc_def(GroupSpec, "CustomGroupSpec")))
-    def add_group(self, **kwargs):
-        spec = CustomGroupSpec(**kwargs)
-        self.set_group(spec)
-        return spec
-
-    @docval(*deepcopy(swap_inc_def(DatasetSpec, "CustomDatasetSpec")))
-    def add_dataset(self, **kwargs):
-        """Add a new specification for a subgroup to this group specification"""
-        spec = CustomDatasetSpec(**kwargs)
-        self.set_dataset(spec)
-        return spec
-
 
 class CustomDatasetSpec(BaseStorageOverride, DatasetSpec):
     @docval(*deepcopy(swap_inc_def(DatasetSpec, "CustomDatasetSpec")))

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -98,6 +98,19 @@ class GroupSpecTests(TestCase):
         spec.set_dataset(self.datasets[0])
         self.assertIs(spec, self.datasets[0].parent)
 
+    def test_add_dataset(self):
+        group = GroupSpec(
+            doc='A test group',
+            name='root'
+        )
+        with self.assertWarns(DeprecationWarning):
+            group.add_dataset(
+                doc='A test dataset',
+                dtype='int',
+                name='dataset'
+            )
+        self.assertIsInstance(group.get_dataset('dataset'), DatasetSpec)
+
     def test_set_link(self):
         group = GroupSpec(
             doc='A test group',
@@ -117,11 +130,12 @@ class GroupSpecTests(TestCase):
             doc='A test group',
             name='root'
         )
-        group.add_link(
-            'A test link',
-            'LinkTarget',
-            name='link_name'
-        )
+        with self.assertWarns(DeprecationWarning):
+            group.add_link(
+                doc='A test link',
+                target_type='LinkTarget',
+                name='link_name'
+            )
         self.assertIsInstance(group.get_link('link_name'), LinkSpec)
 
     def test_set_group(self):
@@ -141,12 +155,12 @@ class GroupSpecTests(TestCase):
             doc='A test group',
             name='root'
         )
-        group.add_group(
-            'A test group',
-            name='subgroup'
-        )
+        with self.assertWarns(DeprecationWarning):
+            group.add_group(
+                'A test group',
+                name='subgroup'
+            )
         self.assertIsInstance(group.get_group('subgroup'), GroupSpec)
-
 
     def assertDatasetsEqual(self, spec1, spec2):
         spec1_dsets = spec1.datasets
@@ -173,7 +187,8 @@ class GroupSpecTests(TestCase):
                          datasets=self.datasets,
                          linkable=False)
         for attrspec in self.attributes:
-            spec.add_attribute(**attrspec)
+            with self.assertWarns(DeprecationWarning):
+                spec.add_attribute(**attrspec)
         self.assertListEqual(spec['attributes'], self.attributes)
         self.assertListEqual(spec['datasets'], self.datasets)
         self.assertNotIn('data_type_def', spec)
@@ -255,11 +270,13 @@ class GroupSpecTests(TestCase):
 
     def test_get_data_type_spec(self):
         expected = AttributeSpec('data_type', 'the data type of this object', 'text', value='MyType')
-        self.assertDictEqual(GroupSpec.get_data_type_spec('MyType'), expected)
+        with self.assertWarns(DeprecationWarning):
+            self.assertDictEqual(GroupSpec.get_data_type_spec('MyType'), expected)
 
     def test_get_namespace_spec(self):
         expected = AttributeSpec('namespace', 'the namespace for the data type of this object', 'text', required=False)
-        self.assertDictEqual(GroupSpec.get_namespace_spec(), expected)
+        with self.assertWarns(DeprecationWarning):
+            self.assertDictEqual(GroupSpec.get_namespace_spec(), expected)
 
     def test_build_warn_extra_args(self):
         spec_dict = {

--- a/tests/unit/spec_tests/test_spec_write.py
+++ b/tests/unit/spec_tests/test_spec_write.py
@@ -1,9 +1,8 @@
 import datetime
 import os
 
-from hdmf.spec.namespace import SpecNamespace, NamespaceCatalog
-from hdmf.spec.spec import GroupSpec
-from hdmf.spec.write import NamespaceBuilder, YAMLSpecWriter, export_spec
+from hdmf.spec import SpecNamespace, NamespaceCatalog, GroupSpec, DatasetSpec, NamespaceBuilder, export_spec
+from hdmf.spec.write import YAMLSpecWriter
 from hdmf.testing import TestCase
 
 
@@ -33,14 +32,10 @@ class TestSpec(TestCase):
 
         ext2 = GroupSpec('An extension of a DataSeries interface',
                          attributes=[],
-                         datasets=[],
+                         datasets=[DatasetSpec(doc='test', dtype='float', name='testdata')],
                          groups=[],
                          data_type_inc='MyDataSeries',
                          data_type_def='MyExtendedMyDataSeries')
-
-        ext2.add_dataset(doc='test',
-                         dtype='float',
-                         name='testdata')
 
         self.data_types = [ext1, ext2]
 


### PR DESCRIPTION
The `hdmf.spec.spec` module contain a number of unused methods and convenience methods that as far as I know are used only in tests. They add unnecessary upkeep and can be deprecated and removed.
- `BaseStorageSpec.add_attribute` (`BaseStorageSpec.set_attribute` exists)
- `GroupSpec.add_group` (`set_group` exists)
- `GroupSpec.add_dataset` (`set_dataset` exists)
- `GroupSpec.add_link` (`set_link` exists)
- `BaseStorageSpec.get_data_type_spec` - not sure why this exists
- `BaseStorageSpec.get_namespace_spec` - same as above
 
## How to test the behavior?
```
pytest
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
