### PR TITLE
Fix validation of variable lengths string datasets in Zarr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 4.1.3 (Upcoming)
+
+### Fixed
+- Fixed bug when validating string datasets in NWB Zarr files. @stephprince [#1348](https://github.com/hdmf-dev/hdmf/pull/1348)
+
 ## HDMF 4.1.2 (November 7, 2025)
 
 ### Fixed

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -116,6 +116,42 @@ class EmptyArrayError(Exception):
     pass
 
 
+def _get_type_compound_dtype(data, builder_dtype):
+    """Helper function to get type information for compound dtypes."""
+    dtypes = []
+    string_formats = []
+    for i in range(len(builder_dtype)):
+        if len(np.shape(data)) == 0:
+            dtype, string_format = get_type(data[()][i])
+        else:
+            dtype, string_format = get_type(data[0][i])
+        dtypes.append(dtype)
+        string_formats.append(string_format)
+    return dtypes, string_formats
+
+
+def _get_type_from_dtype_attr(data, builder_dtype):
+    """Helper function to get type from data with dtype attribute (h5py.Dataset, zarr.Array, etc.)."""
+    # Handle variable-length data with vlen metadata (HDF5 style)
+    if data.dtype.metadata is not None and data.dtype.metadata.get('vlen') is not None:
+        if len(data) > 0:
+            return get_type(data[0], builder_dtype)
+        # Empty string array
+        if data.dtype.metadata["vlen"] is str:
+            return "utf", None
+        # Undetermined variable length data type
+        raise EmptyArrayError()  # pragma: no cover
+
+    # Handle object dtype (zarr style variable-length strings)
+    if data.dtype.kind == 'O':
+        if len(data) > 0:
+            return get_type(data[0], builder_dtype)
+        return "utf", None
+
+    # Standard data type (not compound or vlen)
+    return data.dtype, None
+
+
 def get_type(data, builder_dtype=None):
     """Return a tuple of (the string representation of the type, the format of the string data) for the given data."""
     # String data
@@ -134,54 +170,25 @@ def get_type(data, builder_dtype=None):
     elif isinstance(data, np.ndarray) and len(data.dtype) <= 1:
         if data.size > 0:
             return get_type(data[0], builder_dtype)
-        else:
-            raise EmptyArrayError()
+        raise EmptyArrayError()
     # Numpy bool data
     elif isinstance(data, np.bool_):
         return 'bool', None
     if not hasattr(data, '__len__'):
         return type(data).__name__, None
     # Case for h5py.Dataset, zarr.Array, and other I/O specific array types
-    else:
-        # Compound dtype
-        if builder_dtype and isinstance(builder_dtype, list):
-            dtypes = []
-            string_formats = []
-            for i in range(len(builder_dtype)):
-                if len(np.shape(data)) == 0:
-                    dtype, string_format = get_type(data[()][i])
-                else:
-                    dtype, string_format = get_type(data[0][i])
-                dtypes.append(dtype)
-                string_formats.append(string_format)
-            return dtypes, string_formats
-        # Object has 'dtype' attribute, e.g., an h5py.Dataset
-        if hasattr(data, 'dtype'):
-            if data.dtype.metadata is not None and data.dtype.metadata.get('vlen') is not None:
-                # Try to determine dtype from the first array element
-                if len(data) > 0:
-                    return get_type(data[0], builder_dtype)
-                # Empty array
-                else:
-                    # Empty string array
-                    if data.dtype.metadata["vlen"] is str:
-                        return "utf", None
-                    # Undetermined variable length data type.
-                    else:                        # pragma: no cover
-                        raise EmptyArrayError()  # pragma: no cover
-            elif data.dtype.kind == 'O':
-                if len(data) > 0:
-                    return get_type(data[0], builder_dtype)
-                else:
-                    return "utf", None
-            # Standard data type (i.e., not compound or vlen)
-            else:
-                return data.dtype, None
-        # If all else has failed, try to determine the datatype from the first element of the array
-        if len(data) > 0:
-            return get_type(data[0], builder_dtype)
-        else:
-            raise EmptyArrayError()
+    # Compound dtype
+    if builder_dtype and isinstance(builder_dtype, list):
+        return _get_type_compound_dtype(data, builder_dtype)
+
+    # Object has 'dtype' attribute, e.g., h5py.Dataset or zarr.Array
+    if hasattr(data, 'dtype'):
+        return _get_type_from_dtype_attr(data, builder_dtype)
+
+    # If all else has failed, try to determine the datatype from the first element of the array
+    if len(data) > 0:
+        return get_type(data[0], builder_dtype)
+    raise EmptyArrayError()
 
 
 def check_shape(expected, received):

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 from copy import copy
 from itertools import chain
 from collections import defaultdict, OrderedDict
+from typing import Any, Optional, Union
 
 import numpy as np
 
@@ -116,7 +117,7 @@ class EmptyArrayError(Exception):
     pass
 
 
-def _get_type_compound_dtype(data, builder_dtype):
+def _get_type_compound_dtype(data: Any, builder_dtype: list) -> tuple[list, list]:
     """Helper function to get type information for compound dtypes."""
     dtypes = []
     string_formats = []
@@ -130,7 +131,7 @@ def _get_type_compound_dtype(data, builder_dtype):
     return dtypes, string_formats
 
 
-def _get_type_from_dtype_attr(data, builder_dtype):
+def _get_type_from_dtype_attr(data: Any, builder_dtype: Optional[list]) -> tuple[Union[str, np.dtype], Optional[str]]:
     """Helper function to get type from data with dtype attribute (h5py.Dataset, zarr.Array, etc.)."""
     # Handle variable-length data with vlen metadata (HDF5 style)
     if data.dtype.metadata is not None and data.dtype.metadata.get('vlen') is not None:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -141,7 +141,7 @@ def get_type(data, builder_dtype=None):
         return 'bool', None
     if not hasattr(data, '__len__'):
         return type(data).__name__, None
-    # Case for h5py.Dataset and other I/O specific array types
+    # Case for h5py.Dataset, zarr.Array, and other I/O specific array types
     else:
         # Compound dtype
         if builder_dtype and isinstance(builder_dtype, list):
@@ -169,6 +169,11 @@ def get_type(data, builder_dtype=None):
                     # Undetermined variable length data type.
                     else:                        # pragma: no cover
                         raise EmptyArrayError()  # pragma: no cover
+            elif data.dtype.kind == 'O':
+                if len(data) > 0:
+                    return get_type(data[0], builder_dtype)
+                else:
+                    return "utf", None
             # Standard data type (i.e., not compound or vlen)
             else:
                 return data.dtype, None

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1649,7 +1649,9 @@ class TestObjectDtypeArrays(TestCase):
         self.set_up_spec()
 
         # Create a zarr array with object dtype containing bytes (ASCII strings)
-        zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes), dtype=object, object_codec=numcodecs.VLenBytes())
+        zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes), 
+                                dtype=object, 
+                                object_codec=numcodecs.VLenBytes())
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
                                    datasets=[DatasetBuilder('data', zarr_array)])

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1705,7 +1705,7 @@ class TestVlenStringData(ValidatorTestBase):
         # Create hdf5 dataset with UTF-8 string data
         # convert to StrDataset because data read directly from f.create_dataset will be bytes
         f = h5py.File(name='test_string_dtype_validation.h5', mode='w', driver='core', backing_store=False)
