### PR TITLE
Fix `VectorData.extend()` corrupting 1D numpy arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added abstract methods `HDMFIO.load_namespaces` and `HDMFIO.load_namespaces_io`. @rly [#1299](https://github.com/hdmf-dev/hdmf/pull/1299)
 
 ### Fixed
+- Fixed `VectorData.extend()` silently corrupting 1D numpy arrays by reshaping them into 2D matrices. Replaced `np.vstack` with `np.concatenate` in `extend_data`. @h-mayorquin [#1405](https://github.com/hdmf-dev/hdmf/pull/1405)
 - Fixed a broken test and refactored `VectorIndex.get`. @rly, @mavaylon1 [#1293](https://github.com/hdmf-dev/hdmf/pull/1293)
 
 

--- a/src/hdmf/data_utils.py
+++ b/src/hdmf/data_utils.py
@@ -64,7 +64,7 @@ def extend_data(data, arg):
         data.extend(arg)
         return data
     elif isinstance(data, np.ndarray):
-        return np.vstack((data, arg))
+        return np.concatenate((data, arg))
     elif isinstance(data, h5py.Dataset):
         shape = list(data.shape)
         shape[0] += len(arg)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -258,7 +258,21 @@ class TestDynamicTable(TestCase):
         )
         compound_vector_data.extend(c_data2)
 
-        np.testing.assert_array_equal(compound_vector_data.data, np.vstack((c_data, c_data2)))
+        expected = np.array([('Homo sapiens', 24), ('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        np.testing.assert_array_equal(compound_vector_data.data, expected)
+
+    def test_1d_ndarray_extend(self):
+        """Test that extending a 1D numpy array produces a flat 1D result, not 2D."""
+        vector_data = VectorData(
+            name='scores',
+            description='scalar column',
+            data=np.array([1.0, 2.0])
+        )
+        vector_data.extend(np.array([3.0, 4.0]))
+
+        expected = np.array([1.0, 2.0, 3.0, 4.0])
+        np.testing.assert_array_equal(vector_data.data, expected)
+        self.assertEqual(vector_data.data.ndim, 1)
 
     @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_array_append(self):
@@ -286,7 +300,8 @@ class TestDynamicTable(TestCase):
         )
         vector_data.extend(data2)
 
-        np.testing.assert_array_equal(vector_data.data.data, np.vstack((data, data2)))
+        expected = np.array(['Homo sapiens', 'Mus musculus'])
+        np.testing.assert_array_equal(vector_data.data.data, expected)
 
     @unittest.skipIf(not REQUIREMENTS_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_wrapped_compound_data_append(self):
@@ -314,7 +329,8 @@ class TestDynamicTable(TestCase):
         )
         compound_vector_data.extend(c_data2)
 
-        np.testing.assert_array_equal(compound_vector_data.data.data, np.vstack((c_data, c_data2)))
+        expected = np.array([('Homo sapiens', 24), ('Mus musculus', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
+        np.testing.assert_array_equal(compound_vector_data.data.data, expected)
 
     def test_constructor_bad_columns(self):
         columns = ['bad_column']


### PR DESCRIPTION
## Motivation

`extend_data` in `data_utils.py` uses `np.vstack` to extend numpy arrays, which silently reshapes 1D arrays into 2D matrices instead of concatenating them. For example, extending `[1.0, 2.0]` with `[3.0, 4.0]` produces `[[1.0, 2.0], [3.0, 4.0]]` instead of the expected `[1.0, 2.0, 3.0, 4.0]`. This PR replaces `np.vstack` with `np.concatenate`, which handles all dimensionalities correctly.




## How to test the behavior?
For example, building an electrode table with numpy-backed columns and extending it corrupts the data:

```python
from hdmf.common.table import DynamicTable, VectorData

locations = VectorData(name="location", description="brain region", data=np.array(["CA1", "CA1", "CA3", "CA3"]))
impedances = VectorData(name="impedance", description="impedance in ohms", data=np.array([1.2e6, 1.3e6, 1.1e6, 1.4e6]))

table = DynamicTable(name="electrodes", description="extracellular electrodes", columns=[locations, impedances])

# Add a second batch of electrodes
table["location"].extend(np.array(["VISp", "VISp", "VISl", "VISl"]))
table["impedance"].extend(np.array([1.5e6, 1.6e6, 1.7e6, 1.8e6]))

table["location"].data.shape  # Expected: (8,)  Actual: (2, 4)
table["location"].data
# Expected: ["CA1", "CA1", "CA3", "CA3", "VISp", "VISp", "VISl", "VISl"]
# Actual:   [["CA1", "CA1", "CA3", "CA3"],
#            ["VISp", "VISp", "VISl", "VISl"]]
```

The table goes from 8 electrodes to a 2x4 matrix. Each row now returns an array of four locations instead of a single string, breaking any downstream code that iterates over electrodes.
## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
