### PR TITLE
Add column descriptions to DynamicTable HTML representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)
 
 ### Changed
+- Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)
 - Changed HTML representation to display the `data_type` for nested containers, showing the type in parentheses next to the name (e.g., `MyTimeSeries (TimeSeries)`). @h-mayorquin [#1355](https://github.com/hdmf-dev/hdmf/pull/1355)
 - Changed how to call `BuildManager.build`, `TypeMap.build`, and `ObjectMapper.build` when exporting. The `export` argument is no longer accepted by `TypeMap.build` and `ObjectMapper.build`; `BuildManager.build` still accepts the `export` argument but now uses it to set an internal flag instead of passing it through the call chain. @rly [#1358](https://github.com/hdmf-dev/hdmf/pull/1358)
 - Changed HTML representation of `MultiContainerInterface` to flatten the grouping attribute when only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # HDMF Changelog
 
+## HDMF 4.2.1 (Upcoming)
+
+### Added
+
+### Changed
+- Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)
+
+### Fixed
+
+
 ## HDMF 4.2.0 (December 18, 2025)
 
 ### Added
@@ -8,7 +18,6 @@
   [#1352](https://github.com/hdmf-dev/hdmf/pull/1352)
 
 ### Changed
-- Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)
 - Changed HTML representation to display the `data_type` for nested containers, showing the type in parentheses next to the name (e.g., `MyTimeSeries (TimeSeries)`). @h-mayorquin [#1355](https://github.com/hdmf-dev/hdmf/pull/1355)
 - Changed how to call `BuildManager.build`, `TypeMap.build`, and `ObjectMapper.build` when exporting. The `export` argument is no longer accepted by `TypeMap.build` and `ObjectMapper.build`; `BuildManager.build` still accepts the `export` argument but now uses it to set an internal flag instead of passing it through the call chain. @rly [#1358](https://github.com/hdmf-dev/hdmf/pull/1358)
 - Changed HTML representation of `MultiContainerInterface` to flatten the grouping attribute when only

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1276,17 +1276,22 @@ class DynamicTable(Container):
             if key not in ("id", "colnames", "columns"):
                 out += self._generate_field_html(key, value, level, access_code)
 
-        # Generate column descriptions section
-        col_desc_html = "<table class='data-info'><tbody>"
+        # Generate columns section (field-style, individually collapsed by default)
+        col_desc_inner = ""
+        inner_level = level + 1
         for name in self.colnames:
             desc = self[name].description
-            col_desc_html += f"<tr><th style='text-align: left'>{name}</th>"
-            col_desc_html += f"<td style='text-align: left'>{desc}</td></tr>"
-        col_desc_html += "</tbody></table>"
+            col_access_code = f"{access_code}['{name}']" if access_code else f"['{name}']"
+            col_desc_inner += (
+                f'<details><summary style="display: list-item; margin-left: {inner_level * 20}px;" '
+                f'class="container-fields field-key" title="{col_access_code}"><b>{name}</b></summary>'
+                f'<div style="margin-left: {(inner_level + 1) * 20}px;" class="container-fields">'
+                f'<span class="field-value">{desc}</span></div></details>'
+            )
 
         out += (
             f'<details><summary style="display: list-item; margin-left: {level * 20}px;" '
-            f'class="container-fields field-key"><b>column descriptions</b></summary>{col_desc_html}</details>'
+            f'class="container-fields field-key"><b>columns</b></summary>{col_desc_inner}</details>'
         )
 
         inside = f"{self[:min(nrows, len(self))].to_html()}"

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -160,6 +160,19 @@ class VectorIndex(VectorData):
         """
         self.add_vector(arg, **kwargs)
 
+    def get_target_data(self):
+        """
+        Get the final VectorData target, traversing any nested VectorIndex objects.
+
+        For single ragged arrays, this returns self.target (the VectorData).
+        For double/multi ragged arrays, this traverses the chain of VectorIndex
+        objects to return the final VectorData.
+        """
+        target = self.target
+        while isinstance(target, VectorIndex):
+            target = target.target
+        return target
+
     def __get_slice(self, arg):
         start = 0 if arg == 0 else self.data[arg - 1]
         end = self.data[arg]
@@ -1280,7 +1293,12 @@ class DynamicTable(Container):
         col_desc_inner = ""
         inner_level = level + 1
         for name in self.colnames:
-            desc = self[name].description
+            col = self[name]
+            # For ragged arrays (VectorIndex), get description from the final target VectorData
+            if isinstance(col, VectorIndex):
+                desc = col.get_target_data().description
+            else:
+                desc = col.description
             col_access_code = f"{access_code}['{name}']" if access_code else f"['{name}']"
             col_desc_inner += (
                 f'<details><summary style="display: list-item; margin-left: {inner_level * 20}px;" '

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1276,6 +1276,19 @@ class DynamicTable(Container):
             if key not in ("id", "colnames", "columns"):
                 out += self._generate_field_html(key, value, level, access_code)
 
+        # Generate column descriptions section
+        col_desc_html = "<table class='data-info'><tbody>"
+        for name in self.colnames:
+            desc = self[name].description
+            col_desc_html += f"<tr><th style='text-align: left'>{name}</th>"
+            col_desc_html += f"<td style='text-align: left'>{desc}</td></tr>"
+        col_desc_html += "</tbody></table>"
+
+        out += (
+            f'<details><summary style="display: list-item; margin-left: {level * 20}px;" '
+            f'class="container-fields field-key"><b>column descriptions</b></summary>{col_desc_html}</details>'
+        )
+
         inside = f"{self[:min(nrows, len(self))].to_html()}"
 
         if len(self) >= nrows + 1:

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -2613,6 +2613,21 @@ class TestVectorIndex(TestCase):
         self.assertEqual(result, [['a', 'b',], ['d', 'e']])
         self.assertEqual(len(result), 2)
 
+    def test_get_target_data_single_index(self):
+        """Test get_target_data returns the VectorData for a single ragged array."""
+        foo = VectorData(name='foo', description='foo column', data=['a', 'b', 'c'])
+        foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3])
+        self.assertIs(foo_ind.get_target_data(), foo)
+
+    def test_get_target_data_double_index(self):
+        """Test get_target_data traverses nested VectorIndex to return the final VectorData."""
+        foo = VectorData(name='foo', description='foo column', data=['a', 'b', 'c', 'd'])
+        foo_ind = VectorIndex(name='foo_index', target=foo, data=[2, 3, 4])
+        foo_ind_ind = VectorIndex(name='foo_index_index', target=foo_ind, data=[2, 3])
+        self.assertIs(foo_ind_ind.get_target_data(), foo)
+        self.assertIs(foo_ind.get_target_data(), foo)
+
+
 class TestDoubleIndex(TestCase):
 
     def test_index(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1043,6 +1043,13 @@ Fields:
             'class=\'container-header\'><div class=\'xr-obj-type\'><h3>with_spec (DynamicTable)</h3></div></div><div '
             'style="margin-left: 0px;" class="container-fields"><span class="field-key" title="">description: '
             '</span><span class="field-value">a test table</span></div><details><summary style="display: list-item; '
+            'margin-left: 0px;" class="container-fields field-key"><b>column descriptions</b></summary>'
+            "<table class='data-info'><tbody>"
+            "<tr><th style='text-align: left'>foo</th><td style='text-align: left'>foo column</td></tr>"
+            "<tr><th style='text-align: left'>bar</th><td style='text-align: left'>bar column</td></tr>"
+            "<tr><th style='text-align: left'>baz</th><td style='text-align: left'>baz column</td></tr>"
+            '</tbody></table></details>'
+            '<details><summary style="display: list-item; '
             'margin-left: 0px;" class="container-fields field-key" title=""><b>table</b></summary><table border="1" '
             'class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      '
             '<th>foo</th>\n      <th>bar</th>\n      <th>baz</th>\n    </tr>\n    <tr>\n      <th>id</th>\n      '

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1043,12 +1043,20 @@ Fields:
             'class=\'container-header\'><div class=\'xr-obj-type\'><h3>with_spec (DynamicTable)</h3></div></div><div '
             'style="margin-left: 0px;" class="container-fields"><span class="field-key" title="">description: '
             '</span><span class="field-value">a test table</span></div><details><summary style="display: list-item; '
-            'margin-left: 0px;" class="container-fields field-key"><b>column descriptions</b></summary>'
-            "<table class='data-info'><tbody>"
-            "<tr><th style='text-align: left'>foo</th><td style='text-align: left'>foo column</td></tr>"
-            "<tr><th style='text-align: left'>bar</th><td style='text-align: left'>bar column</td></tr>"
-            "<tr><th style='text-align: left'>baz</th><td style='text-align: left'>baz column</td></tr>"
-            '</tbody></table></details>'
+            'margin-left: 0px;" class="container-fields field-key"><b>columns</b></summary>'
+            '<details><summary style="display: list-item; margin-left: 20px;" '
+            'class="container-fields field-key" title="[\'foo\']"><b>foo</b></summary>'
+            '<div style="margin-left: 40px;" class="container-fields">'
+            '<span class="field-value">foo column</span></div></details>'
+            '<details><summary style="display: list-item; margin-left: 20px;" '
+            'class="container-fields field-key" title="[\'bar\']"><b>bar</b></summary>'
+            '<div style="margin-left: 40px;" class="container-fields">'
+            '<span class="field-value">bar column</span></div></details>'
+            '<details><summary style="display: list-item; margin-left: 20px;" '
+            'class="container-fields field-key" title="[\'baz\']"><b>baz</b></summary>'
+            '<div style="margin-left: 40px;" class="container-fields">'
+            '<span class="field-value">baz column</span></div></details>'
+            '</details>'
             '<details><summary style="display: list-item; '
             'margin-left: 0px;" class="container-fields field-key" title=""><b>table</b></summary><table border="1" '
             'class="dataframe">\n  <thead>\n    <tr style="text-align: right;">\n      <th></th>\n      '


### PR DESCRIPTION
Previously, there was no way to view column descriptions in the HTML display of DynamicTables. I think this will be useful to add. When working on conversion projects I use the HTML to check that everthing is as intended. In addition, this feature will be useful for people reading new NWBFiles through the notebok (e.g. from Dandi) as it improves the representation of common but important tables such as trials, electrodes, and units. This is especially important for custom-added columns, where most columns are hard to interpret without a description.

For the implementation, a new collapsible "columns" section is added to the `generate_html_repr()` method in `DynamicTable`. Each column is displayed as an individually collapsible item (collapsed by default) that shows the column's description when expanded. Column names include an access code tooltip (e.g., `['column_name']`) that can be clicked to copy to clipboard, consistent with other field displays in the HTML representation.

This is how it looks:

<img width="656" height="729" alt="image" src="https://github.com/user-attachments/assets/af74e3f5-9049-4134-a42c-ed56e1efa06b" />


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