-        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8') 
+        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8')
         foo_builder = GroupBuilder('my_foo',
                                attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
                                datasets=[DatasetBuilder('data', dset)])

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1623,7 +1623,7 @@ class TestObjectDtypeArrays(TestCase):
         self.vmap = ValidatorMap(self.namespace)
 
     @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
-    def test_non_empty_object_dtype_array(self):
+    def test_object_dtype_array_utf(self):
         """Test that validator can determine dtype for non-empty zarr.Array with object dtype"""
         import zarr
         import numcodecs
@@ -1638,6 +1638,23 @@ class TestObjectDtypeArrays(TestCase):
                                    datasets=[DatasetBuilder('data', zarr_array)])
         results = self.vmap.validate(bar_builder)
         # Should pass validation - object array with strings should be detected as 'utf' type
+        self.assertEqual(len(results), 0)
+
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_object_dtype_array_ascii_bytes(self):
+        """Test that validator can determine dtype for zarr.Array with object dtype containing ASCII bytes"""
+        import zarr
+        import numcodecs
+
+        self.set_up_spec()
+
+        # Create a zarr array with object dtype containing bytes (ASCII strings)
+        zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes), dtype=object, object_codec=numcodecs.VLenBytes())
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
+                                   datasets=[DatasetBuilder('data', zarr_array)])
+        results = self.vmap.validate(bar_builder)
+        # Should pass validation - object array with bytes should be detected as 'ascii' type
         self.assertEqual(len(results), 0)
 
     @skipIf(not ZARR_INSTALLED, "Zarr is not installed")

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1662,14 +1662,14 @@ class TestVlenStringData(ValidatorTestBase):
         import numcodecs
 
         # Create a zarr array with object dtype containing strings
