### PR TITLE
Fix container class mapped to incorrect namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)
 
 ### Fixed
+- Fixed issue where a container was assigned to an incorrect namespace. @rly [#1373](https://github.com/hdmf-dev/hdmf/pull/1373)
 
 
 ## HDMF 4.2.0 (December 18, 2025)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -521,7 +521,7 @@ class TypeMap:
             for ns_key, ns_data_types in self.__container_types.items():
                 # NOTE that the type_name may appear in multiple namespaces based on how they were resolved
                 # but the same type_name should point to the same class
-                if data_type in ns_data_types:
+                if data_type in ns_data_types and not isinstance(ns_data_types[data_type], TypeSource):
                     namespace = ns_key
                     break
         if namespace is None:

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -1,11 +1,14 @@
+import shutil
+import tempfile
 from abc import ABCMeta, abstractmethod
 
 from hdmf.build import GroupBuilder, DatasetBuilder, ObjectMapper, BuildManager, TypeMap, ContainerConfigurationError
+from hdmf.build.manager import TypeSource
 from hdmf.spec import GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog
 from hdmf.spec.spec import ZERO_OR_MANY
 from hdmf.testing import TestCase
 
-from tests.unit.helpers.utils import Foo, FooBucket, CORE_NAMESPACE
+from tests.unit.helpers.utils import Foo, FooBucket, CORE_NAMESPACE, create_load_namespace_yaml
 
 
 class FooMapper(ObjectMapper):
@@ -343,6 +346,43 @@ class TestRetrieveContainerClass(TestBase):
     def test_get_dt_container_cls_no_namespace(self):
         with self.assertRaisesWith(ValueError, "Namespace could not be resolved for data type 'Unknown'."):
             self.type_map.get_dt_container_cls(data_type="Unknown")
+
+
+class TestRetrieveContainerClassWithTypeSource(TestCase):
+    """Test that get_dt_container_cls skips TypeSource entries when resolving namespace."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.type_map = TypeMap()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_get_dt_container_cls_skips_typesource(self):
+        """Test that namespace lookup skips TypeSource entries and finds the real class."""
+        # Create ns1 with type Bar
+        bar_spec = GroupSpec(doc='A test group spec', data_type_def='Bar')
+        create_load_namespace_yaml('ns1', [bar_spec], self.test_dir, {}, self.type_map)
+
+        # Create ns2 that includes Bar from ns1 - this registers a TypeSource for Bar in ns2
+        create_load_namespace_yaml('ns2', [], self.test_dir, {'ns1': ['Bar']}, self.type_map)
+
+        # ns2 should have a TypeSource for Bar (registered before ns1's class is generated)
+        self.assertIsInstance(self.type_map.container_types['ns2']['Bar'], TypeSource)
+
+        # Register actual class for Bar in ns1
+        Bar = self.type_map.get_dt_container_cls('Bar', 'ns1')
+
+        # Lookup Bar without namespace - should skip ns2's TypeSource and find ns1
+        ret = self.type_map.get_dt_container_cls(data_type='Bar')
+        self.assertIs(ret, Bar)
+
+        # Class should be associated with ns1, not ns2
+        ns, _ = self.type_map.get_container_cls_dt(Bar)
+        self.assertEqual(ns, 'ns1')
+
+        # ns2 should still have TypeSource (not resolved to Bar)
+        self.assertIsInstance(self.type_map.container_types['ns2']['Bar'], TypeSource)
 
 
 # TODO:


### PR DESCRIPTION
## Motivation

- Fix #1347 with a minimal change. Although this resolves the issue, the logic within load_namespaces and TypeMap regarding container class registration is not intuitive, and could be improved with a larger refactor as shown in #1372.

## How to test the behavior?
```
Run tests
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
