### PR TITLE
minor modifications to repr so LINDI files render correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed copying of `TypeMap` and `TypeConfigurator`. Previously, the same global `TypeConfigurator` instance was used in all copies of a `TypeMap`. @rly [#1302](https://github.com/hdmf-dev/hdmf/pull/1302)
 - Fixed `get_data_shape` to use `Data.data.shape` instead of `Data.shape`, which may be overridden by subclasses. @rly [#1311](https://github.com/hdmf-dev/hdmf/pull/1311)
+- Fixed HTML representation of datasets when reading from LINDI. @bendichter [#1335](https://github.com/hdmf-dev/hdmf/pull/1335)
 
 ### Added
 - Added a check for a compound datatype that is not defined in the schema or spec. This is currently not supported. @mavaylon1 [#1276](https://github.com/hdmf-dev/hdmf/pull/1276)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ termset = [
 # development dependencies
 test = [
     "codespell",
+    "lindi",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ termset = [
 # development dependencies
 test = [
     "codespell",
-    "lindi",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1499,20 +1499,27 @@ class HDF5IO(HDMFIO):
         if isinstance(dataset, h5py.Dataset):
             dataset_type = "HDF5 dataset"
             # get info from hdf5 dataset
-            compressed_size = dataset.id.get_storage_size()
-            if hasattr(dataset, "nbytes"):  # TODO: Remove this after h5py minimal version is larger than 3.0
-                uncompressed_size = dataset.nbytes
-            else:
-                uncompressed_size = dataset.size * dataset.dtype.itemsize
-            compression_ratio = uncompressed_size / compressed_size if compressed_size != 0 else "undefined"
+            uncompressed_size = dataset.size * dataset.dtype.itemsize
 
-            hdf5_info_dict = {
-                            "Chunk shape": dataset.chunks,
-                            "Compression": dataset.compression,
-                            "Compression opts": dataset.compression_opts,
-                            "Compression ratio": compression_ratio,
-                            }
-            array_info_dict.update(hdf5_info_dict)
+            array_info_dict.update(
+                {
+                    "Chunk shape": dataset.chunks,
+                    "Compression": dataset.compression,
+                    "Compression opts": dataset.compression_opts,
+                    "Uncompressed size (bytes)": uncompressed_size,
+                }
+            )
+            try:  # Note: get_storage_size() may not be available for all dataset types (e.g., LINDI)
+                compressed_size = dataset.id.get_storage_size()
+                compression_ratio = uncompressed_size / compressed_size if compressed_size != 0 else "undefined"
+                array_info_dict.update({
+                    "Compressed size (bytes)": compressed_size,
+                    "Compression ratio": compression_ratio,
+                })
+            except (AttributeError, TypeError):
+                # If get_storage_size() is not available (e.g., for LINDI datasets),
+                # just skip the HDF5-specific compression info
+                pass
 
         elif isinstance(dataset, np.ndarray):
             dataset_type = "NumPy array"

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1518,7 +1518,7 @@ class HDF5IO(HDMFIO):
                 })
             except (AttributeError, TypeError):
                 # If get_storage_size() is not available (e.g., for LINDI datasets),
-                # just skip the HDF5-specific compression info
+                # just skip the compressed size and compression ratio
                 pass
 
         elif isinstance(dataset, np.ndarray):

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -953,7 +953,7 @@ def generate_array_html_repr(array_info_dict, array, dataset_type=None):
     # Heuristic for displaying data
     array_is_small = array_size_bytes < 1024 * 0.1 # 10 % a kilobyte to display the array
     if array_is_small:
-        repr_html += "<br>" + str(np.asarray(array))
+        repr_html += "<br>" + str(array[()])
 
     return repr_html
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -575,7 +575,7 @@ class TestHTMLRepr(TestCase):
         # Create a LINDI file directly (using .lindi.tar format for local files)
         with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='w') as f:
             f.attrs['test_attr'] = 'test_value'
-            ds = f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64))
+            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64))
 
         # Open the LINDI file and test HTML generation
         with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='r') as f:
@@ -597,10 +597,10 @@ class TestHTMLRepr(TestCase):
             # The HTML should be generated without errors even though LINDI datasets
             # may not have all the same methods as regular HDF5 datasets
             self.assertIsInstance(result_html, str)
