### PR TITLE
Fix reverse class-to-namespace map overwrite when extensions include core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added abstract methods `HDMFIO.load_namespaces` and `HDMFIO.load_namespaces_io`. @rly [#1299](https://github.com/hdmf-dev/hdmf/pull/1299)
 
 ### Fixed
+- Fixed `register_container_type` overwriting the reverse class-to-namespace map when an extension calls `include_namespace("core")`, which caused core types to be stamped with the extension's namespace. @h-mayorquin [#1407](https://github.com/hdmf-dev/hdmf/pull/1407)
 - Fixed a broken test and refactored `VectorIndex.get`. @rly, @mavaylon1 [#1293](https://github.com/hdmf-dev/hdmf/pull/1293)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Reduced memory allocations in `DynamicTable.add_column(..., index=True)` ragged column flattening by using `np.concatenate` instead of `list(itertools.chain.from_iterable(...))` when all entries are compatible numpy arrays. @h-mayorquin [#1403](https://github.com/hdmf-dev/hdmf/pull/1403)
 
 ### Fixed
-- Fixed `register_container_type` overwriting the reverse class-to-namespace map when an extension calls `include_namespace("core")`, which caused core types to be stamped with the extension's namespace. @h-mayorquin [#1407](https://github.com/hdmf-dev/hdmf/pull/1407)
+- Fixed `register_container_type` overwriting the reverse class-to-namespace map when an extension calls `include_namespace("core")`, which caused core types to be stamped with the extension's namespace. @h-mayorquin, @rly [#1407](https://github.com/hdmf-dev/hdmf/pull/1407)
 - Fixed `VectorData.extend()` silently corrupting 1D numpy arrays by reshaping them into 2D matrices. Replaced `np.vstack` with `np.concatenate` in `extend_data`. @h-mayorquin [#1405](https://github.com/hdmf-dev/hdmf/pull/1405)
 - Fixed a broken test and refactored `VectorIndex.get`. @rly, @mavaylon1 [#1293](https://github.com/hdmf-dev/hdmf/pull/1293)
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -783,7 +783,7 @@ class TypeMap:
              'doc': 'the namespace to get the container classes for', 'default': None})
     def get_container_classes(self, **kwargs):
         namespace = getargs('namespace', kwargs)
-        ret = self.__container_cls_to_ns_dt.keys()
+        ret = (k for k in self.__container_cls_to_ns_dt if not isinstance(k, TypeSource))
         if namespace is not None:
             ret = filter(lambda x: self.__container_cls_to_ns_dt[x][0] == namespace, ret)
         return list(ret)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -826,22 +826,22 @@ class TypeMap:
         spec = self.__ns_catalog.get_spec(namespace, data_type)  # make sure the spec exists
         self.__ns_dt_to_container_cls.setdefault(namespace, dict())
         previous_cls = self.__ns_dt_to_container_cls[namespace].get(data_type)
-        # set or replace mapping in ns_dt_to_container_cls
         self.__ns_dt_to_container_cls[namespace][data_type] = container_cls
-        if previous_cls is not None:
-            # NOTE: Removing previous_cls from container_cls_to_ns_dt but previous_cls may still
-            # exist in ns_dt_to_container_cls if it was a TypeSource registered for multiple namespaces.
-            self.__container_cls_to_ns_dt.pop(previous_cls, None)
-        # Keep the first registration: base namespaces are always loaded before extensions
-        # (guaranteed by the topological sort in NamespaceCatalog._order_deps), so the first
-        # entry is the defining namespace. When an extension calls include_namespace("core"),
-        # every core type gets re-registered under the extension namespace; without this guard,
-        # the reverse map would point core types like NWBFile to the extension instead of "core".
+        # Remove the previous reverse-map entry only if it belongs to this (namespace, data_type).
+        # A class can appear in multiple namespaces' forward maps (e.g. via include_namespace),
+        # so we must not remove an entry that belongs to a different namespace.
+        if previous_cls is not None and self.__container_cls_to_ns_dt.get(previous_cls) == (namespace, data_type):
+            self.__container_cls_to_ns_dt.pop(previous_cls)
+        # Only set the reverse map and class attributes on first registration. Base namespaces
+        # are loaded before extensions (topological sort in NamespaceCatalog._order_deps), so
+        # the first entry is the defining namespace. Extensions that include a base namespace
+        # re-register its types; this guard keeps the reverse map and class attributes pointing
+        # to the original namespace.
         if container_cls not in self.__container_cls_to_ns_dt:
             self.__container_cls_to_ns_dt[container_cls] = (namespace, data_type)
-        if not isinstance(container_cls, TypeSource):
-            setattr(container_cls, spec.type_key(), data_type)
-            setattr(container_cls, 'namespace', namespace)
+            if not isinstance(container_cls, TypeSource):
+                setattr(container_cls, spec.type_key(), data_type)
+                setattr(container_cls, 'namespace', namespace)
 
     @docval({"name": "container_cls", "type": type,
              "doc": "the AbstractContainer class for which the given ObjectMapper class gets used for"},

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -832,7 +832,13 @@ class TypeMap:
             # NOTE: Removing previous_cls from container_cls_to_ns_dt but previous_cls may still
             # exist in ns_dt_to_container_cls if it was a TypeSource registered for multiple namespaces.
             self.__container_cls_to_ns_dt.pop(previous_cls, None)
-        self.__container_cls_to_ns_dt[container_cls] = (namespace, data_type)
+        # Keep the first registration: base namespaces are always loaded before extensions
+        # (guaranteed by the topological sort in NamespaceCatalog._order_deps), so the first
+        # entry is the defining namespace. When an extension calls include_namespace("core"),
+        # every core type gets re-registered under the extension namespace; without this guard,
+        # the reverse map would point core types like NWBFile to the extension instead of "core".
+        if container_cls not in self.__container_cls_to_ns_dt:
+            self.__container_cls_to_ns_dt[container_cls] = (namespace, data_type)
         if not isinstance(container_cls, TypeSource):
             setattr(container_cls, spec.type_key(), data_type)
             setattr(container_cls, 'namespace', namespace)

--- a/tests/unit/build_tests/test_classgenerator.py
+++ b/tests/unit/build_tests/test_classgenerator.py
@@ -5,7 +5,6 @@ from warnings import warn
 
 from hdmf.build import TypeMap, CustomClassGenerator
 from hdmf.build.classgenerator import ClassGeneratorManager, MCIClassGenerator
-from hdmf.build.manager import TypeSource
 from hdmf.container import Container, Data, MultiContainerInterface, AbstractContainer
 from hdmf.spec import (
     GroupSpec, AttributeSpec, DatasetSpec, SpecCatalog, SpecNamespace, NamespaceCatalog, LinkSpec, RefSpec
@@ -888,9 +887,8 @@ class TestGetClassObjectReferences(TestCase):
             incl_types={},
             type_map=self.type_map
         )
-        # the type map should contain only TypeSource entries at this point
-        assert len(self.type_map.get_container_classes('ndx-test')) == 2
-        assert all([isinstance(c, TypeSource) for c in self.type_map.get_container_classes('ndx-test')])
+        # no classes should be resolved yet
+        assert len(self.type_map.get_container_classes('ndx-test')) == 0
 
         self.type_map.get_dt_container_cls('Moo', 'ndx-test')
         # now, Moo and Qux should be resolved
@@ -922,9 +920,8 @@ class TestGetClassObjectReferences(TestCase):
             incl_types={},
             type_map=self.type_map
         )
-        # the type map should contain only TypeSource entries at this point
-        assert len(self.type_map.get_container_classes('ndx-test')) == 2
-        assert all([isinstance(c, TypeSource) for c in self.type_map.get_container_classes('ndx-test')])
+        # no classes should be resolved yet
+        assert len(self.type_map.get_container_classes('ndx-test')) == 0
 
         self.type_map.get_dt_container_cls('Woo', 'ndx-test')
         # now, Woo and Qux should be resolved
@@ -965,9 +962,8 @@ class TestGetClassObjectReferences(TestCase):
             incl_types={},
             type_map=self.type_map
         )
-        # the type map should contain only TypeSource entries at this point
-        assert len(self.type_map.get_container_classes('ndx-test')) == 3
-        assert all([isinstance(c, TypeSource) for c in self.type_map.get_container_classes('ndx-test')])
+        # no classes should be resolved yet
+        assert len(self.type_map.get_container_classes('ndx-test')) == 0
 
         self.type_map.get_dt_container_cls('Goo', 'ndx-test')
         # now, Goo, Spam, and Qux should be resolved
@@ -1011,9 +1007,8 @@ class TestGetClassObjectReferences(TestCase):
             incl_types={},
             type_map=self.type_map
         )