-        zarr_array = zarr.array(['string1', 'string2', 'string3'], 
-                                dtype=object, 
+        zarr_array = zarr.array(['string1', 'string2', 'string3'],
+                                dtype=object,
                                 object_codec=numcodecs.VLenUTF8())
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
                                    datasets=[DatasetBuilder('data', zarr_array)])
         results = self.vmap.validate(bar_builder)
-        
+
         # Should pass validation - object array with strings should be detected as 'utf' type
         self.assertEqual(len(results), 0)
 

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1608,19 +1608,52 @@ class TestShapeValidation(ValidatorTestBase):
         self.assertNotIsInstance(result[0], ShapeError)
 
 
-class TestObjectDtypeArrays(TestCase):
-    """Test validation of arrays with object dtype (e.g., zarr variable length strings)"""
+class TestVlenStringData(ValidatorTestBase):
+    """
+    Test validation of variable length string data across backends.
 
-    def set_up_spec(self):
-        spec_catalog = SpecCatalog()
-        spec = GroupSpec('A test group specification with a data type',
-                         data_type_def='Bar',
-                         datasets=[DatasetSpec('an example dataset', 'text', name='data', shape=(None,))],
-                         attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
-        spec_catalog.register_spec(spec, 'test.yaml')
-        self.namespace = SpecNamespace(
-            'a test namespace', CORE_NAMESPACE, [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
-        self.vmap = ValidatorMap(self.namespace)
+    HDF5 datasets and zarr arrays store variable-length strings different.
+    HDF5 uses vlen metadata and Zarr uses an object dtype.
+    """
+
+    def setUp(self):
+        self.hdf5_filename = 'test_string_dtype_validation.h5'
+        super().setUp()
+
+    def tearDown(self):
+        remove_test_file(self.hdf5_filename)
+        super().tearDown()
+
+    def getSpecs(self):
+        # spec with 'bytes' (ASCII) dtype requirement
+        foo = GroupSpec('A test group specification with a data type',
+                        data_type_def='Foo',
+                        datasets=[DatasetSpec('an example dataset', 'bytes', name='data', shape=(None,))],
+                        attributes=[AttributeSpec('attr1', 'an example attribute', 'text')])
+        # spec with 'text' dtype requirement
+        bar = GroupSpec('A test group specification with a data type',
+                        data_type_def='Bar',
+                        datasets=[DatasetSpec('an example dataset', 'text', name='data', shape=(None,))],
+                        attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
+
+        return (foo, bar)
+
+    def runBuilderRoundTrip(self, builder, expected_errors=0):
+        """Executes a round-trip test for a builder (to write to HDF5 file and read back for validation tests)"""
+        ns_catalog = NamespaceCatalog()
+        ns_catalog.add_namespace(self.namespace.name, self.namespace)
+        typemap = TypeMap(ns_catalog)
+        self.manager = BuildManager(typemap)
+
+        with HDF5IO(self.hdf5_filename, manager=self.manager, mode='w') as write_io:
+            write_io.write_builder(builder)
+
+        with HDF5IO(self.hdf5_filename, manager=self.manager, mode='r') as read_io:
+            read_builder = read_io.read_builder()
+            results = self.vmap.validate(read_builder)
+            if expected_errors == 0:
+                self.assertEqual(len(results), 0, results)
+            return results
 
     @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_object_dtype_array_utf(self):
@@ -1628,15 +1661,15 @@ class TestObjectDtypeArrays(TestCase):
         import zarr
         import numcodecs
 
-        self.set_up_spec()
-
         # Create a zarr array with object dtype containing strings
-        # Zarr uses object dtype for variable-length strings, unlike HDF5 which uses vlen metadata
-        zarr_array = zarr.array(['string1', 'string2', 'string3'], dtype=object, object_codec=numcodecs.VLenUTF8())
+        zarr_array = zarr.array(['string1', 'string2', 'string3'], 
+                                dtype=object, 
+                                object_codec=numcodecs.VLenUTF8())
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
                                    datasets=[DatasetBuilder('data', zarr_array)])
         results = self.vmap.validate(bar_builder)
