### PR TITLE
Reduce memory allocations in ragged column writing by using `np.concatenate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Added warning when `data_type_def` and `data_type_inc` are the same in a spec. @rly [#1312](https://github.com/hdmf-dev/hdmf/pull/1312)
 - Added abstract methods `HDMFIO.load_namespaces` and `HDMFIO.load_namespaces_io`. @rly [#1299](https://github.com/hdmf-dev/hdmf/pull/1299)
 
+### Enhancements
+- Reduced memory allocations in `DynamicTable.add_column(..., index=True)` ragged column flattening by using `np.concatenate` instead of `list(itertools.chain.from_iterable(...))` when all entries are compatible numpy arrays. @h-mayorquin [#1403](https://github.com/hdmf-dev/hdmf/pull/1403)
+
 ### Fixed
 - Fixed a broken test and refactored `VectorIndex.get`. @rly, @mavaylon1 [#1293](https://github.com/hdmf-dev/hdmf/pull/1293)
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -21,15 +21,9 @@ from ..term_set import TermSetWrapper
 
 def _flatten_one_ragged_level(data):
     """Flatten one ragged nesting level with a fast path for numpy arrays."""
-    if len(data) == 0:
-        return []
-
     all_entries_are_numpy_arrays = all(isinstance(value, np.ndarray) for value in data)
     if all_entries_are_numpy_arrays:
-        try:
-            return np.concatenate(data)
-        except (TypeError, ValueError):
-            pass
+        return np.concatenate(data)
 
     return list(itertools.chain.from_iterable(data))
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -24,22 +24,12 @@ def _flatten_one_ragged_level(data):
     if len(data) == 0:
         return []
 
-    # Explicit NumPy fast path with readability-oriented checks.
     all_entries_are_numpy_arrays = all(isinstance(value, np.ndarray) for value in data)
     if all_entries_are_numpy_arrays:
-        first_array = data[0]
-        # Check whether all arrays have the same nonzero number of dimensions
-        first_array_has_nonzero_dimension = first_array.ndim > 0
-        all_arrays_have_same_dimension = all(value.ndim == first_array.ndim for value in data)
-        if first_array_has_nonzero_dimension and all_arrays_have_same_dimension:
-            all_arrays_have_same_trailing_shape = (
-                first_array.ndim == 1 or all(value.shape[1:] == first_array.shape[1:] for value in data)
-            )
-            if all_arrays_have_same_trailing_shape:
-                try:
-                    return np.concatenate(data)
-                except (TypeError, ValueError):
-                    pass
+        try:
+            return np.concatenate(data)
+        except (TypeError, ValueError):
+            pass
 
     return list(itertools.chain.from_iterable(data))
 

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -21,6 +21,9 @@ from ..term_set import TermSetWrapper
 
 def _flatten_one_ragged_level(data):
     """Flatten one ragged nesting level with a fast path for numpy arrays."""
+    if len(data) == 0:
+        return []
+
     all_entries_are_numpy_arrays = all(isinstance(value, np.ndarray) for value in data)
     if all_entries_are_numpy_arrays:
         return np.concatenate(data)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -28,9 +28,10 @@ def _flatten_one_ragged_level(data):
     all_entries_are_numpy_arrays = all(isinstance(value, np.ndarray) for value in data)
     if all_entries_are_numpy_arrays:
         first_array = data[0]
-        all_arrays_have_nonzero_dimension = first_array.ndim > 0
+        # Check whether all arrays have the same nonzero number of dimensions
+        first_array_has_nonzero_dimension = first_array.ndim > 0
         all_arrays_have_same_dimension = all(value.ndim == first_array.ndim for value in data)
-        if all_arrays_have_nonzero_dimension and all_arrays_have_same_dimension:
+        if first_array_has_nonzero_dimension and all_arrays_have_same_dimension:
             all_arrays_have_same_trailing_shape = (
                 first_array.ndim == 1 or all(value.shape[1:] == first_array.shape[1:] for value in data)
             )

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -19,6 +19,30 @@ from ..utils import docval, getargs, ExtenderMeta, popargs, pystr, AllowPosition
 from ..term_set import TermSetWrapper
 
 
+def _flatten_one_ragged_level(data):
+    """Flatten one ragged nesting level with a fast path for numpy arrays."""
+    if len(data) == 0:
+        return []
+
+    # Explicit NumPy fast path with readability-oriented checks.
+    all_entries_are_numpy_arrays = all(isinstance(value, np.ndarray) for value in data)
+    if all_entries_are_numpy_arrays:
+        first_array = data[0]
+        all_arrays_have_nonzero_dimension = first_array.ndim > 0
+        all_arrays_have_same_dimension = all(value.ndim == first_array.ndim for value in data)
+        if all_arrays_have_nonzero_dimension and all_arrays_have_same_dimension:
+            all_arrays_have_same_trailing_shape = (
+                first_array.ndim == 1 or all(value.shape[1:] == first_array.shape[1:] for value in data)
+            )
+            if all_arrays_have_same_trailing_shape:
+                try:
+                    return np.concatenate(data)
+                except (TypeError, ValueError):
+                    pass
+
+    return list(itertools.chain.from_iterable(data))
+
+
 @register_class('VectorData')
 class VectorData(Data):
     """
@@ -983,7 +1007,7 @@ class DynamicTable(Container):
                     except TypeError as e:
                         raise ValueError("Cannot automatically construct VectorIndex for nested array. "
                                          "Invalid data array element found.") from e
-                    flatten_data = list(itertools.chain.from_iterable(flatten_data))
+                    flatten_data = _flatten_one_ragged_level(flatten_data)
                 # if our data still is an array (e.g., a list or numpy array) then warn that the index parameter
                 # may be incorrect.
                 if len(flatten_data) > 0 and isinstance(flatten_data[0], (np.ndarray, list, tuple)):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -557,6 +557,23 @@ class TestDynamicTable(TestCase):
         self.assertListEqual(table['qux'][:], expected + [[10, 11, 12], ])
         self.assertListEqual(table.qux_index.data, [3, 7, 10])
 
+    def test_add_column_auto_index_bool_with_numpy_object_array(self):
+        """Regression: auto-index flattening preserves semantics when data is a numpy object array.
+
+        numpy object arrays (dtype=object) are a common input for ragged columns. This ensures that the
+        np.concatenate fast path in _flatten_one_ragged_level produces the same cell values and
+        VectorIndex boundaries as the original itertools.chain path.
+        """
+        table = self.with_spec()
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        expected = [np.array([1, 2, 3]), np.array([1, 2, 3, 4])]
+        data = np.array(expected, dtype=object)
+        table.add_column(name='qux', description='qux column', data=data, index=True)
+        np.testing.assert_array_equal(table['qux'][:][0], expected[0])
+        np.testing.assert_array_equal(table['qux'][:][1], expected[1])
+        self.assertListEqual(table.qux_index.data, [3, 7])
+
     def test_add_column_auto_multi_index_int(self):
         """
         Add a column as a list of lists of lists after we have already added data so that we need to create a

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -570,10 +570,11 @@ class TestDynamicTable(TestCase):
         expected = [np.array([1, 2, 3]), np.array([1, 2, 3, 4])]
         data = np.array(expected, dtype=object)
         table.add_column(name='qux', description='qux column', data=data, index=True)
-        # The flattened data should remain a numpy array, not a Python list
+        # The underlying VectorData should remain a numpy array, not a Python list
         expected_data = np.array([1, 2, 3, 1, 2, 3, 4])
-        self.assertIsInstance(table['qux'].data, np.ndarray)
-        np.testing.assert_array_equal(table['qux'].data, expected_data)
+        vector_data = table['qux'].target
+        self.assertIsInstance(vector_data.data, np.ndarray)
+        np.testing.assert_array_equal(vector_data.data, expected_data)
         self.assertListEqual(table.qux_index.data, [3, 7])
 
     def test_add_column_auto_multi_index_int(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -557,12 +557,12 @@ class TestDynamicTable(TestCase):
         self.assertListEqual(table['qux'][:], expected + [[10, 11, 12], ])
         self.assertListEqual(table.qux_index.data, [3, 7, 10])
 
-    def test_add_column_auto_index_bool_with_numpy_object_array(self):
-        """Regression: auto-index flattening preserves semantics when data is a numpy object array.
+    def test_add_column_auto_index_bool_with_numpy_arrays(self):
+        """Regression: add_column with index=True preserves numpy array storage.
 
-        numpy object arrays (dtype=object) are a common input for ragged columns. This ensures that the
-        np.concatenate fast path in _flatten_one_ragged_level produces the same cell values and
-        VectorIndex boundaries as the original itertools.chain path.
+        When ragged column data is provided as numpy arrays, the underlying VectorData should
+        store an ndarray rather than a Python list. This avoids unnecessary memory allocations
+        during writing.
         """
         table = self.with_spec()
         table.add_row(foo=5, bar=50.0, baz='lizard')
@@ -570,8 +570,10 @@ class TestDynamicTable(TestCase):
         expected = [np.array([1, 2, 3]), np.array([1, 2, 3, 4])]
         data = np.array(expected, dtype=object)
         table.add_column(name='qux', description='qux column', data=data, index=True)
-        np.testing.assert_array_equal(table['qux'][:][0], expected[0])
-        np.testing.assert_array_equal(table['qux'][:][1], expected[1])
+        # The flattened data should remain a numpy array, not a Python list
+        expected_data = np.array([1, 2, 3, 1, 2, 3, 4])
+        self.assertIsInstance(table['qux'].data, np.ndarray)
+        np.testing.assert_array_equal(table['qux'].data, expected_data)
         self.assertListEqual(table.qux_index.data, [3, 7])
 
     def test_add_column_auto_multi_index_int(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -593,6 +593,19 @@ class TestDynamicTable(TestCase):
         np.testing.assert_array_equal(vector_data.data, expected_data)
         self.assertListEqual(table.qux_index.data, [3, 7])
 
+    def test_add_column_auto_index_with_empty_sub_arrays(self):
+        """Regression: add_column with index=2 handles rows containing empty sub-arrays.
+
+        When index > 1, the first flatten can produce an empty list (e.g., [[], []] flattens to []).
+        The second flatten iteration must handle that empty input without raising.
+        """
+        table = self.with_spec()
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        table.add_row(foo=5, bar=50.0, baz='lizard')
+        data = [[], []]
+        table.add_column(name='qux', description='qux column', data=data, index=2)
+        self.assertListEqual(table['qux'][:], [[], []])
+
     def test_add_column_auto_multi_index_int(self):
         """
         Add a column as a list of lists of lists after we have already added data so that we need to create a


### PR DESCRIPTION
## Motivation


I am working on converting sessions from the IBL project to NWB, and some of these sessions contain large ragged array columns on the units table. During writing, I observed total memory allocations of around 24 GiB, with some sessions exceeding 32 GiB, so I am concerned about reducing the memory footprint. Profiling reveals that a meaningful part of the allocations comes from `DynamicTable.add_column(..., index=True)`: when it receives ragged data, it flattens it using `list(itertools.chain.from_iterable(data))`, which iterates element-by-element through every numpy array, boxing each value into an individual Python object and appending it to a growing list.

This PR adds a `_flatten_one_ragged_level` helper that detects when all entries are compatible numpy arrays and flattens them with a single `np.concatenate` call. Unlike the `itertools.chain` path, `np.concatenate` computes the total output size upfront, allocates one contiguous buffer, and copies raw memory without creating any intermediate Python objects. The function validates shape compatibility (matching ndim and trailing dimensions) and falls back to the original `itertools.chain` path for non-array or mixed-type data, so behavior is unchanged for edge cases. 

## How to test the behavior?
<details>
<summary>Profiling script</summary>

```python

