### PR TITLE
HTML repr: Remove double nesting in processing modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ coverage.xml
 
 # Version
 _version.py
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ### Changed
 - Changed how to call `BuildManager.build`, `TypeMap.build`, and `ObjectMapper.build` when exporting. The `export` argument is no longer accepted by `TypeMap.build` and `ObjectMapper.build`; `BuildManager.build` still accepts the `export` argument but now uses it to set an internal flag instead of passing it through the call chain. @rly [#1358](https://github.com/hdmf-dev/hdmf/pull/1358)
-- Changed HTML representation of `MultiContainerInterface` to flatten the `data_interfaces` field,
-  removing the redundant nesting level for `ProcessingModule` in PyNWB. @h-mayorquin [#1354](https://github.com/hdmf-dev/hdmf/pull/1354)
+- Changed HTML representation of `MultiContainerInterface` to flatten the grouping attribute when only
+  one grouping is defined (`len(__clsconf__) == 1`), removing the redundant nesting level since users
+  can access children directly via `container["name"]`. @h-mayorquin [#1354](https://github.com/hdmf-dev/hdmf/pull/1354)
 
 ### Fixed
 - Fixed bug when validating string datasets in NWB Zarr files. @stephprince [#1348](https://github.com/hdmf-dev/hdmf/pull/1348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   If `copy=False`, the returned type map will be a direct reference to the global type map. @rly
   [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)
 
+### Changed
+- Changed HTML representation of `MultiContainerInterface` to flatten the `data_interfaces` field,
+  removing the redundant nesting level for `ProcessingModule` in PyNWB. @h-mayorquin
+
 ### Fixed
 - Fixed bug when validating string datasets in NWB Zarr files. @stephprince [#1348](https://github.com/hdmf-dev/hdmf/pull/1348)
 - Fixed a performance regression that affected calling setters of HDMF Common data types. @rly [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 - Changed HTML representation of `MultiContainerInterface` to flatten the `data_interfaces` field,
-  removing the redundant nesting level for `ProcessingModule` in PyNWB. @h-mayorquin
+  removing the redundant nesting level for `ProcessingModule` in PyNWB. @h-mayorquin [#1354](https://github.com/hdmf-dev/hdmf/pull/1354)
 
 ### Fixed
 - Fixed bug when validating string datasets in NWB Zarr files. @stephprince [#1348](https://github.com/hdmf-dev/hdmf/pull/1348)

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1340,7 +1340,7 @@ class MultiContainerInterface(Container):
             setattr(cls, get, cls.__make_get(get, attr, container_type))
 
     def _generate_field_html(self, key, value, level, access_code):
-        """Override here to flatten 'data_interfaces' rendering in MultiContainers with data_interfaces keys 
+        """Override here to flatten 'data_interfaces' rendering in MultiContainers with data_interfaces keys
         In practice this is the ProcessingModule
 
         The 'data_interfaces' wrapper in ProcessingModule is redundant since the

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1357,9 +1357,9 @@ class MultiContainerInterface(Container):
         clsconf = self.__clsconf__
         if isinstance(clsconf, dict):
             clsconf = [clsconf]
-        
+
         single_element_container = len(clsconf) == 1
-        
+
         if len(clsconf) == 1 and isinstance(value, LabelledDict):
             html_repr = ""
             for child_name, child_container in value.items():

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1339,6 +1339,25 @@ class MultiContainerInterface(Container):
         if get is not None:
             setattr(cls, get, cls.__make_get(get, attr, container_type))
 
+    def _generate_field_html(self, key, value, level, access_code):
+        """Override here to flatten 'data_interfaces' rendering in MultiContainers with data_interfaces keys 
+        In practice this is the ProcessingModule
+
+        The 'data_interfaces' wrapper in ProcessingModule is redundant since the
+        ProcessingModule container itself already indicates it holds data interfaces.
+        This method renders the contained objects directly without that extra nesting level.
+        """
+        # Only flatten the 'data_interfaces' field (used by ProcessingModule in PyNWB)
+        if isinstance(value, LabelledDict) and key == 'data_interfaces':
+            # Render the contents of the LabelledDict directly without the wrapper
+            html_repr = ""
+            for item_key, item_value in value.items():
+                item_access_code = f"{access_code}['{item_key}']"
+                html_repr += super()._generate_field_html(item_key, item_value, level, item_access_code)
+            return html_repr
+        else:
+            return super()._generate_field_html(key, value, level, access_code)
+
 
 class Row(object, metaclass=ExtenderMeta):
     """

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1340,23 +1340,26 @@ class MultiContainerInterface(Container):
             setattr(cls, get, cls.__make_get(get, attr, container_type))
 
     def _generate_field_html(self, key, value, level, access_code):
-        """Override here to flatten 'data_interfaces' rendering in MultiContainers with data_interfaces keys
-        In practice this is the ProcessingModule
+        """Override to flatten single grouping attribute in MultiContainerInterface.
 
-        The 'data_interfaces' wrapper in ProcessingModule is redundant since the
-        ProcessingModule container itself already indicates it holds data interfaces.
-        This method renders the contained objects directly without that extra nesting level.
+        When a MultiContainerInterface has only one grouping attribute (len(__clsconf__) == 1),
+        the grouping attribute wrapper is redundant since users can access children directly
+        via container["name"] instead of container.attr["name"]. This method removes
+        that extra nesting level in the HTML representation.
         """
-        # Only flatten the 'data_interfaces' field (used by ProcessingModule in PyNWB)
-        if isinstance(value, LabelledDict) and key == 'data_interfaces':
-            # Render the contents of the LabelledDict directly without the wrapper
+        clsconf = self.__clsconf__
+        if isinstance(clsconf, dict):
+            clsconf = [clsconf]
+
+        if len(clsconf) == 1 and isinstance(value, LabelledDict):
             html_repr = ""
-            for item_key, item_value in value.items():
-                item_access_code = f"{access_code}['{item_key}']"
-                html_repr += super()._generate_field_html(item_key, item_value, level, item_access_code)
+            for child_name, child_container in value.items():
+                parent_access_code = access_code.rsplit('.', 1)[0] if '.' in access_code else ""
+                child_access_code = f"{parent_access_code}['{child_name}']"
+                html_repr += super()._generate_field_html(child_name, child_container, level, child_access_code)
             return html_repr
-        else:
-            return super()._generate_field_html(key, value, level, access_code)
+
+        return super()._generate_field_html(key, value, level, access_code)
 
 
 class Row(object, metaclass=ExtenderMeta):

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1342,19 +1342,31 @@ class MultiContainerInterface(Container):
     def _generate_field_html(self, key, value, level, access_code):
         """Override to flatten single grouping attribute in MultiContainerInterface.
 
-        When a MultiContainerInterface has only one grouping attribute (len(__clsconf__) == 1),
-        the grouping attribute wrapper is redundant since users can access children directly
-        via container["name"] instead of container.attr["name"]. This method removes
-        that extra nesting level in the HTML representation.
+        When a MultiContainerInterface has only one grouping attribute (len(__clsconf__) == 1)
+        and the value is a LabelledDict, the grouping attribute wrapper is redundant since
+        users can access children directly via container["name"] instead of container.attr["name"].
+        This method removes that extra nesting level in the HTML representation.
+
+        Examples of classes that get flattened:
+        - ProcessingModule: flattens "data_interfaces"
+        - Position: flattens "spatial_series"
+        - LFP: flattens "electrical_series"
+        - ImageSegmentation: flattens "plane_segmentations"
         """
+        # Normalize to list since __clsconf__ can be a dict or a list (e.g. LFP in pynwb uses a list with 1 element)
         clsconf = self.__clsconf__
         if isinstance(clsconf, dict):
             clsconf = [clsconf]
-
+        
+        single_element_container = len(clsconf) == 1
+        
         if len(clsconf) == 1 and isinstance(value, LabelledDict):
             html_repr = ""
             for child_name, child_container in value.items():
-                parent_access_code = access_code.rsplit('.', 1)[0] if '.' in access_code else ""
+                # Strip ".attr_name" from access_code and use direct ["child"] access
+                # e.g. ".spatial_series" becomes "", then we build "['SpatialSeries1']"
+                # This works because __getitem__ is defined for single clsconf (see line __build_class for details)
+                parent_access_code = access_code.rsplit('.', 1)[0]
                 child_access_code = f"{parent_access_code}['{child_name}']"
                 html_repr += super()._generate_field_html(child_name, child_container, level, child_access_code)
             return html_repr

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -1358,8 +1358,6 @@ class MultiContainerInterface(Container):
         if isinstance(clsconf, dict):
             clsconf = [clsconf]
 
-        single_element_container = len(clsconf) == 1
-
         if len(clsconf) == 1 and isinstance(value, LabelledDict):
             html_repr = ""
             for child_name, child_container in value.items():

--- a/tests/unit/test_multicontainerinterface.py
+++ b/tests/unit/test_multicontainerinterface.py
@@ -351,11 +351,9 @@ class TestBasic(TestCase):
                 'class=\'container-header\'><div '
                 'class=\'xr-obj-type\'><h3>FooSingle</h3></div></div><details><summary style="display: list-item; '
                 'margin-left: 0px;" class="container-fields field-key" '
-                'title=".containers"><b>containers</b></summary><details><summary style="display: list-item; '
-                'margin-left: 20px;" class="container-fields field-key" title=".containers['
-                '\'obj1\']"><b>obj1</b></summary></details><details><summary style="display: list-item; margin-left: '
-                '20px;" class="container-fields field-key" title=".containers['
-                '\'obj2\']"><b>obj2</b></summary></details></details></div>'
+                'title="[\'obj1\']"><b>obj1</b></summary></details><details><summary style="display: list-item; '
+                'margin-left: 0px;" class="container-fields field-key" '
+                'title="[\'obj2\']"><b>obj2</b></summary></details></div>'
             )
         )
 


### PR DESCRIPTION
This PR modifies the html repr of the NWBFiles so the processing modules do not display a double nesting with the data_interfaces attribute:


<img width="1481" height="1028" alt="image" src="https://github.com/user-attachments/assets/6e483b4e-53b6-4cb7-b791-9248f9751ec5" />

Left is the new behavior right is the old behavior


This uses duck typing in the MultiContainerinterface to eliminate the double nesting (right on the image above) for the `ProcessingModule`. As `ProcessingModule` lives on pynwb I can't do the more natural solution of either overriding the method there (which would imply having some of the html repr code in pynwb) or checking of class instance here (which risks a circular dependency). 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
