### PR TITLE
Fix tox env names in workflows

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py313-upgraded
+          tox -e pytest-py314-upgraded
 
       - name: Build wheel and source distribution
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
           - { name: windows-python3.9-minimum            , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.14-upgraded-optional , test-tox-env: pytest-py314-upgraded-optional , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum              , test-tox-env: pytest-py39-minimum            , python-ver: "3.9" , os: macos-15-intel }
-          - { name: macos-python3.14-upgraded            , test-tox-env: pytest-py313-upgraded          , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-upgraded            , test-tox-env: pytest-py314-upgraded          , python-ver: "3.14", os: macos-latest }
           # No prebuilt wheels for numcodecs==0.15.1 for Python 3.14 on PyPI and cannot build numcodecs == 0.15.1 on macos-latest
           # So optional requirements testing on macos-latest (arm64) is disabled. See https://github.com/hdmf-dev/hdmf/pull/1367
           - { name: macos-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: macos-latest }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # HDMF Changelog
 
-## HDMF 4.3.0 (January 21, 2026)
+## HDMF 4.3.1 (Upcoming)
+
+### Fixed
+- Fixed issue with with testing and deployment of releases. @rly [#1383](https://github.com/hdmf-dev/hdmf/pull/1383)
+
+
+## HDMF 4.3.0 (January 22, 2026)
 
 ### Added
 - Added support for Python 3.14. @bendichter [#1366](https://github.com/hdmf-dev/hdmf/issues/1366)


### PR DESCRIPTION
## Motivation

Fix #1382 

## How to test the behavior?
```
Will have to make a tag/release
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