-        # the type map should contain only TypeSource entries at this point
-        assert len(self.type_map.get_container_classes('ndx-test')) == 3
-        assert all([isinstance(c, TypeSource) for c in self.type_map.get_container_classes('ndx-test')])
+        # no classes should be resolved yet
+        assert len(self.type_map.get_container_classes('ndx-test')) == 0
 
         self.type_map.get_dt_container_cls('Boo', 'ndx-test')
         # now, Boo, Bam, and Qux should be resolved

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -649,26 +649,22 @@ class TestGetDtContainerClsTypeSourceResolution(TestCase):
         self.assertIsNone(cls)
 
     def test_get_container_classes_after_partial_resolution(self):
-        """Test get_container_classes with a mix of TypeSource and real classes."""
+        """Test get_container_classes only returns resolved classes, not TypeSource placeholders."""
         bar_spec = GroupSpec(doc='A test group spec', data_type_def='Bar')
         baz_spec = GroupSpec(doc='A test group spec', data_type_def='Baz')
         create_load_namespace_yaml('ns1', [bar_spec, baz_spec], self.test_dir, {}, self.type_map)
 
-        # Initially, all should be TypeSource
+        # Initially, no resolved classes
         classes = self.type_map.get_container_classes('ns1')
-        self.assertEqual(len(classes), 2)
-        self.assertTrue(all(isinstance(c, TypeSource) for c in classes))
+        self.assertEqual(len(classes), 0)
 
         # Resolve only Bar
         self.type_map.get_dt_container_cls('Bar', 'ns1')
 