+        
         # Should pass validation - object array with strings should be detected as 'utf' type
         self.assertEqual(len(results), 0)
 
@@ -1645,8 +1678,6 @@ class TestObjectDtypeArrays(TestCase):
         """Test that validator can determine dtype for zarr.Array with object dtype containing ASCII bytes"""
         import zarr
         import numcodecs
-
-        self.set_up_spec()
 
         # Create a zarr array with object dtype containing bytes (ASCII strings)
         zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes),
@@ -1665,8 +1696,6 @@ class TestObjectDtypeArrays(TestCase):
         import zarr
         import numcodecs
 
-        self.set_up_spec()
-
         # Create an empty zarr array with object dtype
         empty_zarr_array = zarr.array([], dtype=object, object_codec=numcodecs.VLenUTF8())
         bar_builder = GroupBuilder('my_bar',
@@ -1675,3 +1704,34 @@ class TestObjectDtypeArrays(TestCase):
         results = self.vmap.validate(bar_builder)
         # Should pass validation - empty object array defaults to 'utf' type
         self.assertEqual(len(results), 0)
+
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_utf8_for_ascii_zarr(self):
+        """Test that validator does not allow UTF-8 data where ASCII is specified for zarr object dtype arrays"""
+        import zarr
+        import numcodecs
+
+        # Create a zarr array with UTF-8 strings
+        zarr_array = zarr.array(['string1', 'string2', 'string3'], dtype=object, object_codec=numcodecs.VLenUTF8())
+        bar_builder = GroupBuilder('my_foo',
+                                   attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
+                                   datasets=[DatasetBuilder('data', zarr_array)])
+        results = self.vmap.validate(bar_builder)
+
+        # Should fail validation - UTF-8 strings should not be allowed where bytes/ASCII is specified
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], DtypeError)
+        self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
+
+    def test_utf8_for_ascii_hdf5(self):
+        """Test that validator does not allow UTF-8 data where ASCII is specified for HDF5 vlen strings"""
+        # Create builder with UTF-8 string data and run round trip validation
+        builder = GroupBuilder('my_foo',
+                               attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
+                               datasets=[DatasetBuilder('data', ['string1', 'string2', 'string3'])])
+        results = self.runBuilderRoundTrip(builder, expected_errors=1)
+
+        # Should fail validation - UTF-8 strings should not be allowed where bytes/ASCII is specified
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], DtypeError)
+        self.assertEqual("Foo/data (data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1713,7 +1713,7 @@ class TestVlenStringData(ValidatorTestBase):
         # Create hdf5 dataset with UTF-8 string data
         # convert to StrDataset because data read directly from f.create_dataset will be bytes
         f = h5py.File(name=self.hdf5_filename, mode='w', driver='core', backing_store=False)
-        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8') 
+        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8')
         foo_builder = GroupBuilder('my_foo',
                                attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
                                datasets=[DatasetBuilder('data', dset)])

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, date
-from unittest import mock, skip
+from unittest import mock, skip, skipIf
 
 import numpy as np
 from dateutil.tz import tzlocal
@@ -13,6 +13,7 @@ from hdmf.validate import ValidatorMap
 from hdmf.validate.errors import (DtypeError, MissingError, ExpectedArrayError, MissingDataType,
                                   IncorrectQuantityError, IllegalLinkError, ShapeError)
 from hdmf.backends.hdf5 import HDF5IO
+from hdmf.utils import ZARR_INSTALLED
 
 CORE_NAMESPACE = 'test_core'
 
@@ -1605,3 +1606,53 @@ class TestShapeValidation(ValidatorTestBase):
         # Should be ExpectedArrayError, not ShapeError
         self.assertIsInstance(result[0], ExpectedArrayError)
         self.assertNotIsInstance(result[0], ShapeError)
+
+    
+class TestObjectDtypeArrays(TestCase):
+    """Test validation of arrays with object dtype (e.g., zarr variable length strings)"""
+
+    def set_up_spec(self):
+        spec_catalog = SpecCatalog()
+        spec = GroupSpec('A test group specification with a data type',
+                         data_type_def='Bar',
+                         datasets=[DatasetSpec('an example dataset', 'text', name='data', shape=(None,))],
+                         attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
+        spec_catalog.register_spec(spec, 'test.yaml')
+        self.namespace = SpecNamespace(
+            'a test namespace', CORE_NAMESPACE, [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
+        self.vmap = ValidatorMap(self.namespace)
+
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")    
+    def test_non_empty_object_dtype_array(self):
+        """Test that validator can determine dtype for non-empty zarr.Array with object dtype"""
+        import zarr
+        import numcodecs
+
+        self.set_up_spec()
+
+        # Create a zarr array with object dtype containing strings
+        # Zarr uses object dtype for variable-length strings, unlike HDF5 which uses vlen metadata
+        zarr_array = zarr.array(['string1', 'string2', 'string3'], dtype=object, object_codec=numcodecs.VLenUTF8())
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
+                                   datasets=[DatasetBuilder('data', zarr_array)])
+        results = self.vmap.validate(bar_builder)
+        # Should pass validation - object array with strings should be detected as 'utf' type
+        self.assertEqual(len(results), 0)
+
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")    
+    def test_empty_object_dtype_array(self):
+        """Test that validator can determine dtype for empty zarr.Array with object dtype"""
+        import zarr
+        import numcodecs
+
+        self.set_up_spec()
+
+        # Create an empty zarr array with object dtype
+        empty_zarr_array = zarr.array([], dtype=object, object_codec=numcodecs.VLenUTF8())
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},
+                                   datasets=[DatasetBuilder('data', empty_zarr_array)])
+        results = self.vmap.validate(bar_builder)
+        # Should pass validation - empty object array defaults to 'utf' type
+        self.assertEqual(len(results), 0)

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1649,8 +1649,8 @@ class TestObjectDtypeArrays(TestCase):
         self.set_up_spec()
 
         # Create a zarr array with object dtype containing bytes (ASCII strings)
-        zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes), 
-                                dtype=object, 
+        zarr_array = zarr.array(np.array(['string1', 'string2'], dtype=bytes),
+                                dtype=object,
                                 object_codec=numcodecs.VLenBytes())
         bar_builder = GroupBuilder('my_bar',
                                    attributes={'data_type': 'Bar', 'attr1': 'a string attribute'},

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import datetime, date
 from unittest import mock, skip, skipIf
 
+import h5py
 import numpy as np
 from dateutil.tz import tzlocal
 from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder, TypeMap, BuildManager
@@ -13,7 +14,7 @@ from hdmf.validate import ValidatorMap
 from hdmf.validate.errors import (DtypeError, MissingError, ExpectedArrayError, MissingDataType,
                                   IncorrectQuantityError, IllegalLinkError, ShapeError)
 from hdmf.backends.hdf5 import HDF5IO
-from hdmf.utils import ZARR_INSTALLED
+from hdmf.utils import ZARR_INSTALLED, StrDataset
 
 CORE_NAMESPACE = 'test_core'
 
@@ -1639,23 +1640,6 @@ class TestVlenStringData(ValidatorTestBase):
 
         return (foo, bar)
 
-    def runBuilderRoundTrip(self, builder, expected_errors=0):
-        """Executes a round-trip test for a builder (to write to HDF5 file and read back for validation tests)"""
-        ns_catalog = NamespaceCatalog()
-        ns_catalog.add_namespace(self.namespace.name, self.namespace)
-        typemap = TypeMap(ns_catalog)
-        self.manager = BuildManager(typemap)
-
-        with HDF5IO(self.hdf5_filename, manager=self.manager, mode='w') as write_io:
-            write_io.write_builder(builder)
-
-        with HDF5IO(self.hdf5_filename, manager=self.manager, mode='r') as read_io:
-            read_builder = read_io.read_builder()
-            results = self.vmap.validate(read_builder)
-            if expected_errors == 0:
-                self.assertEqual(len(results), 0, results)
-            return results
-
     @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_object_dtype_array_utf(self):
         """Test that validator can determine dtype for non-empty zarr.Array with object dtype"""
@@ -1726,13 +1710,16 @@ class TestVlenStringData(ValidatorTestBase):
 
     def test_utf8_for_ascii_hdf5(self):
         """Test that validator does not allow UTF-8 data where ASCII is specified for HDF5 vlen strings"""
-        # Create builder with UTF-8 string data and run round trip validation
-        builder = GroupBuilder('my_foo',
+        # Create hdf5 dataset with UTF-8 string data
+        # convert to StrDataset because data read directly from f.create_dataset will be bytes
+        f = h5py.File(name=self.hdf5_filename, mode='w', driver='core', backing_store=False)
+        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8') 
+        foo_builder = GroupBuilder('my_foo',
                                attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
-                               datasets=[DatasetBuilder('data', ['string1', 'string2', 'string3'])])
-        results = self.runBuilderRoundTrip(builder, expected_errors=1)
+                               datasets=[DatasetBuilder('data', dset)])
+        results = self.vmap.validate(foo_builder)
 
         # Should fail validation - UTF-8 strings should not be allowed where bytes/ASCII is specified
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], DtypeError)
-        self.assertEqual("Foo/data (data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
+        self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1612,8 +1612,9 @@ class TestVlenStringData(ValidatorTestBase):
     """
     Test validation of variable length string data across backends.
 
-    HDF5 datasets and zarr arrays store variable-length strings different.
-    HDF5 uses vlen metadata and Zarr uses an object dtype.
+    HDF5 datasets and Zarr arrays store variable-length strings differently.
+    Validation of HDF5 vlen string datasets uses the data.dtype.metadata['vlen'] field and
+    validation of Zarr arrays uses the data.dtype.kind field from the object dtype.
     """
 
     def setUp(self):

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1607,7 +1607,7 @@ class TestShapeValidation(ValidatorTestBase):
         self.assertIsInstance(result[0], ExpectedArrayError)
         self.assertNotIsInstance(result[0], ShapeError)
 
-    
+
 class TestObjectDtypeArrays(TestCase):
     """Test validation of arrays with object dtype (e.g., zarr variable length strings)"""
 
@@ -1622,7 +1622,7 @@ class TestObjectDtypeArrays(TestCase):
             'a test namespace', CORE_NAMESPACE, [{'source': 'test.yaml'}], version='0.1.0', catalog=spec_catalog)
         self.vmap = ValidatorMap(self.namespace)
 