-            self.assertGreater(len(result_html), 0)
 
         # Cleanup
         os.remove('temp_for_lindi.lindi.tar')
+
 
 class TestData(TestCase):
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -522,10 +522,10 @@ class TestHTMLRepr(TestCase):
                 '</th><td style="text-align: left">32.00 bytes</td></tr><tr><th style="text-align: left">Chunk shape'
                 '</th><td style="text-align: left">None</td></tr><tr><th style="text-align: left">Compression</th><td '
                 'style="text-align: left">None</td></tr><tr><th style="text-align: left">Compression opts</th><td '
-                'style="text-align: left">None</td></tr><tr><th style="text-align: left">Uncompressed size (bytes)</th><td '
-                'style="text-align: left">32</td></tr><tr><th style="text-align: left">Compressed size (bytes)</th><td '
-                'style="text-align: left">32</td></tr><tr><th style="text-align: left">Compression ratio</th><td '
-                'style="text-align: left">1.0</td></tr></tbody></table><br>[1 2 3 4]'
+                'style="text-align: left">None</td></tr><tr><th style="text-align: left">Uncompressed size (bytes)'
+                '</th><td style="text-align: left">32</td></tr><tr><th style="text-align: left">Compressed size '
+                '(bytes)</th><td style="text-align: left">32</td></tr><tr><th style="text-align: left">Compression '
+                'ratio</th><td style="text-align: left">1.0</td></tr></tbody></table><br>[1 2 3 4]'
             )
 
             self.assertIn(expected_html_table, obj._repr_html_())

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -571,29 +571,29 @@ class TestHTMLRepr(TestCase):
     def test_repr_html_lindi_dataset(self):
         """Test HTML repr for LINDI datasets without get_storage_size method."""
         import lindi
-        
+
         # Create a LINDI file directly (using .lindi.tar format for local files)
         with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='w') as f:
             f.attrs['test_attr'] = 'test_value'
             ds = f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64))
-        
+
         # Open the LINDI file and test HTML generation
         with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='r') as f:
             lindi_dataset = f['my_dataset']
-            
+
             # Test the generate_dataset_html method directly
             result_html = HDF5IO.generate_dataset_html(lindi_dataset)
-            
+
             # Expected HTML should include basic fields
             expected_fields = [
                 'Data type',
                 'Shape',
                 'Array size',
             ]
-            
+
             for field in expected_fields:
                 self.assertIn(field, result_html)
-            
+
             # The HTML should be generated without errors even though LINDI datasets
             # may not have all the same methods as regular HDF5 datasets
             self.assertIsInstance(result_html, str)

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -568,6 +568,40 @@ class TestHTMLRepr(TestCase):
 
         os.remove('array_data.h5')
 
+    def test_repr_html_lindi_dataset(self):
+        """Test HTML repr for LINDI datasets without get_storage_size method."""
+        import lindi
+        
+        # Create a LINDI file directly (using .lindi.tar format for local files)
+        with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='w') as f:
+            f.attrs['test_attr'] = 'test_value'
+            ds = f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64))
+        
+        # Open the LINDI file and test HTML generation
+        with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='r') as f:
+            lindi_dataset = f['my_dataset']
+            
+            # Test the generate_dataset_html method directly
+            result_html = HDF5IO.generate_dataset_html(lindi_dataset)
+            
+            # Expected HTML should include basic fields
+            expected_fields = [
+                'Data type',
+                'Shape',
+                'Array size',
+            ]
+            
+            for field in expected_fields:
+                self.assertIn(field, result_html)
+            
+            # The HTML should be generated without errors even though LINDI datasets
+            # may not have all the same methods as regular HDF5 datasets
+            self.assertIsInstance(result_html, str)
+            self.assertGreater(len(result_html), 0)
+
+        # Cleanup
+        os.remove('temp_for_lindi.lindi.tar')
+
 class TestData(TestCase):
 
     def test_constructor_scalar(self):

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -522,7 +522,9 @@ class TestHTMLRepr(TestCase):
                 '</th><td style="text-align: left">32.00 bytes</td></tr><tr><th style="text-align: left">Chunk shape'
                 '</th><td style="text-align: left">None</td></tr><tr><th style="text-align: left">Compression</th><td '
                 'style="text-align: left">None</td></tr><tr><th style="text-align: left">Compression opts</th><td '