-        # Now there should be one real class and one TypeSource
+        # Now there should be one real class
         classes = self.type_map.get_container_classes('ns1')
-        self.assertEqual(len(classes), 2)
-        type_source_count = sum(1 for c in classes if isinstance(c, TypeSource))
-        real_class_count = sum(1 for c in classes if not isinstance(c, TypeSource))
-        self.assertEqual(type_source_count, 1)
-        self.assertEqual(real_class_count, 1)
+        self.assertEqual(len(classes), 1)
+        self.assertFalse(isinstance(classes[0], TypeSource))
 
 
 class TestNamespaceLookupWithTypeSource(TestCase):
@@ -789,10 +785,9 @@ class TestLoadNamespacesMultipleTypes(TestCase):
         baz_spec = GroupSpec(doc='A test group spec', data_type_def='Baz')
         create_load_namespace_yaml('ns1', [bar_spec, baz_spec], self.test_dir, {}, self.type_map)
 
-        # After load_namespaces, all types should be TypeSource (not actual classes)
+        # After load_namespaces, no classes should be resolved yet
         classes = self.type_map.get_container_classes('ns1')
-        for cls in classes:
-            self.assertIsInstance(cls, TypeSource)
+        self.assertEqual(len(classes), 0)
 
     def test_resolve_all_types_in_namespace(self):
         """Test resolving all types in a namespace one by one."""

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -812,6 +812,54 @@ class TestLoadNamespacesMultipleTypes(TestCase):
         self.assertSetEqual(class_names, {'Bar', 'Baz', 'Qux'})
 
 
