### PR TITLE
Add missing tox environments for macOS CI jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,9 @@ commands =
 
 # list of pre-defined environments
 [testenv:pytest-py{310,311,312,313,314}-upgraded]
-[testenv:pytest-py314-upgraded-optional]
-[testenv:pytest-py314-prerelease-optional]
+[testenv:pytest-py{313,314}-upgraded-optional]
+[testenv:pytest-py314-prerelease]
+[testenv:pytest-py{313,314}-prerelease-optional]
 [testenv:pytest-py310-minimum]
 
 # TODO: Update to 3.14 when linkml and its deps support 3.14


### PR DESCRIPTION
## Summary
- The macOS CI matrix in `run_all_tests.yml` references three tox environments that were not declared in `tox.ini`, causing instant exit code 254 failures:
  - `pytest-py313-upgraded-optional` (macOS uses py313 for optional tests due to numcodecs arm64 wheel issues)
  - `pytest-py313-prerelease-optional` (same reason)
  - `pytest-py314-prerelease` (non-optional prerelease, macOS only)
- Added the missing environment declarations. Linux/Windows were unaffected because they use only py314 for optional/prerelease, which was already declared.

See failing run: https://github.com/hdmf-dev/hdmf/actions/runs/22429733337

## Test plan
- [ ] Verify the three previously failing macOS jobs pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)