### PR TITLE
ci: add Python 3.14 to CI test matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,12 +51,13 @@ body:
     attributes:
       label: Python Version
       options:
+        - "3.14"
         - "3.13"
         - "3.12"
         - "3.11"
         - "3.10"
         - "3.9"
-        - "newer"
+        - "other version (specify below)"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/check_sphinx_links.yml
+++ b/.github/workflows/check_sphinx_links.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'  # TODO: Update to 3.13 when linkml and its deps support 3.13
+          python-version: '3.13'  # TODO: Update to 3.14 when linkml and its deps support 3.14
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -30,22 +30,25 @@ jobs:
           - { name: linux-python3.11-upgraded              , test-tox-env: pytest-py311-upgraded            , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12-upgraded              , test-tox-env: pytest-py312-upgraded            , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13-upgraded              , test-tox-env: pytest-py313-upgraded            , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-upgraded-optional     , test-tox-env: pytest-py313-upgraded-optional   , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-prerelease-optional   , test-tox-env: pytest-py313-prerelease-optional , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.14-upgraded              , test-tox-env: pytest-py314-upgraded            , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-upgraded-optional     , test-tox-env: pytest-py314-upgraded-optional   , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-prerelease-optional   , test-tox-env: pytest-py314-prerelease-optional , python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-python3.9-minimum              , test-tox-env: pytest-py39-minimum              , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.10-upgraded            , test-tox-env: pytest-py310-upgraded            , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11-upgraded            , test-tox-env: pytest-py311-upgraded            , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12-upgraded            , test-tox-env: pytest-py312-upgraded            , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13-upgraded            , test-tox-env: pytest-py313-upgraded            , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional   , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-prerelease-optional , test-tox-env: pytest-py313-prerelease-optional , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14-upgraded            , test-tox-env: pytest-py314-upgraded            , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-upgraded-optional   , test-tox-env: pytest-py314-upgraded-optional   , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-prerelease-optional , test-tox-env: pytest-py314-prerelease-optional , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum                , test-tox-env: pytest-py39-minimum              , python-ver: "3.9" , os: macos-15-intel }
           - { name: macos-python3.10-upgraded              , test-tox-env: pytest-py310-upgraded            , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11-upgraded              , test-tox-env: pytest-py311-upgraded            , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12-upgraded              , test-tox-env: pytest-py312-upgraded            , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13-upgraded              , test-tox-env: pytest-py313-upgraded            , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-upgraded-optional     , test-tox-env: pytest-py313-upgraded-optional   , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-prerelease-optional   , test-tox-env: pytest-py313-prerelease-optional , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.14-upgraded              , test-tox-env: pytest-py314-upgraded            , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-upgraded-optional     , test-tox-env: pytest-py314-upgraded-optional   , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-prerelease-optional   , test-tox-env: pytest-py314-prerelease-optional , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6
@@ -139,9 +142,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.13-ros3   , python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.13-ros3 , python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.13-ros3   , python-ver: "3.13", os: macos-latest }
+          - { name: linux-python3.14-ros3   , python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-python3.14-ros3 , python-ver: "3.14", os: windows-latest }
+          - { name: macos-python3.14-ros3   , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -47,8 +47,11 @@ jobs:
           - { name: macos-python3.12-upgraded              , test-tox-env: pytest-py312-upgraded            , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13-upgraded              , test-tox-env: pytest-py313-upgraded            , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.14-upgraded              , test-tox-env: pytest-py314-upgraded            , python-ver: "3.14", os: macos-latest }
-          - { name: macos-python3.14-upgraded-optional     , test-tox-env: pytest-py314-upgraded-optional   , python-ver: "3.14", os: macos-latest }
-          - { name: macos-python3.14-prerelease-optional   , test-tox-env: pytest-py314-prerelease-optional , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-prerelease            , test-tox-env: pytest-py314-prerelease          , python-ver: "3.14", os: macos-latest }
+          # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+          # So optional requirements testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf/pull/1367
+          - { name: macos-python3.13-upgraded-optional     , test-tox-env: pytest-py313-upgraded-optional   , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-prerelease-optional   , test-tox-env: pytest-py313-prerelease-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6
@@ -97,16 +100,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: Update to 3.13 when linkml and its deps support 3.13
+          # TODO: Update to 3.14 when linkml and its deps support 3.14
           - { name: linux-gallery-python3.9-minimum                , test-tox-env: gallery-py39-minimum              , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.12-upgraded-optional     , test-tox-env: gallery-py312-upgraded-optional   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-gallery-python3.12-prerelease-optional   , test-tox-env: gallery-py312-prerelease-optional , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-gallery-python3.13-upgraded-optional     , test-tox-env: gallery-py313-upgraded-optional   , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-gallery-python3.13-prerelease-optional   , test-tox-env: gallery-py313-prerelease-optional , python-ver: "3.13", os: ubuntu-latest }
           - { name: windows-gallery-python3.9-minimum              , test-tox-env: gallery-py39-minimum              , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.12-upgraded-optional   , test-tox-env: gallery-py312-upgraded-optional   , python-ver: "3.12", os: windows-latest }
-          - { name: windows-gallery-python3.12-prerelease-optional , test-tox-env: gallery-py312-prerelease-optional , python-ver: "3.12", os: windows-latest }
+          - { name: windows-gallery-python3.13-upgraded-optional   , test-tox-env: gallery-py313-upgraded-optional   , python-ver: "3.13", os: windows-latest }
+          - { name: windows-gallery-python3.13-prerelease-optional , test-tox-env: gallery-py313-prerelease-optional , python-ver: "3.13", os: windows-latest }
           - { name: macos-gallery-python3.9-minimum                , test-tox-env: gallery-py39-minimum              , python-ver: "3.9" , os: macos-15-intel }
-          - { name: macos-gallery-python3.12-upgraded-optional     , test-tox-env: gallery-py312-upgraded-optional   , python-ver: "3.12", os: macos-latest }
-          - { name: macos-gallery-python3.12-prerelease-optional   , test-tox-env: gallery-py312-prerelease-optional , python-ver: "3.12", os: macos-latest }
+          - { name: macos-gallery-python3.13-upgraded-optional     , test-tox-env: gallery-py313-upgraded-optional   , python-ver: "3.13", os: macos-latest }
+          - { name: macos-gallery-python3.13-prerelease-optional   , test-tox-env: gallery-py313-prerelease-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -31,7 +31,7 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:  # used by codecov-action
       OS: ${{ matrix.os }}
-      PYTHON: '3.12'  # TODO: Update to 3.13 when linkml and its deps support 3.13
+      PYTHON: '3.13'  # TODO: Update to 3.14 when linkml and its deps support 3.14
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,12 +24,13 @@ jobs:
         include:
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.9-minimum              , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.13-upgraded            , test-tox-env: pytest-py313-upgraded          , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: ubuntu-latest , upload-wheels: true }
+          - { name: linux-python3.14-upgraded            , test-tox-env: pytest-py314-upgraded          , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-upgraded-optional   , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.9-minimum            , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.13-upgraded-optional , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14-upgraded-optional , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum              , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: macos-15-intel }
-          - { name: macos-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.14-upgraded-optional   , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6
@@ -130,7 +131,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v7
@@ -163,7 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,10 +27,12 @@ jobs:
           - { name: linux-python3.14-upgraded            , test-tox-env: pytest-py314-upgraded          , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-upgraded-optional   , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.9-minimum            , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.13-upgraded-optional , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: windows-latest }
           - { name: windows-python3.14-upgraded-optional , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum              , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: macos-15-intel }
-          - { name: macos-python3.14-upgraded-optional   , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-upgraded            , test-tox-env: pytest-py313-upgraded          , python-ver: "3.14", os: macos-latest }
+          # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
+          # So optional requirements testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf/pull/1367
+          - { name: macos-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6
@@ -86,11 +88,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: Update to 3.13 when linkml and its deps support 3.13
+          # TODO: Update to 3.14 when linkml and its deps support 3.14
           - { name: linux-gallery-python3.9-minimum              , test-tox-env: gallery-py39-minimum            , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.12-upgraded-optional   , test-tox-env: gallery-py312-upgraded-optional , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-gallery-python3.13-upgraded-optional   , test-tox-env: gallery-py313-upgraded-optional , python-ver: "3.13", os: ubuntu-latest }
           - { name: windows-gallery-python3.9-minimum            , test-tox-env: gallery-py39-minimum            , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.12-upgraded-optional , test-tox-env: gallery-py312-upgraded-optional , python-ver: "3.12", os: windows-latest }
+          - { name: windows-gallery-python3.13-upgraded-optional , test-tox-env: gallery-py313-upgraded-optional , python-ver: "3.13", os: windows-latest }
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v6

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: '3.12'  # TODO: Update to 3.13 when linkml and its deps support 3.13
+    python: '3.13'  # TODO: Update to 3.14 when linkml and its deps support 3.14
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 4.3.0 (Upcoming)
+
+### Added
+- Added support for Python 3.14. @bendichter [#1366](https://github.com/hdmf-dev/hdmf/issues/1366)
+
 ## HDMF 4.2.0 (December 18, 2025)
 
 ### Added

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ sphinx_gallery_conf = {
 }
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.12", None),
+    "python": ("https://docs.python.org/3.14", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),

--- a/docs/source/install_developers.rst
+++ b/docs/source/install_developers.rst
@@ -52,11 +52,11 @@ Option 2: Using conda
 
 The `conda package and environment management system`_ is an alternate way of managing virtual environments.
 First, install Anaconda_ to install the ``conda`` tool. Then create and
-activate a new virtual environment called ``"hdmf-env"`` with Python 3.13 installed.
+activate a new virtual environment called ``"hdmf-env"`` with Python 3.14 installed.
 
 .. code:: bash
 
-    conda create --name hdmf-env python=3.13
+    conda create --name hdmf-env python=3.14
     conda activate hdmf-env
 
 Similar to a virtual environment created with ``venv``, a conda environment

--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -4,7 +4,7 @@
 Installing HDMF
 ---------------
 
-HDMF requires having Python 3.9-3.13 installed. If you don't have Python installed and want the simplest way to
+HDMF requires having Python 3.9-3.14 installed. If you don't have Python installed and want the simplest way to
 get started, we recommend you install and use the `Anaconda Distribution`_. It includes Python, NumPy, and many other
 commonly used packages for scientific computing and data science.
 

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.13
+  - python==3.14
   - h5py==3.12.1
   - matplotlib==3.9.2
   - numpy==2.2.1

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -5,10 +5,10 @@ channels:
   - defaults
 dependencies:
   - python==3.14
-  - h5py==3.12.1
-  - matplotlib==3.9.2
-  - numpy==2.2.1
-  - pandas==2.2.3
+  - h5py==3.15.1
+  - matplotlib==3.10.8
+  - numpy==2.4.0
+  - pandas==2.3.3
   - python-dateutil==2.9.0.post0
-  - pytest==8.3.4
-  - pytest-cov==6.0.0
+  - pytest==9.0.2
+  - pytest-cov==7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: BSD License",
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -630,7 +630,7 @@ def __builddoc(func, validator, docstring_fmt, arg_fmt, ret_fmt=None, returns=No
 
             if module.startswith("builtins"):
                 return ":py:class:`~{name}`".format(name=name)
-            elif module.startswith("h5py") or module.startswith('pandas'):
+            elif module.startswith("h5py") or module.startswith('pandas') or module.startswith('pathlib'):
                 return ":py:class:`~{module}.{name}`".format(name=name, module=module.split('.')[0])
             else:
                 return ":py:class:`~{module}.{name}`".format(name=name, module=module)

--- a/tox.ini
+++ b/tox.ini
@@ -45,9 +45,9 @@ commands =
     wheelinstall: python -c "import hdmf; import hdmf.common"
 
 # list of pre-defined environments
-[testenv:pytest-py{39,310,311,312,313}-upgraded]
-[testenv:pytest-py313-upgraded-optional]
-[testenv:pytest-py313-prerelease-optional]
+[testenv:pytest-py{39,310,311,312,313,314}-upgraded]
+[testenv:pytest-py314-upgraded-optional]
+[testenv:pytest-py314-prerelease-optional]
 [testenv:pytest-py39-minimum]
 
 # TODO: Update to 3.13 when linkml and its deps support 3.13


### PR DESCRIPTION
Update GitHub Actions workflow to test against Python 3.14 across all platforms (Linux, Windows, macOS). Replaces Python 3.13 as the latest version for upgraded, upgraded-optional, and prerelease-optional test configurations.

fix #1366 