+class TestBuildStampsCoreNamespaceWithExtensionLoaded(TestCase):
+    """Regression test for namespace contamination when extensions include_namespace("core").
+
+    Reproduces the real-world bug: loading an extension that calls include_namespace("core")
+    re-registers every core type (e.g. NWBFile) under the extension namespace. Without the fix,
+    building a core type stamps the extension's namespace on the builder instead of "core".
+    See issue #1391.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.type_map = TypeMap()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_build_core_type_keeps_core_namespace_after_extension_loads(self):
+        """Loading an extension with include_namespace("core") must not change the namespace of core types."""
+        # Define "core" namespace with NWBFile, like pynwb core
+        nwbfile_spec = GroupSpec(doc='The root NWB file type', data_type_def='NWBFile')
+        create_load_namespace_yaml(
+            namespace_name='core',
+            specs=[nwbfile_spec],
+            output_dir=self.test_dir,
+            incl_types={},
+            type_map=self.type_map,
+        )
+        NWBFile = self.type_map.get_dt_container_cls(data_type='NWBFile', namespace='core')
+
+        # Load an extension that does include_namespace("core"), like ndx-events or ndx-hed
+        events_spec = GroupSpec(doc='An events type', data_type_def='EventsTable', data_type_inc='NWBFile')
+        create_load_namespace_yaml(
+            namespace_name='ndx-events',
+            specs=[events_spec],
+            output_dir=self.test_dir,
+            incl_types={'core': None},  # None means include_namespace("core"), i.e. all core types
+            type_map=self.type_map,
+        )
+
+        # Build an NWBFile (core type) and verify the builder carries namespace="core"
+        builder = self.type_map.build(
+            container=NWBFile(name='root'),
+            manager=BuildManager(self.type_map),
+            source='test.nwb',
+        )
+        self.assertEqual(builder.attributes['namespace'], 'core')
+
+
 # TODO:
 class TestWildCardNamedSpecs(TestCase):
     pass

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -812,24 +812,18 @@ class TestLoadNamespacesMultipleTypes(TestCase):
         self.assertSetEqual(class_names, {'Bar', 'Baz', 'Qux'})
 
 
-class TestBuildStampsCoreNamespaceWithExtensionLoaded(TestCase):
-    """Regression test for namespace contamination when extensions include_namespace("core").
+class TestExtensionIncludeNamespaceDoesNotContaminateCore(TestCase):
+    """Tests that loading an extension with include_namespace("core") does not contaminate core types.
 
-    Reproduces the real-world bug: loading an extension that calls include_namespace("core")
-    re-registers every core type (e.g. NWBFile) under the extension namespace. Without the fix,
-    building a core type stamps the extension's namespace on the builder instead of "core".
-    See issue #1391.
+    When an extension calls include_namespace("core"), all core types get re-registered under the
+    extension namespace. These tests verify that the reverse map, class attributes, and builders
+    all still point to the original "core" namespace.
     """
 
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
         self.type_map = TypeMap()
 
-    def tearDown(self):
-        shutil.rmtree(self.test_dir)
-
-    def test_build_core_type_keeps_core_namespace_after_extension_loads(self):
-        """Loading an extension with include_namespace("core") must not change the namespace of core types."""
         # Define "core" namespace with NWBFile, like pynwb core
         nwbfile_spec = GroupSpec(doc='The root NWB file type', data_type_def='NWBFile')
         create_load_namespace_yaml(
@@ -839,7 +833,7 @@ class TestBuildStampsCoreNamespaceWithExtensionLoaded(TestCase):
             incl_types={},
             type_map=self.type_map,
         )
-        NWBFile = self.type_map.get_dt_container_cls(data_type='NWBFile', namespace='core')
+        self.NWBFile = self.type_map.get_dt_container_cls(data_type='NWBFile', namespace='core')
 
         # Load an extension that does include_namespace("core"), like ndx-events or ndx-hed
         events_spec = GroupSpec(doc='An events type', data_type_def='EventsTable', data_type_inc='NWBFile')
@@ -851,13 +845,102 @@ class TestBuildStampsCoreNamespaceWithExtensionLoaded(TestCase):
             type_map=self.type_map,
         )
 
-        # Build an NWBFile (core type) and verify the builder carries namespace="core"
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_build_core_type_keeps_core_namespace(self):
+        """Building a core type must produce a builder with namespace='core'."""
         builder = self.type_map.build(
-            container=NWBFile(name='root'),
+            container=self.NWBFile(name='root'),
             manager=BuildManager(self.type_map),
             source='test.nwb',
         )
         self.assertEqual(builder.attributes['namespace'], 'core')
