### PR TITLE
Avoid copying type map when calling AbstractContainer setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## HDMF 4.1.3 (Upcoming)
 
+### Added
+- Added an argument `copy` to `get_type_map` to control whether a copy of the type map is returned or not.
+  If `copy=False`, the returned type map will be a direct reference to the global type map. @rly
+  [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)
+
 ### Fixed
 - Fixed bug when validating string datasets in NWB Zarr files. @stephprince [#1348](https://github.com/hdmf-dev/hdmf/pull/1348)
+- Fixed a performance regression that affected calling setters of HDMF Common data types. @rly [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)
+
 
 ## HDMF 4.1.2 (November 7, 2025)
 
@@ -11,6 +18,7 @@
 - Fixed bug when converting string datasets that are Zarr arrays. @oruebel @rly [#1171](https://github.com/hdmf-dev/hdmf/pull/1171)
 - Fixed unclear shape validation error message. @bendichter @rly [#787](https://github.com/hdmf-dev/hdmf/pull/787)
 - Fixed testing of sphinx gallery examples with optional dependencies. @rly [#1343](https://github.com/hdmf-dev/hdmf/pull/1343)
+
 
 ## HDMF 4.1.1 (October 22, 2025)
 
@@ -29,6 +37,8 @@
 ### Changed
 - Changed error for attempting to overwrite an existing specification into a warning that any specification redefinitions will be ignored. @stephprince [#1309](https://github.com/hdmf-dev/hdmf/pull/1309)
 - Deprecated the experimental `HERDManager.link_resources` and `HERDManager.link_external_resources` and added the property `HERDManager.external_resources` to support downstream API function overloading. @mavaylon1, @rly [#1292](https://github.com/hdmf-dev/hdmf/pull/1292)
+- Deprecated calling `get_type_map` with the `extensions` argument. Call `load_namespaces` on the returned `TypeMap`
+  instead. @rly [#1302](https://github.com/hdmf-dev/hdmf/pull/1302)
 
 
 ## HDMF 4.1.0 (May 28, 2025)

--- a/src/hdmf/common/__init__.py
+++ b/src/hdmf/common/__init__.py
@@ -171,6 +171,12 @@ def get_class(**kwargs):
 @docval({'name': 'extensions', 'type': (str, TypeMap, list),
          'doc': 'a path to a namespace, a TypeMap, or a list consisting paths to namespaces and TypeMaps',
          'default': None},
+        {
+            'name': 'copy', 'type': bool,
+            'doc': 'Whether to return a deepcopy of the TypeMap. '
+            'If False, a direct reference may be returned (use with caution).',
+            'default': True
+        },
         returns="the namespaces loaded from the given file", rtype=tuple,
         is_method=False)
 def get_type_map(**kwargs):
@@ -178,10 +184,13 @@ def get_type_map(**kwargs):
     Get a BuildManager to use for I/O using the given extensions. If no extensions are provided,
     return a BuildManager that uses the core namespace
     '''
-    extensions = getargs('extensions', kwargs)
+    extensions, copy_map = getargs('extensions', 'copy', kwargs)
     type_map = None
     if extensions is None:
-        type_map = deepcopy(__TYPE_MAP)
+        if copy_map:
+            type_map = deepcopy(__TYPE_MAP)
+        else:
+            type_map = __TYPE_MAP
     else:
         warnings.warn("The 'extensions' argument is deprecated and will be removed in HDMF 5.0", DeprecationWarning)
         if isinstance(extensions, TypeMap):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -116,7 +116,7 @@ class AbstractContainer(metaclass=ExtenderMeta):
         # TODO: refactor this so that it does not call get_type_map every time an attribute is set
         # and there is non circular import
         from hdmf.common import get_type_map # circular import
-        return get_type_map()
+        return get_type_map(copy=False)
 
     @property
     def data_type(self):


### PR DESCRIPTION
## Motivation

Fix #1351

## How to test the behavior?
All tests should still pass but there should be fewer copies of `get_type_map` when calling the setters for HDMF data types and extensions of those.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
