### PR TITLE
Fix Python float/int validation against float64/int64 specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Fixed
 - Fixed `VectorData.extend()` silently corrupting 1D numpy arrays by reshaping them into 2D matrices. Replaced `np.vstack` with `np.concatenate` in `extend_data`. @h-mayorquin [#1405](https://github.com/hdmf-dev/hdmf/pull/1405)
+- Fixed validation of Python native `float` and `int` values against `float64` and `int64` specs. Python `float` is 64-bit but was mapped to `float32`, and Python `int` is 64-bit (or larger) but was mapped to `int32`. @rly [#1410](https://github.com/hdmf-dev/hdmf/pull/1410)
 - Fixed a broken test and refactored `VectorIndex.get`. @rly, @mavaylon1 [#1293](https://github.com/hdmf-dev/hdmf/pull/1293)
 
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -153,6 +153,10 @@ def get_type(data, builder_dtype=None):
     elif isinstance(data, np.bool_):
         return 'bool', None
     if not hasattr(data, '__len__'):
+        if type(data) is float:  # Python float is 64-bit
+            return 'float64', None
+        if type(data) is int:  # Python int is 64-bit (or larger)
+            return 'int64', None
         return type(data).__name__, None
     # Case for h5py.Dataset, zarr.Array, and other I/O specific array types
     # Compound dtype

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -508,6 +508,46 @@ class TestDtypeValidation(TestCase):
         results = self.vmap.validate(bar_builder)
         self.assertEqual(len(results), 0)
 
+    def test_python_float_for_float64(self):
+        """Test that validator allows Python float data where float64 is specified."""
+        self.set_up_spec('float64')
+        value = 1.0
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
+    def test_python_int_for_int64(self):
+        """Test that validator allows Python int data where int64 is specified."""
+        self.set_up_spec('int64')
+        value = 1
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
+    def test_python_float_for_float32(self):
+        """Test that validator allows Python float data where float (float32) is specified."""
+        self.set_up_spec('float')
+        value = 1.0
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
+    def test_python_int_for_int32(self):
+        """Test that validator allows Python int data where int (int32) is specified."""
+        self.set_up_spec('int')
+        value = 1
+        bar_builder = GroupBuilder('my_bar',
+                                   attributes={'data_type': 'Bar', 'attr1': value},
+                                   datasets=[DatasetBuilder('data', value)])
+        results = self.vmap.validate(bar_builder)
+        self.assertEqual(len(results), 0)
+
     def test_scalar_compound_dtype(self):
         """Test that validator allows scalar compound dtype data where a compound dtype is specified."""
         spec_catalog = SpecCatalog()


### PR DESCRIPTION
## Summary
- Python native `float` is 64-bit, but `get_type()` was returning `"float"` which aliases to float32 in the spec system, causing validation failures against float64 specs
- Same issue for Python native `int` (64-bit or larger) returning `"int"` which aliases to int32
- Fixed `get_type()` to return `"float64"` for Python `float` and `"int64"` for Python `int`
- Uses exact type check (`type(data) is float`) to avoid catching numpy subclasses or `bool`
- Backward compatible: specs expecting float32/int32 already accept float64/int64 via `additional_allowed`

Fixes #1368

## Test plan
- [x] Added test: Python `float` validates against `float64` spec (was failing, now passes)
- [x] Added test: Python `int` validates against `int64` spec (was failing, now passes)
- [x] Added test: Python `float` still validates against `float` (float32) spec (regression check)
- [x] Added test: Python `int` still validates against `int` (int32) spec (regression check)
- [x] All 91 validator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)