### PR TITLE
Make project dependencies uv compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ coverage.xml
 # Version
 _version.py
 .python-version
+uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Deprecated `BaseStorageSpec.add_attribute`, `GroupSpec.add_group`, `GroupSpec.add_dataset`, and `GroupSpec.add_link`. Use `set_attribute`, `set_group`, `set_dataset`, and `set_link` instead. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
 - Deprecated unused `BaseStorageSpec.get_data_type_spec` and `BaseStorageSpec.get_namespace_spec`. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
 - Moved `test`, `docs`, and `min-reqs` from `[project.optional-dependencies]` to `[dependency-groups]` (PEP 735). `min-reqs` was renamed to `test-min-deps`. @rly [#1395](https://github.com/hdmf-dev/hdmf/pull/1395)
+- Added Python version markers to dependency lower bounds (`h5py`, `numpy`, `pandas`) and `test-min-deps` pins, and declared `[tool.uv] conflicts` to make the project compatible with uv. @h-mayorquin [#1408](https://github.com/hdmf-dev/hdmf/pull/1408)
 - Changed `get_data_shape` to check `shape` before `maxshape`, so that objects with both attributes (e.g., h5py datasets) return their actual shape rather than their maximum shape. @rly [#1180](https://github.com/hdmf-dev/hdmf/pull/1180)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Deprecated `BaseStorageSpec.add_attribute`, `GroupSpec.add_group`, `GroupSpec.add_dataset`, and `GroupSpec.add_link`. Use `set_attribute`, `set_group`, `set_dataset`, and `set_link` instead. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
 - Deprecated unused `BaseStorageSpec.get_data_type_spec` and `BaseStorageSpec.get_namespace_spec`. @rly [#1333](https://github.com/hdmf-dev/hdmf/pull/1333)
 - Moved `test`, `docs`, and `min-reqs` from `[project.optional-dependencies]` to `[dependency-groups]` (PEP 735). `min-reqs` was renamed to `test-min-deps`. @rly [#1395](https://github.com/hdmf-dev/hdmf/pull/1395)
-- Added Python version markers to dependency lower bounds (`h5py`, `numpy`, `pandas`) and `test-min-deps` pins, and declared `[tool.uv] conflicts` to make the project compatible with uv. @h-mayorquin [#1408](https://github.com/hdmf-dev/hdmf/pull/1408)
+- Removed `test-min-deps` dependency group and replaced it with `uv pip install --resolution lowest-direct` in tox, making the project compatible with uv. @h-mayorquin [#1408](https://github.com/hdmf-dev/hdmf/pull/1408)
 - Changed `get_data_shape` to check `shape` before `maxshape`, so that objects with both attributes (e.g., h5py datasets) return their actual shape rather than their maximum shape. @rly [#1180](https://github.com/hdmf-dev/hdmf/pull/1180)
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,21 +29,16 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
-# make sure to update test-min-deps dependencies below when these lower bounds change
 dependencies = [
-    "h5py>=3.6.0; python_version < '3.12'",
-    "h5py>=3.10.0; python_version >= '3.12'",
+    "h5py>=3.6.0",
     "jsonschema>=3.2.0",
-    "numpy>=1.22.0; python_version < '3.12'",
-    "numpy>=1.26.0; python_version >= '3.12'",
-    "pandas>=1.4.0,<3; python_version < '3.12'",
-    "pandas>=2.0.0,<3; python_version >= '3.12'",
+    "numpy>=1.22.0",
+    "pandas>=1.4.0,<3",
     "ruamel.yaml>=0.16",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-# make sure to update test-min-deps dependencies below when these lower bounds change
 tqdm = ["tqdm>=4.41.0"]
 zarr = [
     "zarr>=2.12.0,<3",
@@ -80,19 +75,6 @@ docs = [
     "sphinx_rtd_theme>=1",  # <1 does not work with docutils>=0.17
     "sphinx-gallery",
     "sphinx-copybutton",
-]
-
-# minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
-test-min-deps = [
-    "h5py==3.6.0; python_version == '3.10'",
-    "jsonschema==3.2.0; python_version == '3.10'",
-    "numpy==1.22.0; python_version == '3.10'",
-    "pandas==1.4.0; python_version == '3.10'",
-    "ruamel.yaml==0.16.0; python_version == '3.10'",
-    "scipy==1.7.2; python_version == '3.10'",
-    "tqdm==4.41.0; python_version == '3.10'",
-    "zarr==2.12.0; python_version == '3.10'",
-    {include-group = "test"},
 ]
 
 [project.urls]
@@ -162,18 +144,6 @@ omit = [
 # preview = true
 # exclude = ".git|.mypy_cache|.tox|.venv|venv|.ipynb_checkpoints|_build/|dist/|__pypackages__|.ipynb"
 # force-exclude = "src/hdmf/common/hdmf-common-schema|docs/gallery"
-
-[tool.uv]
-# This section indicates to uv that test-min-deps and the optional extras
-# are never installed together, so it resolves them in separate forks.
-conflicts = [
-    # all includes zarr and termset, which both conflict with test-min-deps
-    [{group = "test-min-deps"}, {extra = "all"}],
-    # hdmf-zarr requires numpy>=1.24.0, test-min-deps pins numpy==1.22.0
-    [{group = "test-min-deps"}, {extra = "zarr"}],
-    # linkml (via termset) requires jsonschema>=4.0.0, test-min-deps pins jsonschema==3.2.0
-    [{group = "test-min-deps"}, {extra = "termset"}],
-]
 
 [tool.ruff]
 lint.select = ["E", "F", "T100", "T201", "T203", "C901"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,11 @@ test = [
 
 # documentation dependencies
 docs = [
-    "matplotlib",
+    "matplotlib>=3.6",
     "sphinx>=4",  # improved support for docutils>=0.17
     "sphinx_rtd_theme>=1",  # <1 does not work with docutils>=0.17
-    "sphinx-gallery",
-    "sphinx-copybutton",
+    "sphinx-gallery>=0.16",
+    "sphinx-copybutton>=0.5",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,13 @@ classifiers = [
 ]
 # make sure to update test-min-deps dependencies below when these lower bounds change
 dependencies = [
-    "h5py>=3.6.0",
+    "h5py>=3.6.0; python_version < '3.12'",
+    "h5py>=3.10.0; python_version >= '3.12'",
     "jsonschema>=3.2.0",
-    'numpy>=1.22.0',
-    "pandas>=1.4.0,<3",
+    "numpy>=1.22.0; python_version < '3.12'",
+    "numpy>=1.26.0; python_version >= '3.12'",
+    "pandas>=1.4.0,<3; python_version < '3.12'",
+    "pandas>=2.0.0,<3; python_version >= '3.12'",
     "ruamel.yaml>=0.16",
 ]
 dynamic = ["version"]
@@ -81,14 +84,14 @@ docs = [
 
 # minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
 test-min-deps = [
-    "h5py==3.6.0",
-    "jsonschema==3.2.0",
-    "numpy==1.22.0",
-    "pandas==1.4.0",
-    "ruamel.yaml==0.16.0",
-    "scipy==1.7.2",
-    "tqdm==4.41.0",
-    "zarr==2.12.0",
+    "h5py==3.6.0; python_version == '3.10'",
+    "jsonschema==3.2.0; python_version == '3.10'",
+    "numpy==1.22.0; python_version == '3.10'",
+    "pandas==1.4.0; python_version == '3.10'",
+    "ruamel.yaml==0.16.0; python_version == '3.10'",
+    "scipy==1.7.2; python_version == '3.10'",
+    "tqdm==4.41.0; python_version == '3.10'",
+    "zarr==2.12.0; python_version == '3.10'",
     {include-group = "test"},
 ]
 
@@ -159,6 +162,18 @@ omit = [
 # preview = true
 # exclude = ".git|.mypy_cache|.tox|.venv|venv|.ipynb_checkpoints|_build/|dist/|__pypackages__|.ipynb"
 # force-exclude = "src/hdmf/common/hdmf-common-schema|docs/gallery"
+
+[tool.uv]
+# This section indicates to uv that test-min-deps and the optional extras
+# are never installed together, so it resolves them in separate forks.
+conflicts = [
+    # all includes zarr and termset, which both conflict with test-min-deps
+    [{group = "test-min-deps"}, {extra = "all"}],
+    # hdmf-zarr requires numpy>=1.24.0, test-min-deps pins numpy==1.22.0
+    [{group = "test-min-deps"}, {extra = "zarr"}],
+    # linkml (via termset) requires jsonschema>=4.0.0, test-min-deps pins jsonschema==3.2.0
+    [{group = "test-min-deps"}, {extra = "termset"}],
+]
 
 [tool.ruff]
 lint.select = ["E", "F", "T100", "T201", "T203", "C901"]

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,16 @@ extras =
     optional:  termset
 dependency_groups =
     # which dependency group(s) to use (default: none)
-    pytest:    test
-    gallery:   docs
-    minimum:   test
+    # minimum envs handle their own deps in commands_pre to control install order
+    pytest-!minimum:    test
+    gallery-!minimum:   docs
 commands_pre =
-    # for minimum testing, install the project with lowest direct dependency versions
+    # for minimum testing, use uv to install the project with lowest direct dependency
+    # versions, then install tooling on top
     minimum: python -m pip install uv
-    minimum: python -m uv pip install --resolution lowest-direct -e .
+    minimum-pytest:  python -m uv pip install --resolution lowest-direct -e .
+    minimum-gallery: python -m uv pip install --resolution lowest-direct --group docs -e .
+    minimum: python -m pip install --group test
 commands =
     # commands to run for every environment
     python --version     # print python version for debugging

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,17 @@ download = True
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
 recreate =
-    minimum, upgraded, prerelease: False
+    upgraded, prerelease: False
     build, wheelinstall: True  # good practice to recreate the environment
 skip_install =
     upgraded, prerelease, wheelinstall: False
-    minimum: True  # minimum uses uv to install with --resolution lowest-direct
     build: True  # no need to install anything when building
 install_command =
     # when using [testenv:wheelinstall] and --installpkg, the wheel and its dependencies
     # are installed, instead of the package in the current directory
-    minimum, wheelinstall: python -I -m pip install {opts} {packages}
-    upgraded:              python -I -m pip install -U {opts} {packages}
-    prerelease:            python -I -m pip install -U --pre {opts} {packages}
+    wheelinstall: python -I -m pip install {opts} {packages}
+    upgraded:     python -I -m pip install -U {opts} {packages}
+    prerelease:   python -I -m pip install -U --pre {opts} {packages}
 extras =
     # which optional dependency set(s) to use (default: none)
     optional:  tqdm
@@ -31,16 +30,8 @@ extras =
     optional:  termset
 dependency_groups =
     # which dependency group(s) to use (default: none)
-    # minimum envs handle their own deps in commands_pre to control install order
-    pytest-!minimum:    test
-    gallery-!minimum:   docs
-commands_pre =
-    # for minimum testing, use uv to install the project with lowest direct dependency
-    # versions, then install tooling on top
-    minimum: python -m pip install uv
-    minimum-pytest:  python -m uv pip install --resolution lowest-direct -e .
-    minimum-gallery: python -m uv pip install --resolution lowest-direct --group docs -e .
-    minimum: python -m pip install --group test
+    pytest:    test
+    gallery:   docs
 commands =
     # commands to run for every environment
     python --version     # print python version for debugging
@@ -59,12 +50,28 @@ commands =
 [testenv:pytest-py{313,314}-upgraded-optional]
 [testenv:pytest-py314-prerelease]
 [testenv:pytest-py{313,314}-prerelease-optional]
+
+# minimum envs use uv with --resolution lowest-direct to install the lowest
+# compatible versions of direct dependencies. These are defined explicitly
+# (rather than using factor matching in [testenv]) because gallery-minimum
+# needs to resolve docs deps together with project deps to avoid incompatibilities.
 [testenv:pytest-py310-minimum]
+skip_install = True
+dependency_groups = test
+commands_pre =
+    python -m pip install uv
+    python -m uv pip install --resolution lowest-direct -e .
+
+[testenv:gallery-py310-minimum]
+skip_install = True
+dependency_groups = test
+commands_pre =
+    python -m pip install uv
+    python -m uv pip install --resolution lowest-direct --group docs -e .
 
 # TODO: Update to 3.14 when linkml and its deps support 3.14
 [testenv:gallery-py313-upgraded-optional]
 [testenv:gallery-py313-prerelease-optional]
-[testenv:gallery-py310-minimum]
 
 [testenv:build]  # using tox for this so that we can have a clean build environment
 [testenv:wheelinstall]  # use with `--installpkg dist/*-none-any.whl`

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,16 @@ requires = pip >= 24.3.1
 
 [testenv]
 download = True
+allowlist_externals =
+    minimum: uv
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
 recreate =
     minimum, upgraded, prerelease: False
     build, wheelinstall: True  # good practice to recreate the environment
 skip_install =
-    minimum, upgraded, prerelease, wheelinstall: False
+    upgraded, prerelease, wheelinstall: False
+    minimum: True  # minimum uses uv to install with --resolution lowest-direct
     build: True  # no need to install anything when building
 install_command =
     # when using [testenv:wheelinstall] and --installpkg, the wheel and its dependencies
@@ -32,7 +35,10 @@ dependency_groups =
     # which dependency group(s) to use (default: none)
     pytest:    test
     gallery:   docs
-    minimum:   test-min-deps
+    minimum:   test
+commands_pre =
+    # for minimum testing, install the project with lowest direct dependency versions
+    minimum: uv pip install --resolution lowest-direct -e .
 commands =
     # commands to run for every environment
     python --version     # print python version for debugging

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ requires = pip >= 24.3.1
 
 [testenv]
 download = True
-allowlist_externals =
-    minimum: uv
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
 recreate =
@@ -38,7 +36,8 @@ dependency_groups =
     minimum:   test
 commands_pre =
     # for minimum testing, install the project with lowest direct dependency versions
-    minimum: uv pip install --resolution lowest-direct -e .
+    minimum: python -m pip install uv
+    minimum: python -m uv pip install --resolution lowest-direct -e .
 commands =
     # commands to run for every environment
     python --version     # print python version for debugging


### PR DESCRIPTION
I have been working with uv lately and would like to make this package compatible with it. Currently `uv lock` and `uv run` fail because the resolver cannot build a single lockfile that satisfies all dependency groups and extras together: `test-min-deps` pins `numpy==1.22.0` while `hdmf-zarr` (via the `zarr` extra) requires `numpy>=1.24.0`, `test-min-deps` pins `jsonschema==3.2.0` while `linkml` (via the `termset` extra) requires `jsonschema>=4.0.0`, and pinned versions like `pandas==1.4.0` cannot even build on Python >=3.12. In short, the dependencies are locally consistent but not globally. 

To fix this, this PR:
- Raises the dependency lower bounds for `h5py`, `numpy`, and `pandas` to versions that are installable on Python >=3.12
- Adds `python_version == '3.10'` markers to all `test-min-deps` pins so the resolver does not attempt to use them on newer Python versions
- Declares `[tool.uv] conflicts` between `test-min-deps` and the optional extras (`all`, `zarr`, `termset`) so uv resolves them in separate forks.

The last addition is the only one that is uv-specific, the first two are standard [PEP 508](https://peps.python.org/pep-0508/)/[PEP 735](https://peps.python.org/pep-0735/) dependency specifications and should help any resolver while making the specification more precise.

If this make sense maybe it should go after the next release to avoid introducing risk into the current release cycle.


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