-                'style="text-align: left">None</td></tr><tr><th style="text-align: left">Compression ratio</th><td '
+                'style="text-align: left">None</td></tr><tr><th style="text-align: left">Uncompressed size (bytes)</th><td '
+                'style="text-align: left">32</td></tr><tr><th style="text-align: left">Compressed size (bytes)</th><td '
+                'style="text-align: left">32</td></tr><tr><th style="text-align: left">Compression ratio</th><td '
                 'style="text-align: left">1.0</td></tr></tbody></table><br>[1 2 3 4]'
             )
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -569,37 +569,56 @@ class TestHTMLRepr(TestCase):
         os.remove('array_data.h5')
 
     def test_repr_html_lindi_dataset(self):
-        """Test HTML repr for LINDI datasets without get_storage_size method."""
-        import lindi
+        """Test HTML repr for datasets without get_storage_size method (e.g., LINDI datasets)."""
+        from unittest.mock import PropertyMock, patch
+        import h5py
 
-        # Create a LINDI file directly (using .lindi.tar format for local files)
-        with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='w') as f:
-            f.attrs['test_attr'] = 'test_value'
+        # Create a regular HDF5 dataset using h5py
+        with h5py.File('array_data.h5', 'w') as f:
             f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4, 5, 6, 7, 8], dtype=np.int64))
 
-        # Open the LINDI file and test HTML generation
-        with lindi.LindiH5pyFile.from_lindi_file('temp_for_lindi.lindi.tar', mode='r') as f:
-            lindi_dataset = f['my_dataset']
+        # Read the dataset and mock the id to simulate LINDI behavior
+        with h5py.File('array_data.h5', 'r') as f:
+            dataset = f['my_dataset']
+            original_id = dataset.id
 
-            # Test the generate_dataset_html method directly
-            result_html = HDF5IO.generate_dataset_html(lindi_dataset)
+            # Create a wrapper that has all attributes except get_storage_size
+            class MockDatasetId:
+                """Mock DatasetID that raises AttributeError for get_storage_size."""
+                def __getattr__(self, name):
+                    if name == 'get_storage_size':
+                        raise AttributeError(f"'{type(self).__name__}' object has no attribute 'get_storage_size'")
+                    return getattr(original_id, name)
 
-            # Expected HTML should include basic fields
-            expected_fields = [
-                'Data type',
-                'Shape',
-                'Array size',
-            ]
+            mock_id = MockDatasetId()
 
-            for field in expected_fields:
-                self.assertIn(field, result_html)
+            # Patch the dataset's id property
+            with patch.object(type(dataset), 'id', new_callable=PropertyMock) as mock_id_prop:
+                mock_id_prop.return_value = mock_id
 
-            # The HTML should be generated without errors even though LINDI datasets
-            # may not have all the same methods as regular HDF5 datasets
-            self.assertIsInstance(result_html, str)
+                # Test the generate_dataset_html method directly
+                result_html = HDF5IO.generate_dataset_html(dataset)
+
+                # Expected HTML should include basic fields
+                expected_fields = [
+                    'Data type',
+                    'Shape',
+                    'Array size',
+                ]
+
+                for field in expected_fields:
+                    self.assertIn(field, result_html)
+
+                # The HTML should be generated without errors even though the dataset
+                # doesn't have get_storage_size method (like LINDI datasets)
+                self.assertIsInstance(result_html, str)
+
+                # Should NOT include compressed size or compression ratio since get_storage_size is not available
+                self.assertNotIn('Compressed size (bytes)', result_html)
+                self.assertNotIn('Compression ratio', result_html)
 
         # Cleanup
-        os.remove('temp_for_lindi.lindi.tar')
+        os.remove('array_data.h5')
 
 
 class TestData(TestCase):


### PR DESCRIPTION
## Motivation

fix #1266

## How to test the behavior?
```python
import pynwb
import lindi

# Load https://api.dandiarchive.org/api/assets/2b9e441b-56bc-4be2-893e-0e02d22d239d/download/
f = lindi.LindiH5pyFile.from_lindi_file("https://lindi.neurosift.org/dandi/dandisets/000582/assets/2b9e441b-56bc-4be2-893e-0e02d22d239d/nwb.lindi.json")
nwb = pynwb.NWBHDF5IO(file=f, mode='r').read()

nwb._repr_html_()
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
