### PR TITLE
Fix writing compound dtype datasets with a single field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HDMF 5.0.1 (Upcoming)
 
 ### Fixed
+- Fixed writing compound dtype datasets with a single field. @rly [#1420](https://github.com/hdmf-dev/hdmf/pull/1420)
 - Replaced undeclared `pyyaml` dependency with `ruamel.yaml` (a declared core dependency) in `test_common_io.py`. The test relied on PyYAML being transitively installed by pip's `h5py`, which is not the case in conda environments. @rly [#1418](https://github.com/hdmf-dev/hdmf/pull/1418)
 
 ## HDMF 5.0.0 (March 2, 2026)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1385,7 +1385,7 @@ class HDF5IO(HDMFIO):
             data_shape = io_settings.pop('shape')
         elif hasattr(data, 'shape'):
             data_shape = data.shape
-        elif isinstance(dtype, np.dtype) and len(dtype) > 1:  # check if compound dtype
+        elif isinstance(dtype, np.dtype) and dtype.names is not None:  # check if compound dtype
             data_shape = (len(data),)
         else:
             data_shape = get_data_shape(data)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -208,13 +208,13 @@ class H5IOTest(TestCase):
         """Test that a compound dtype with a single field can be written."""
         a = np.array([('val1',), ('val2',)], dtype=[('key', 'O')])
         dset_builder = DatasetBuilder(
-                    name='test_dataset',
-                    data=a.tolist(),
-                    attributes={},
-                    dtype=[
-                        DtypeSpec('key', doc='key', dtype='text'),
-                    ],
-                )
+              name='test_dataset',
+              data=a.tolist(),
+              attributes={},
+              dtype=[
+                  DtypeSpec('key', doc='key', dtype='text'),
+              ],
+          )
         self.io.write_dataset(self.f, dset_builder)
         dset = self.f['test_dataset']
         self.assertEqual(dset.shape, (2,))

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -23,6 +23,7 @@ from hdmf.backends.errors import UnsupportedOperation
 from hdmf.build import GroupBuilder, DatasetBuilder, BuildManager, TypeMap, OrphanContainerBuildError, LinkBuilder
 from hdmf.container import Container, HERDManager
 from hdmf import Data, docval
+from hdmf.common import SimpleMultiContainer, get_hdf5io
 from hdmf.data_utils import DataChunkIterator, GenericDataChunkIterator, InvalidDataIOError, append_data
 from hdmf.spec.catalog import SpecCatalog
 from hdmf.spec.namespace import NamespaceCatalog, SpecNamespace
@@ -1205,54 +1206,21 @@ class TestHERDIO(TestCase):
         self.remove_er_files()
 
     def test_write_herd_as_child(self):
-        """Test writing and reading HERD as a child group of a container."""
-        from hdmf.common import get_type_map
-        from hdmf.utils import getargs
+        """Test writing and reading HERD as a child group of a
+        SimpleMultiContainer so that the Data is written and the
+        link from HERD to the data can be verified."""
 
-        class SimpleFile(Container, HERDManager):
-            @docval({'name': 'external_resources', 'type': HERD, 'doc': 'HERD', 'default': None})
-            def __init__(self, **kwargs):
-                external_resources = getargs('external_resources', kwargs)
-                super().__init__(name='root')
-                self._herd = None
-                if external_resources is not None:
-                    self.external_resources = external_resources
+        class _HERDManagerContainer(SimpleMultiContainer, HERDManager):
+            pass
 
