### PR TITLE
Fix TypeMap.merge to preserve original namespace associations for DynamicTableRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF (Unreleased)
+
+### Fixed
+- Fixed bug where `DynamicTableRegion` was written with namespace `hdmf_experimental` instead of `hdmf_common` when using NWB extensions that depend on `hdmf-experimental`. The issue was in `TypeMap.merge()` where the iteration order of `__container_types` could cause the wrong namespace to be associated with a class. @bendichter [#1347](https://github.com/hdmf-dev/hdmf/issues/1347)
+
 ## HDMF 4.1.2 (November 7, 2025)
 
 ### Fixed

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -459,6 +459,15 @@ class TypeMap:
             for data_type in type_map.__container_types[namespace]:
                 container_cls = type_map.__container_types[namespace][data_type]
                 self.register_container_type(namespace, data_type, container_cls)
+        # Copy __data_types directly to preserve original namespace associations.
+        # This is needed because register_container_type uses setdefault, which means
+        # the iteration order of __container_types determines which namespace gets
+        # associated with a class. By copying __data_types directly, we ensure the
+        # original namespace associations are preserved (e.g., DynamicTableRegion
+        # stays associated with hdmf-common, not hdmf-experimental).
+        for container_cls, ns_dt in type_map._TypeMap__data_types.items():
+            if container_cls not in self.__data_types:
+                self.__data_types[container_cls] = ns_dt
         for container_cls in type_map.__mapper_cls:
             self.register_map(container_cls, type_map.__mapper_cls[container_cls])
         for custom_generators in reversed(type_map.__class_generator_manager.custom_generators):

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -5,6 +5,7 @@ from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNa
 from hdmf.spec.spec import ZERO_OR_MANY
 from hdmf.testing import TestCase
 
+from hdmf.container import Container
 from tests.unit.helpers.utils import Foo, FooBucket, CORE_NAMESPACE
 
 
@@ -343,6 +344,81 @@ class TestRetrieveContainerClass(TestBase):
     def test_get_dt_container_cls_no_namespace(self):
         with self.assertRaisesWith(ValueError, "Namespace could not be resolved for data type 'Unknown'."):
             self.type_map.get_dt_container_cls(data_type="Unknown")
+
+
+class TestTypeMapMerge(TestCase):
+    """Test TypeMap.merge preserves original namespace associations."""
+
+    def test_merge_preserves_data_types_namespace(self):
+        """Test that merge() preserves the original namespace associations in __data_types.
+
+        This is a regression test for https://github.com/hdmf-dev/hdmf/issues/1347
+        where DynamicTableRegion was incorrectly associated with hdmf-experimental
+        instead of hdmf-common after loading extensions.
+        """
+        # Create a "source" namespace with a type
+        source_spec = GroupSpec(
+            doc='A source type',
+            data_type_def='SourceType',
+        )
+        source_catalog = SpecCatalog()
+        source_catalog.register_spec(source_spec, 'source.yaml')
+        source_ns = SpecNamespace(
+            doc='source namespace',
+            name='source_ns',
+            schema=[{'source': 'source.yaml'}],
+            version='1.0.0',
+            catalog=source_catalog
+        )
+        source_ns_catalog = NamespaceCatalog()
+        source_ns_catalog.add_namespace('source_ns', source_ns)
+        source_type_map = TypeMap(source_ns_catalog)
+
+        # Create a container class for SourceType and register it
+        class SourceContainer(Container):
+            pass
+
+        source_type_map.register_container_type('source_ns', 'SourceType', SourceContainer)
+
+        # Create a "dependent" namespace that includes SourceType
+        dep_spec = GroupSpec(
+            doc='A dependent type',
+            data_type_def='DependentType',
+            data_type_inc='SourceType',
+        )
+        dep_catalog = SpecCatalog()
+        dep_catalog.register_spec(source_spec, 'source.yaml')  # need source spec for hierarchy
+        dep_catalog.register_spec(dep_spec, 'dependent.yaml')
+        dep_ns = SpecNamespace(
+            doc='dependent namespace',
+            name='dependent_ns',
+            schema=[{'source': 'source.yaml'}, {'source': 'dependent.yaml'}],
+            version='1.0.0',
+            catalog=dep_catalog
+        )
+
+        # Create a namespace catalog with both namespaces
+        # Order matters here - we add dependent_ns first to simulate the issue
+        combined_ns_catalog = NamespaceCatalog()
+        combined_ns_catalog.add_namespace('dependent_ns', dep_ns)
+        combined_ns_catalog.add_namespace('source_ns', source_ns)
+
+        # Create a new TypeMap for the combined namespaces
+        combined_type_map = TypeMap(combined_ns_catalog)
+
+        # Register SourceType in dependent_ns first (simulates what happens with TypeSource)
+        combined_type_map.register_container_type('dependent_ns', 'SourceType', SourceContainer)
+        # Then register in source_ns
+        combined_type_map.register_container_type('source_ns', 'SourceType', SourceContainer)
+
+        # Now merge the source_type_map (which has correct namespace association) into a new TypeMap
+        target_type_map = TypeMap(combined_ns_catalog)
+        target_type_map.merge(source_type_map)
+
+        # The key test: after merge, get_container_ns_dt should return source_ns, not dependent_ns
+        ns, dt = target_type_map.get_container_cls_dt(SourceContainer)
+        self.assertEqual(ns, 'source_ns')
+        self.assertEqual(dt, 'SourceType')
 
 
 # TODO:


### PR DESCRIPTION
fix #1347

Generated by Claude