+
+    def test_reverse_map_returns_core_namespace(self):
+        """get_container_cls_dt must return 'core' for a core type."""
+        ns, dt = self.type_map.get_container_cls_dt(self.NWBFile)
+        self.assertEqual(ns, 'core')
+        self.assertEqual(dt, 'NWBFile')
+
+    def test_class_namespace_attribute_not_overwritten(self):
+        """The class-level .namespace attribute must remain 'core'."""
+        self.assertEqual(self.NWBFile.namespace, 'core')
+
+
+class TestRegisterContainerTypeCrossNamespace(TestCase):
+    """Tests that register_container_type correctly handles types shared across namespaces.
+
+    These tests verify that:
+    - Replacing a class in one namespace does not corrupt the reverse map for another namespace.
+    - Replacing a TypeSource with a real class in the same namespace still works correctly.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.type_map = TypeMap()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_resolving_included_type_does_not_destroy_original_mapping(self):
+        """Replacing a TypeSource in a non-primary namespace must not destroy the primary namespace's reverse map."""
+        bar_spec = GroupSpec(doc='A test group spec', data_type_def='Bar')
+        create_load_namespace_yaml(
+            namespace_name='ns1',
+            specs=[bar_spec],
+            output_dir=self.test_dir,
+            incl_types={},
+            type_map=self.type_map,
+        )
+
+        # ns2 includes Bar from ns1
+        baz_spec = GroupSpec(doc='Another type', data_type_def='Baz', data_type_inc='Bar')
+        create_load_namespace_yaml(
+            namespace_name='ns2',
+            specs=[baz_spec],
+            output_dir=self.test_dir,
+            incl_types={'ns1': ['Bar']},
+            type_map=self.type_map,
+        )
+
+        # Resolve Bar in ns1 (primary namespace) - this replaces the TypeSource with a real class
+        Bar = self.type_map.get_dt_container_cls('Bar', 'ns1')
+        ns, dt = self.type_map.get_container_cls_dt(Bar)
+        self.assertEqual(ns, 'ns1')
+        self.assertEqual(dt, 'Bar')
+
+        # Resolve Bar in ns2 - this replaces the TypeSource in ns2's forward map with Bar.
+        # The reverse map for Bar must still point to ns1.
+        Bar_via_ns2 = self.type_map.get_dt_container_cls('Bar', 'ns2')
+        self.assertIs(Bar_via_ns2, Bar)
+        ns, dt = self.type_map.get_container_cls_dt(Bar)
+        self.assertEqual(ns, 'ns1')
+        self.assertEqual(dt, 'Bar')
+
+    def test_typesource_replacement_updates_reverse_map(self):
+        """Replacing a TypeSource with a real class in the same namespace must update the reverse map."""
+        bar_spec = GroupSpec(doc='A test group spec', data_type_def='Bar')
+        create_load_namespace_yaml(
+            namespace_name='ns1',
+            specs=[bar_spec],
+            output_dir=self.test_dir,
+            incl_types={},
+            type_map=self.type_map,
+        )
+
+        # Before resolution, Bar should be a TypeSource
+        bar_ts = self.type_map.get_dt_container_cls('Bar', 'ns1', autogen=False)
+        self.assertIsInstance(bar_ts, TypeSource)
+
+        # Resolve to a real class — this replaces the TypeSource in register_container_type
+        Bar = self.type_map.get_dt_container_cls('Bar', 'ns1')
+        self.assertFalse(isinstance(Bar, TypeSource))
+
+        # The real class should be in the reverse map pointing to ns1
+        ns, dt = self.type_map.get_container_cls_dt(Bar)
+        self.assertEqual(ns, 'ns1')
+        self.assertEqual(dt, 'Bar')
 
 
 # TODO:


### PR DESCRIPTION
Closes #1406.

The approach here is to guard the reverse map assignment in `register_container_type` with `if container_cls not in self.__container_cls_to_ns_dt`, restoring the first-registration-wins semantics that `setdefault` provided before PR #1372. This is safe because `NamespaceCatalog._order_deps` topologically sorts namespaces so base namespaces always load before extensions, meaning the first registration is always the defining one.


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
