### PR TITLE
Add HTML repr to `LabelledDict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added support for Python 3.14. @bendichter [#1366](https://github.com/hdmf-dev/hdmf/issues/1366)
+- Added `_repr_html_` method to `LabelledDict` for interactive HTML display in notebooks. @h-mayorquin [#1381](https://github.com/hdmf-dev/hdmf/pull/1381)
 
 ### Changed
 - Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # HDMF Changelog
 
+## HDMF 4.3.1 (Upcoming)
+
+### Added
+- Added `_repr_html_` method to `LabelledDict` for interactive HTML display in notebooks. @h-mayorquin [#1381](https://github.com/hdmf-dev/hdmf/pull/1381)
+
+
 ## HDMF 4.3.0 (January 21, 2026)
 
 ### Added
 - Added support for Python 3.14. @bendichter [#1366](https://github.com/hdmf-dev/hdmf/issues/1366)
-- Added `_repr_html_` method to `LabelledDict` for interactive HTML display in notebooks. @h-mayorquin [#1381](https://github.com/hdmf-dev/hdmf/pull/1381)
 
 ### Changed
 - Added a collapsible "columns" section to the `DynamicTable` HTML representation that displays column descriptions, making it easier to inspect column metadata in notebooks. @h-mayorquin [#1369](https://github.com/hdmf-dev/hdmf/pull/1369)

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -1140,6 +1140,63 @@ class LabelledDict(dict):
         """update is not supported. A TypeError will be raised."""
         raise TypeError('update is not supported for %s' % self.__class__.__name__)
 
+    def _repr_html_(self):
+        """Generate an HTML representation of the LabelledDict.
+
+        This method produces an interactive HTML view similar to what is shown
+        when expanding a field in a Container's HTML representation. Each item
+        in the dict is displayed as an expandable section showing its own
+        HTML representation if available.
+        """
+        # CSS styles matching Container.css_style
+        css_style = """
+        <style>
+            .container-fields {
+                font-family: "Open Sans", Arial, sans-serif;
+            }
+            .container-fields .field-value {
+                color: #00788E;
+            }
+            .container-fields details > summary {
+                cursor: pointer;
+                display: list-item;
+            }
+            .container-fields details > summary:hover {
+                color: #0A6EAA;
+            }
+        </style>
+        """
+
+        html_repr = css_style
+        html_repr += "<div class='container-wrap'>"
+        html_repr += f"<div class='container-header'><div class='xr-obj-type'><h3>{self.label}</h3></div></div>"
+
+        if len(self) == 0:
+            html_repr += "<div class='container-fields'><i>Empty</i></div>"
+            html_repr += "</div>"
+            return html_repr
+
+        for key, value in self.items():
+            # Get the class name for display
+            class_name = type(value).__name__
+            display_name = f"{key} <span style='font-weight: normal; color: #888;'>({class_name})</span>"
+
+            # Delegate to the item's _repr_html_ if available
+            if hasattr(value, '_repr_html_'):
+                inner_html = value._repr_html_()
+            else: # Edge case, I am not sure when if this can happen
+                inner_html = f"<span class='field-value'>{value}</span>"
+
+            html_repr += (
+                f"<details><summary style='display: list-item; margin-left: 0px;' "
+                f"class='container-fields field-key' title=\"['{key}']\"><b>{display_name}</b></summary>"
+            )
+            html_repr += f"<div style='margin-left: 20px;'>{inner_html}</div>"
+            html_repr += "</details>"
+
+        html_repr += "</div>"
+        return html_repr
+
 
 @docval_macro('array_data')
 class StrDataset(h5py.Dataset):

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -302,3 +302,25 @@ class TestLabelledDict(TestCase):
         self.assertIn('item2', html)
         self.assertIn('MyTestClass', html)
         self.assertIn('<style>', html)
+
+    def test_repr_html_empty(self):
+        """Test that _repr_html_ works on an empty LabelledDict."""
+        ld = LabelledDict(label='acquisition', key_attr='prop1')
+        html = ld._repr_html_()
+        self.assertIn('acquisition', html)
+        self.assertIn('Empty', html)
+
+    def test_repr_html_nested(self):
+        """Test that _repr_html_ uses item's _repr_html_ when available."""
+        from hdmf.container import Container
+
+        ld = LabelledDict(label='acquisition', key_attr='name')
+        container = Container('my_container')
+        ld.add(container)
+
+        html = ld._repr_html_()
+        self.assertIn('acquisition', html)
+        self.assertIn('my_container', html)
+        self.assertIn('Container', html)
+        # Verify nested _repr_html_ was called (Container's HTML includes this class)
+        self.assertIn('container-header', html)

--- a/tests/unit/utils_test/test_labelleddict.py
+++ b/tests/unit/utils_test/test_labelleddict.py
@@ -287,3 +287,18 @@ class TestLabelledDict(TestCase):
 
         with self.assertRaisesWith(TypeError, "setdefault is not supported for LabelledDict"):
             ld.setdefault(object())
+
+    def test_repr_html_(self):
+        """Test that _repr_html_ generates HTML with label and items."""
+        ld = LabelledDict(label='acquisition', key_attr='prop1')
+        obj1 = MyTestClass('item1', 'value1')
+        obj2 = MyTestClass('item2', 'value2')
+        ld.add(obj1)
+        ld.add(obj2)
+
+        html = ld._repr_html_()
+        self.assertIn('acquisition', html)
+        self.assertIn('item1', html)
+        self.assertIn('item2', html)
+        self.assertIn('MyTestClass', html)
+        self.assertIn('<style>', html)


### PR DESCRIPTION
## Motivation

Right now it looks like this:
<img width="987" height="833" alt="image" src="https://github.com/user-attachments/assets/0db916c8-3942-41fc-8a43-78bc4f387879" />


After this PR:
<img width="639" height="603" alt="image" src="https://github.com/user-attachments/assets/9ac57b22-4f79-41bb-bc75-9fa10d4bd43b" />



## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
