### PR TITLE
Fix "different specification" warning around unresolved specs

### DIFF
--- a/src/hdmf/spec/namespace.py
+++ b/src/hdmf/spec/namespace.py
@@ -314,11 +314,28 @@ class NamespaceCatalog:
         if name in self.__namespaces:
             raise KeyError("namespace '%s' already exists" % name)
         self.__namespaces[name] = namespace
+
+        # Determine which source files are owned by this namespace
+        # (not imported from other namespaces via 'namespace' schema entries).
+        # Only specs from own sources should be added to the unresolved cache
+        # to avoid duplicates when multiple namespaces import the same types.
+        own_sources = set()
+        for elem in namespace.schema:
+            if 'source' in elem:
+                own_sources.add(elem['source'])
+
         for dt in namespace.catalog.get_registered_types():
             source = namespace.catalog.get_spec_source_file(dt)
             # do not add types that have already been loaded
             # use dict with None values as ordered set because order of specs does matter
             self.__loaded_specs.setdefault(source, dict()).update({dt: None})
+
+            # Only add to unresolved spec dicts for types from this namespace's
+            # own source files. Types imported from other namespaces are already
+            # tracked under their original namespace's source.
+            if source not in own_sources:
+                continue
+
             # Build the unresolved spec dict for caching (if not already present from file loading)
             if source not in self.__unresolved_spec_dicts:
                 self.__unresolved_spec_dicts[source] = {'groups': [], 'datasets': []}

--- a/tests/unit/spec_tests/test_load_namespace.py
+++ b/tests/unit/spec_tests/test_load_namespace.py
@@ -329,6 +329,43 @@ class TestCatchDupNS(TestCase):
             self.assertTrue(str(w.message) != msg)
             warnings.warn(str(w.message), w.category)
 
+class TestMergeNoDuplicateSpecs(TestCase):
+    """Test that merging namespace catalogs does not create duplicate entries in the unresolved spec cache."""
+
+    def test_merge_no_duplicate_unresolved_specs(self):
+        """After merging, get_spec_source_dict should not return duplicate specs for shared source files."""
+        hdmf_typemap = get_type_map()
+
+        # Create a new catalog and merge the hdmf type map into it
+        ns_catalog = NamespaceCatalog()
+        ns_catalog.merge(hdmf_typemap.namespace_catalog)
+
+        # hdmf-common's base.yaml defines: Data (dataset), Container (group), SimpleMultiContainer (group).
+        # hdmf-experimental imports these types but should NOT cause duplicates in the unresolved cache.
+        spec_dict = ns_catalog.get_spec_source_dict('base.yaml')
+        self.assertIsNotNone(spec_dict)
+        dataset_defs = [s.data_type_def for s in spec_dict.get('datasets', [])]
+        group_defs = [s.data_type_def for s in spec_dict.get('groups', [])]
+        self.assertEqual(dataset_defs, ['Data'])
+        self.assertEqual(group_defs, ['Container', 'SimpleMultiContainer'])
+
+    def test_convert_namespace_no_warnings_after_merge(self):
+        """convert_namespace should not produce warnings about different specifications after merge."""
+        from hdmf.backends.utils import NamespaceToBuilderHelper
+
+        hdmf_typemap = get_type_map()
+        ns_catalog = NamespaceCatalog()
+        ns_catalog.merge(hdmf_typemap.namespace_catalog)
+
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+            for ns_name in ns_catalog.namespaces:
+                NamespaceToBuilderHelper.convert_namespace(ns_catalog, ns_name)
+
+        spec_warnings = [w for w in ws if 'different specification' in str(w.message)]
+        self.assertEqual(spec_warnings, [], f"Unexpected spec warnings: {[str(w.message) for w in spec_warnings]}")
+
+
 class TestCustomSpecClasses(TestCase):
 
     def setUp(self):  # noqa: C901


### PR DESCRIPTION
## Motivation

Fix #1400.

No changelog is needed because this bug was introduced in the dev branch after the last release.

### Root Cause

`NamespaceCatalog.add_namespace()` appends specs to `__unresolved_spec_dicts` for **all** registered types in a namespace, including types imported from other namespaces. When called for multiple namespaces that share types (e.g., `hdmf-common` then `hdmf-experimental`, which imports hdmf-common types), shared types like `Data` get appended multiple times.

The duplicates also have mismatched keys (`data_type_def` vs `neurodata_type_def`) because imported types are rebuilt using the importing namespace's spec classes, making them unequal and triggering the warning during `convert_namespace`.

### Fix

In `add_namespace`, only append specs to the unresolved cache for types whose source file is one of the namespace's **own** source files (from `schema` entries with a `source` key). Types imported from other namespaces are skipped since they are already tracked under their original namespace.


## How to test the behavior?
```
Run pynwb and hdmf-zarr tests and observe the lack of warning. New HDMF tests were also added.
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