-    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")    
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_non_empty_object_dtype_array(self):
         """Test that validator can determine dtype for non-empty zarr.Array with object dtype"""
         import zarr
@@ -1640,7 +1640,7 @@ class TestObjectDtypeArrays(TestCase):
         # Should pass validation - object array with strings should be detected as 'utf' type
         self.assertEqual(len(results), 0)
 
-    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")    
+    @skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_empty_object_dtype_array(self):
         """Test that validator can determine dtype for empty zarr.Array with object dtype"""
         import zarr

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1618,14 +1618,6 @@ class TestVlenStringData(ValidatorTestBase):
     validation of Zarr arrays uses the data.dtype.kind field from the object dtype.
     """
 
-    def setUp(self):
-        self.hdf5_filename = 'test_string_dtype_validation.h5'
-        super().setUp()
-
-    def tearDown(self):
-        remove_test_file(self.hdf5_filename)
-        super().tearDown()
-
     def getSpecs(self):
         # spec with 'bytes' (ASCII) dtype requirement
         foo = GroupSpec('A test group specification with a data type',
@@ -1712,8 +1704,8 @@ class TestVlenStringData(ValidatorTestBase):
         """Test that validator does not allow UTF-8 data where ASCII is specified for HDF5 vlen strings"""
         # Create hdf5 dataset with UTF-8 string data
         # convert to StrDataset because data read directly from f.create_dataset will be bytes
-        f = h5py.File(name=self.hdf5_filename, mode='w', driver='core', backing_store=False)
-        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8')
+        f = h5py.File(name='test_string_dtype_validation.h5', mode='w', driver='core', backing_store=False)
+        dset = StrDataset(f.create_dataset('data', data=['string1', 'string2', 'string3']), encoding='utf8') 
         foo_builder = GroupBuilder('my_foo',
                                attributes={'data_type': 'Foo', 'attr1': 'a string attribute'},
                                datasets=[DatasetBuilder('data', dset)])


### PR DESCRIPTION
## Motivation

Fix https://github.com/hdmf-dev/hdmf-zarr/issues/221.


Zarr does not natively support variable length strings, and validation of vlen string arrays uses the HDF5 specific `data.dtype.metadata` field. This field is None for Zarr arrays resulting in the data type not being correctly extracted during validation using the `get_type` method.

## How to test the behavior?

Validate an NWB zarr file with an io object input

```python
import datetime
import uuid

import hdmf_zarr
import numpy
import pynwb

nwbfile = pynwb.NWBFile(
    session_description="",
    identifier=str(uuid.uuid4()),
    session_start_time=datetime.datetime.now().astimezone()
)
regular_timestamps = numpy.arange(1.2, 11.2, 2)
timestamps_length = len(regular_timestamps)
time_series = pynwb.TimeSeries(
    name="test_time_series",
    data=numpy.zeros(shape=(timestamps_length, timestamps_length - 1)),
    timestamps=regular_timestamps,
    unit="",
)
nwbfile.add_acquisition(time_series)

nwbfile_path = "test_validation_time_series.nwb.zarr"
with hdmf_zarr.NWBZarrIO(path=nwbfile_path, mode="w") as io:
    io.write(nwbfile)

with hdmf_zarr.NWBZarrIO(path=nwbfile_path, mode="r") as io:
    invalidations = pynwb.validate(io=io)
    print(invalidations) # should be empty []
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