-            @property
-            def external_resources(self):
-                return self._herd
-
-            @external_resources.setter
-            def external_resources(self, herd):
-                self._herd = herd
-                self._herd.parent = self
-
-        tm = get_type_map()
-        file_spec = GroupSpec(
-            'A simple file with HERD',
-            data_type_def='SimpleFile',
-            groups=[
-                GroupSpec(
-                    'external resources',
-                    name='external_resources',
-                    data_type_inc='HERD',
-                    quantity='?',
-                )
-            ],
-        )
-        tm.namespace_catalog.get_namespace('hdmf-common').catalog.register_spec(file_spec, 'test.yaml')
-        tm.register_container_type('hdmf-common', 'SimpleFile', SimpleFile)
-        manager = BuildManager(tm)
-
-        sf = SimpleFile()
-        data = Data(name='species', data=['Homo sapiens'])
-        data.parent = sf
-
+        species = Data(name='species', data=['Homo sapiens'])
         herd = HERD()
-        sf.external_resources = herd
+        container = _HERDManagerContainer(name='root', containers=[species, herd])
+
+        container.external_resources = herd
         herd.add_ref(
-            file=sf,
-            container=data,
+            file=container,
+            container=species,
             key='Homo sapiens',
             entity_id='NCBI:9606',
             entity_uri='https://example.com',
@@ -1260,15 +1228,20 @@ class TestHERDIO(TestCase):
 
         path = get_temp_filepath()
         try:
-            with HDF5IO(path, manager=manager, mode='w') as io:
-                io.write(sf)
+            with get_hdf5io(path=path, mode='w') as io:
+                io.write(container)
 
-            with HDF5IO(path, manager=manager, mode='r') as io:
-                read_sf = io.read()
-                self.assertIsInstance(read_sf.external_resources, HERD)
-                read_keys = read_sf.external_resources.keys[:]
+            with get_hdf5io(path=path, mode='r') as io:
+                read_container = io.read()
+                read_herd = read_container.get_container('external_resources')
+                self.assertIsInstance(read_herd, HERD)
+                read_keys = read_herd.keys[:]
                 self.assertEqual(read_keys.shape, (1,))
                 self.assertEqual(read_keys[0][0], 'Homo sapiens')
+
+                read_objects = read_herd.objects[:]
+                self.assertEqual(read_objects.shape, (1,))
+                self.assertEqual(read_objects[0][1], species.object_id)
         finally:
             remove_test_file(path)
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -21,7 +21,7 @@ from hdmf.backends.hdf5.h5tools import HDF5IO, SPEC_LOC_ATTR, H5PY_3
 from hdmf.backends.warnings import BrokenLinkWarning
 from hdmf.backends.errors import UnsupportedOperation
 from hdmf.build import GroupBuilder, DatasetBuilder, BuildManager, TypeMap, OrphanContainerBuildError, LinkBuilder
-from hdmf.container import Container
+from hdmf.container import Container, HERDManager
 from hdmf import Data, docval
 from hdmf.data_utils import DataChunkIterator, GenericDataChunkIterator, InvalidDataIOError, append_data
 from hdmf.spec.catalog import SpecCatalog
@@ -203,6 +203,23 @@ class H5IOTest(TestCase):
         dset = self.f['test_dataset']
         for field in a.dtype.names:
             self.assertTrue(np.all(dset[field][:] == a[field]))
+
+    def test_write_dataset_list_single_field_compound_datatype(self):
+        """Test that a compound dtype with a single field can be written."""
+        a = np.array([('val1',), ('val2',)], dtype=[('key', 'O')])
+        dset_builder = DatasetBuilder(
+                    name='test_dataset',
+                    data=a.tolist(),
+                    attributes={},
+                    dtype=[
+                        DtypeSpec('key', doc='key', dtype='text'),
+                    ],
+                )
+        self.io.write_dataset(self.f, dset_builder)
+        dset = self.f['test_dataset']
+        self.assertEqual(dset.shape, (2,))
+        self.assertEqual(dset['key'][0].decode('utf-8'), 'val1')
+        self.assertEqual(dset['key'][1].decode('utf-8'), 'val2')
 
     def test_write_dataset_list_compress_gzip(self):
         a = H5DataIO(np.arange(30).reshape(5, 2, 3),
@@ -1186,6 +1203,74 @@ class TestHERDIO(TestCase):
             (0, read_foofile.object_id, 'FooFile', '', ''))
 
         self.remove_er_files()
+
+    def test_write_herd_as_child(self):
+        """Test writing and reading HERD as a child group of a container."""
+        from hdmf.common import get_type_map
+        from hdmf.utils import getargs
+
+        class SimpleFile(Container, HERDManager):
+            @docval({'name': 'external_resources', 'type': HERD, 'doc': 'HERD', 'default': None})
+            def __init__(self, **kwargs):
+                external_resources = getargs('external_resources', kwargs)
+                super().__init__(name='root')
+                self._herd = None
+                if external_resources is not None:
+                    self.external_resources = external_resources
+
+            @property
+            def external_resources(self):
+                return self._herd
+
+            @external_resources.setter
+            def external_resources(self, herd):
+                self._herd = herd
+                self._herd.parent = self
+
+        tm = get_type_map()
+        file_spec = GroupSpec(
+            'A simple file with HERD',
+            data_type_def='SimpleFile',
+            groups=[
+                GroupSpec(
+                    'external resources',
+                    name='external_resources',
+                    data_type_inc='HERD',
+                    quantity='?',
+                )
+            ],
+        )
+        tm.namespace_catalog.get_namespace('hdmf-common').catalog.register_spec(file_spec, 'test.yaml')
+        tm.register_container_type('hdmf-common', 'SimpleFile', SimpleFile)
+        manager = BuildManager(tm)
+
+        sf = SimpleFile()
+        data = Data(name='species', data=['Homo sapiens'])
+        data.parent = sf
+
+        herd = HERD()
+        sf.external_resources = herd
+        herd.add_ref(
+            file=sf,
+            container=data,
+            key='Homo sapiens',
+            entity_id='NCBI:9606',
+            entity_uri='https://example.com',
+        )
+
+        path = get_temp_filepath()
+        try:
+            with HDF5IO(path, manager=manager, mode='w') as io:
+                io.write(sf)
+
+            with HDF5IO(path, manager=manager, mode='r') as io:
+                read_sf = io.read()
+                self.assertIsInstance(read_sf.external_resources, HERD)
+                read_keys = read_sf.external_resources.keys[:]
+                self.assertEqual(read_keys.shape, (1,))
+                self.assertEqual(read_keys[0][0], 'Homo sapiens')
+        finally:
+            remove_test_file(path)
 
 
 class TestMultiWrite(TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -208,13 +208,13 @@ class H5IOTest(TestCase):
         """Test that a compound dtype with a single field can be written."""
         a = np.array([('val1',), ('val2',)], dtype=[('key', 'O')])
         dset_builder = DatasetBuilder(
-              name='test_dataset',
-              data=a.tolist(),
-              attributes={},
-              dtype=[
-                  DtypeSpec('key', doc='key', dtype='text'),
-              ],
-          )
+            name='test_dataset',
+            data=a.tolist(),
+            attributes={},
+            dtype=[
+                DtypeSpec('key', doc='key', dtype='text'),
+            ],
+        )
         self.io.write_dataset(self.f, dset_builder)
         dset = self.f['test_dataset']
         self.assertEqual(dset.shape, (2,))


### PR DESCRIPTION
## Summary

- Fix compound dtype detection in `__list_fill__` to handle single-field compound dtypes (e.g., HERD's `keys` table with dtype `[('key', 'O')]`)
- The old check `len(dtype) > 1` missed single-field compound dtypes, causing `get_data_shape` to return a 2-D shape that mismatched the 1-D `maxshape`, producing an h5py error
- Use `dtype.names is not None` to correctly detect all compound dtypes

Fixes #1419

## Test plan

- [x] `test_write_dataset_list_single_field_compound_datatype` — unit test for writing a single-field compound dtype dataset
- [x] `test_write_herd_as_child` — integration test writing/reading HERD as a child group of a container (mirrors the NWB use case)
- [x] Existing compound dtype and HERD tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)