import itertools
import os
import resource

import numpy as np

import hdmf.common.table as table_mod
from hdmf.common.table import DynamicTable

try:
    import psutil
except ImportError:  # pragma: no cover
    psutil = None

# Toggle between "current" and "old" for before/after profiling.
MODE = "old"
NUM_UNITS = 800
SPIKES_PER_UNIT = 4000
REPEAT = 2

if MODE == "old":
    table_mod._flatten_one_ragged_level = lambda data: list(itertools.chain.from_iterable(data))

table = DynamicTable(name="units", description="memray ragged flatten profile")
table.add_column(name="label", description="unit label")
for i in range(NUM_UNITS):
    table.add_row(label=f"u{i}")

for rep in range(REPEAT):
    rng = np.random.default_rng(rep)
    rows = []
    for _ in range(NUM_UNITS):
        n = int(rng.poisson(SPIKES_PER_UNIT))
        arr = np.sort(rng.random(max(n, 1), dtype=np.float64) * 1000.0)
        rows.append(arr)
    ragged = np.array(rows, dtype=object)
    table.add_column(
        name=f"spike_times_{rep}",
        description="ragged spike times",
        data=ragged,
        index=True,
    )

print(f"mode={MODE} rows={len(table)} columns={len(table.colnames)}")

# Peak resident set size from the OS (KB on Linux, bytes on macOS).
ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
peak_rss_bytes = ru_maxrss if os.uname().sysname == "Darwin" else ru_maxrss * 1024
peak_rss_mib = peak_rss_bytes / (1024 ** 2)

if psutil is not None:
    process = psutil.Process(os.getpid())
    current_rss_mib = process.memory_info().rss / (1024 ** 2)
    print(f"current_rss_mib={current_rss_mib:.2f} peak_rss_mib={peak_rss_mib:.2f}")
else:
    print(f"peak_rss_mib={peak_rss_mib:.2f} (psutil not installed; current RSS unavailable)")
```

</details>

Using the script above with 800 units and ~4,000 spikes each, the old path uses ~424 MiB RSS versus ~203 MiB with the new path (~2x reduction). Memray reports a larger gap: peak tracked memory drops from 361 MB to 148 MB (~2.4x) and total allocations from 1.05 GB to 387 MB (~2.7x), while allocation count stays roughly the same (~59k vs ~56k). 

I am not very familiar with a lot of the machinery I am touching here, so I am wary of unintended side effects, but I thought the best way to start the discussion would be with a PR.






## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
