### PR TITLE
Handle closed HDF5 files gracefully in _repr_html_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Enhancements
 - Replaced `hasattr(data, "__len__")` checks with `ndim`-based collection detection via new `_is_collection` and `_get_length` helpers in `hdmf.utils`. This fixes compatibility with array libraries that follow the Python array API standard (e.g., zarr v3), which provide `ndim` and `shape` but not `__len__`. @h-mayorquin [#1414](https://github.com/hdmf-dev/hdmf/pull/1414)
 - Added `_unwrap_scalar` helper in `hdmf.utils` to convert 0-d ndarrays to numpy scalars via `.item()`. This fixes `isinstance` checks against Python scalar types that fail on 0-d ndarrays returned by array-API-conforming libraries (e.g., zarr v3 scalar indexing). @h-mayorquin [#1415](https://github.com/hdmf-dev/hdmf/pull/1415)
+- Added `HDF5IO.is_open()` to check whether the HDF5 file handle is still valid. @rly [#1423](https://github.com/hdmf-dev/hdmf/pull/1423)
 
 ### Fixed
+- Fixed `_repr_html_` raising `RuntimeError` when the backing HDF5 file is closed. A warning banner is now shown and failed renders display a descriptive message instead of raising. @rly [#1423](https://github.com/hdmf-dev/hdmf/pull/1423)
 - Fixed writing compound dtype datasets with a single field. @rly [#1420](https://github.com/hdmf-dev/hdmf/pull/1420)
 - Replaced undeclared `pyyaml` dependency with `ruamel.yaml` (a declared core dependency) in `test_common_io.py`. The test relied on PyYAML being transitively installed by pip's `h5py`, which is not the case in conda environments. @rly [#1418](https://github.com/hdmf-dev/hdmf/pull/1418)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -725,6 +725,12 @@ class HDF5IO(HDMFIO):
             # an error before self.__file has been created
             self.__file = None
 
+    def is_open(self) -> bool:
+        """Check whether this HDF5IO object is open for reading/writing."""
+        if self.__file is None:
+            return False
+        return bool(self.__file)
+
     def close_linked_files(self):
         """Close all opened, linked-to files.
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -727,8 +727,7 @@ class HDF5IO(HDMFIO):
 
     def is_open(self) -> bool:
         """Check whether this HDF5IO object is open for reading/writing."""
-        if self.__file is None:
-            return False
+        # Returns False if file is None or closed
         return bool(self.__file)
 
     def close_linked_files(self):

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -727,7 +727,7 @@ class HDF5IO(HDMFIO):
 
     def is_open(self) -> bool:
         """Check whether this HDF5IO object is open for reading/writing."""
-        # Returns False if file is None or closed
+        # Return False if file is None or closed
         return bool(self.__file)
 
     def close_linked_files(self):

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1358,6 +1358,7 @@ class DynamicTable(Container):
         html_repr = self.css_style + self.js_script
         html_repr += "<div class='container-wrap'>"
         html_repr += f"<div class='container-header'><div class='xr-obj-type'><h3>{header_text}</h3></div></div>"
+        html_repr += self._closed_file_warning_html()
         html_repr += self.generate_html_repr()
         html_repr += "</div>"
         return html_repr
@@ -1391,10 +1392,14 @@ class DynamicTable(Container):
             f'class="container-fields field-key"><b>columns</b></summary>{col_desc_inner}</details>'
         )
 
-        inside = f"{self[:min(nrows, len(self))].to_html()}"
+        try:
+            inside = f"{self[:min(nrows, len(self))].to_html()}"
 
-        if len(self) >= nrows + 1:
-            inside += f"<p>... and {len(self) - nrows} more row(s).</p>"
+            if len(self) >= nrows + 1:
+                inside += f"<p>... and {len(self) - nrows} more row(s).</p>"
+        except Exception as e:
+            reason = "the file backing this object is closed" if self._file_is_closed() else str(e)
+            inside = f"<p><em>{type(self).__name__} (unable to render table data: {reason})</em></p>"
 
         out += (
             f'<details><summary style="display: list-item; margin-left: {level * 20}px;" '

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -789,32 +789,27 @@ class Container(AbstractContainer):
     def _generate_array_html(self, array, level):
         """Generates HTML for array data (e.g., NumPy arrays, HDF5 datasets, Zarr datasets and DataIO objects)."""
 
-        try:
-            is_numpy_array = isinstance(array, np.ndarray)
-            read_io = self.get_read_io()
-            it_was_read_with_io = read_io is not None
-            is_data_io = isinstance(array, DataIO)
+        is_numpy_array = isinstance(array, np.ndarray)
+        read_io = self.get_read_io()
+        it_was_read_with_io = read_io is not None
+        is_data_io = isinstance(array, DataIO)
 
-            if is_numpy_array:
-                array_info_dict = get_basic_array_info(array)
-                repr_html = generate_array_html_repr(array_info_dict, array, "NumPy array")
-            elif is_data_io:
-                array_info_dict = get_basic_array_info(array.data)
-                repr_html = generate_array_html_repr(array_info_dict, array.data, "DataIO")
-            elif it_was_read_with_io:
-                # The backend handles the representation here. Two special cases worth noting:
-                # 1. Array-type attributes (e.g., start_frame in ImageSeries) remain NumPy arrays
-                #    even when their parent container has an IO
-                # 2. Data may have been modified after being read from storage
-                repr_html = read_io.generate_dataset_html(array)
-            else:  # Not sure which object could get here
-                object_class = array.__class__.__name__
-                array_info_dict = get_basic_array_info(array.data)
-                repr_html = generate_array_html_repr(array_info_dict, array.data, object_class)
-        except Exception as e:
+        if is_numpy_array:
+            array_info_dict = get_basic_array_info(array)
+            repr_html = generate_array_html_repr(array_info_dict, array, "NumPy array")
+        elif is_data_io:
+            array_info_dict = get_basic_array_info(array.data)
+            repr_html = generate_array_html_repr(array_info_dict, array.data, "DataIO")
+        elif it_was_read_with_io:
+            # The backend handles the representation here. Two special cases worth noting:
+            # 1. Array-type attributes (e.g., start_frame in ImageSeries) remain NumPy arrays
+            #    even when their parent container has an IO
+            # 2. Data may have been modified after being read from storage
+            repr_html = read_io.generate_dataset_html(array)
+        else:  # Not sure which object could get here
             object_class = array.__class__.__name__
-            reason = "the file backing this object is closed" if self._file_is_closed() else str(e)
-            repr_html = f'<span class="field-key">{object_class} (unable to render: {reason})</span>'
+            array_info_dict = get_basic_array_info(array.data)
+            repr_html = generate_array_html_repr(array_info_dict, array.data, object_class)
 
         return f'<div style="margin-left: {level * 20}px;" class="container-fields">{repr_html}</div>'
 

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -679,12 +679,35 @@ class Container(AbstractContainer):
         </script>
         """
 
+    def _file_is_closed(self) -> bool:
+        """Check if the backing file for this container is closed.
+
+        Returns True if the read IO has an is_open method and it returns False.
+        Returns False if there is no read IO or the IO does not have is_open.
+        """
+        read_io = self.get_read_io()
+        # TODO: After is_open() is implemented across all backends (and added as
+        # an abstractmethod on HDMFIO), remove the hasattr check.
+        return read_io is not None and hasattr(read_io, "is_open") and not read_io.is_open()
+
+    def _closed_file_warning_html(self) -> str:
+        """Return an HTML warning banner if the backing file is closed, or empty string otherwise."""
+        if self._file_is_closed():
+            return (
+                "<div style='padding: 10px; margin: 10px 0; background-color: #fff3cd; "
+                "border: 1px solid #ffc107; border-radius: 4px; color: #856404;'>"
+                "<b>Warning:</b> The file backing this object is closed. "
+                "Some data may not be rendered below.</div>"
+            )
+        return ""
+
     def _repr_html_(self) -> str:
         """Generates the HTML representation of the object."""
         header_text = self.name if self.name == self.__class__.__name__ else f"{self.name} ({self.__class__.__name__})"
         html_repr = self.css_style + self.js_script
         html_repr += "<div class='container-wrap'>"
         html_repr += f"<div class='container-header'><div class='xr-obj-type'><h3>{header_text}</h3></div></div>"
+        html_repr += self._closed_file_warning_html()
         html_repr += self._generate_html_repr(self.fields, is_field=True)
         html_repr += "</div>"
         return html_repr
@@ -722,24 +745,30 @@ class Container(AbstractContainer):
             return f'<div style="margin-left: {level * 20}px;" class="container-fields"><span class="field-key"' \
                    f' title="{access_code}">{key}: </span><span class="field-value">{value}</span></div>'
 
-        # Detects array-like objects that conform to the Array Interface specification
-        # (e.g., NumPy arrays, HDF5 datasets, DataIO objects). Objects must have both
-        # 'shape' and 'dtype' attributes. Iterators are excluded as they lack 'shape'.
-        # This approach keeps the implementation generic without coupling to specific backends methods
-        is_array_data = hasattr(value, "shape") and hasattr(value, "dtype")
+        try:
+            # Detects array-like objects that conform to the Array Interface specification
+            # (e.g., NumPy arrays, HDF5 datasets, DataIO objects). Objects must have both
+            # 'shape' and 'dtype' attributes. Iterators are excluded as they lack 'shape'.
+            # This approach keeps the implementation generic without coupling to specific backends methods
+            is_array_data = hasattr(value, "shape") and hasattr(value, "dtype")
 
-        if is_array_data:
-            html_content = self._generate_array_html(value, level + 1)
-        elif hasattr(value, "generate_html_repr"):
-            html_content = value.generate_html_repr(level + 1, access_code)
-        elif hasattr(value, '__repr_html__'):
-            html_content = value.__repr_html__()
-        elif hasattr(value, "fields"):  # Note that h5py.Dataset has a fields attribute so there is an implicit order
-            html_content = self._generate_html_repr(value.fields, level + 1, access_code, is_field=True)
-        elif isinstance(value, (list, dict, np.ndarray)):
-            html_content = self._generate_html_repr(value, level + 1, access_code, is_field=False)
-        else:
-            html_content = f'<span class="field-key">{value}</span>'
+            if is_array_data:
+                html_content = self._generate_array_html(value, level + 1)
+            elif hasattr(value, "generate_html_repr"):
+                html_content = value.generate_html_repr(level + 1, access_code)
+            elif hasattr(value, '__repr_html__'):
+                html_content = value.__repr_html__()
+            # Note: h5py.Dataset has a fields attribute so there is an implicit order
+            elif hasattr(value, "fields"):
+                html_content = self._generate_html_repr(value.fields, level + 1, access_code, is_field=True)
+            elif isinstance(value, (list, dict, np.ndarray)):
+                html_content = self._generate_html_repr(value, level + 1, access_code, is_field=False)
+            else:
+                html_content = f'<span class="field-key">{value}</span>'
+        except Exception as e:
+            object_class = type(value).__name__
+            reason = "the file backing this object is closed" if self._file_is_closed() else str(e)
+            html_content = f'<span class="field-key">{object_class} (unable to render: {reason})</span>'
 
         display_name = str(key)
         if isinstance(value, AbstractContainer):   # Excludes things like LabelledDict, ndarray, etc
@@ -760,27 +789,32 @@ class Container(AbstractContainer):
     def _generate_array_html(self, array, level):
         """Generates HTML for array data (e.g., NumPy arrays, HDF5 datasets, Zarr datasets and DataIO objects)."""
 
-        is_numpy_array = isinstance(array, np.ndarray)
-        read_io = self.get_read_io()
-        it_was_read_with_io = read_io is not None
-        is_data_io = isinstance(array, DataIO)
+        try:
+            is_numpy_array = isinstance(array, np.ndarray)
+            read_io = self.get_read_io()
+            it_was_read_with_io = read_io is not None
+            is_data_io = isinstance(array, DataIO)
 
-        if is_numpy_array:
-            array_info_dict = get_basic_array_info(array)
-            repr_html = generate_array_html_repr(array_info_dict, array, "NumPy array")
-        elif is_data_io:
-            array_info_dict = get_basic_array_info(array.data)
-            repr_html = generate_array_html_repr(array_info_dict, array.data, "DataIO")
-        elif it_was_read_with_io:
-            # The backend handles the representation here. Two special cases worth noting:
-            # 1. Array-type attributes (e.g., start_frame in ImageSeries) remain NumPy arrays
-            #    even when their parent container has an IO
-            # 2. Data may have been modified after being read from storage
-            repr_html = read_io.generate_dataset_html(array)
-        else:  # Not sure which object could get here
+            if is_numpy_array:
+                array_info_dict = get_basic_array_info(array)
+                repr_html = generate_array_html_repr(array_info_dict, array, "NumPy array")
+            elif is_data_io:
+                array_info_dict = get_basic_array_info(array.data)
+                repr_html = generate_array_html_repr(array_info_dict, array.data, "DataIO")
+            elif it_was_read_with_io:
+                # The backend handles the representation here. Two special cases worth noting:
+                # 1. Array-type attributes (e.g., start_frame in ImageSeries) remain NumPy arrays
+                #    even when their parent container has an IO
+                # 2. Data may have been modified after being read from storage
+                repr_html = read_io.generate_dataset_html(array)
+            else:  # Not sure which object could get here
+                object_class = array.__class__.__name__
+                array_info_dict = get_basic_array_info(array.data)
+                repr_html = generate_array_html_repr(array_info_dict, array.data, object_class)
+        except Exception as e:
             object_class = array.__class__.__name__
-            array_info_dict = get_basic_array_info(array.data)
-            repr_html = generate_array_html_repr(array_info_dict, array.data, object_class)
+            reason = "the file backing this object is closed" if self._file_is_closed() else str(e)
+            repr_html = f'<span class="field-key">{object_class} (unable to render: {reason})</span>'
 
         return f'<div style="margin-left: {level * 20}px;" class="container-fields">{repr_html}</div>'
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1120,6 +1120,36 @@ Fields:
         )
 
 
+    def test_repr_html_closed_file(self):
+        """Test that _repr_html_ handles a closed HDF5 file gracefully."""
+        with h5py.File('test_table_repr.h5', 'w') as f:
+            f.create_dataset('foo', data=[1, 2, 3])
+            f.create_dataset('bar', data=[10.0, 20.0, 30.0])
+            f.create_dataset('baz', data=['cat', 'dog', 'bird'])
+
+        with HDF5IO('test_table_repr.h5', mode='r') as io:
+            f = io._file
+            columns = [
+                VectorData(name='foo', description='foo column', data=f['foo']),
+                VectorData(name='bar', description='bar column', data=f['bar']),
+                VectorData(name='baz', description='baz column', data=f['baz']),
+            ]
+            table = DynamicTable(
+                name='test_table', description='a test table', columns=columns,
+                id=list(range(3)),
+            )
+            table.read_io = io
+            for col in columns:
+                col.read_io = io
+
+        # File is now closed
+        html = table._repr_html_()
+        self.assertIn("file backing this object is closed", html)
+        self.assertIn("unable to render table data", html)
+        self.assertIn("<b>Warning:</b>", html)
+
+        os.remove('test_table_repr.h5')
+
     def test_add_column_existing_attr(self):
         table = self.with_table_columns()
         attrs = ['name', 'description', 'parent', 'id', 'fields']  # just a few

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -1122,28 +1122,22 @@ Fields:
 
     def test_repr_html_closed_file(self):
         """Test that _repr_html_ handles a closed HDF5 file gracefully."""
-        with h5py.File('test_table_repr.h5', 'w') as f:
-            f.create_dataset('foo', data=[1, 2, 3])
-            f.create_dataset('bar', data=[10.0, 20.0, 30.0])
-            f.create_dataset('baz', data=['cat', 'dog', 'bird'])
+        table = DynamicTable(name='test_table', description='a test table')
+        table.add_column('foo', 'foo column')
+        table.add_column('bar', 'bar column')
+        table.add_column('baz', 'baz column')
+        table.add_row(foo=1, bar=10.0, baz='cat')
+        table.add_row(foo=2, bar=20.0, baz='dog')
+        table.add_row(foo=3, bar=30.0, baz='bird')
 
-        with HDF5IO('test_table_repr.h5', mode='r') as io:
-            f = io._file
-            columns = [
-                VectorData(name='foo', description='foo column', data=f['foo']),
-                VectorData(name='bar', description='bar column', data=f['bar']),
-                VectorData(name='baz', description='baz column', data=f['baz']),
-            ]
-            table = DynamicTable(
-                name='test_table', description='a test table', columns=columns,
-                id=list(range(3)),
-            )
-            table.read_io = io
-            for col in columns:
-                col.read_io = io
+        with HDF5IO('test_table_repr.h5', manager=get_manager(), mode='w') as io:
+            io.write(table)
+
+        with HDF5IO('test_table_repr.h5', manager=get_manager(), mode='r') as io:
+            read_table = io.read()
 
         # File is now closed
-        html = table._repr_html_()
+        html = read_table._repr_html_()
         self.assertIn("file backing this object is closed", html)
         self.assertIn("unable to render table data", html)
         self.assertIn("<b>Warning:</b>", html)

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -8,7 +8,7 @@ from hdmf.container import AbstractContainer, Container, Data, HERDManager
 from hdmf.common.resources import HERD
 from hdmf.testing import TestCase
 from hdmf.utils import docval
-from hdmf.common import DynamicTable, VectorData, DynamicTableRegion
+from hdmf.common import DynamicTable, VectorData, DynamicTableRegion, SimpleMultiContainer, get_manager
 from hdmf.backends.hdf5.h5tools import HDF5IO
 
 from tests.unit.helpers.io import DoNothingIO
@@ -590,37 +590,34 @@ class TestHTMLRepr(TestCase):
         os.remove('array_data.h5')
 
     def test_repr_html_hdf5_dataset_closed_file(self):
-        """Test that _repr_html_ shows a warning banner and gracefully renders when the file is closed."""
+        """Test that _repr_html_ shows a warning banner when the file is closed."""
+        smc = SimpleMultiContainer(name='root')
+        smc.add_container(Data(name='my_data', data=np.array([1, 2, 3, 4], dtype=np.int64)))
 
-        with h5py.File('test_closed.h5', 'w') as f:
-            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+        with HDF5IO('test_closed.h5', manager=get_manager(), mode='w') as io:
+            io.write(smc)
 
-        io = HDF5IO('test_closed.h5', mode='r')
-        dataset = io._file['my_dataset']
-        obj = self.ContainerWithData(data=dataset, str="hello")
-        obj.read_io = io
-        io.close()
+        with HDF5IO('test_closed.h5', manager=get_manager(), mode='r') as io:
+            read_smc = io.read()
 
         # File is now closed
-        html = obj._repr_html_()
+        html = read_smc._repr_html_()
         self.assertIn("<b>Warning:</b>", html)
         self.assertIn("The file backing this object is closed", html)
-        self.assertIn("unable to render", html)
 
         os.remove('test_closed.h5')
 
     def test_repr_html_no_warning_banner_when_file_open(self):
         """Test that _repr_html_ does not show a warning banner when the file is open."""
+        smc = SimpleMultiContainer(name='root')
+        smc.add_container(Data(name='my_data', data=np.array([1, 2, 3, 4], dtype=np.int64)))
 
-        with h5py.File('test_open.h5', 'w') as f:
-            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+        with HDF5IO('test_open.h5', manager=get_manager(), mode='w') as io:
+            io.write(smc)
 
-        with HDF5IO('test_open.h5', mode='r') as io:
-            dataset = io._file['my_dataset']
-            obj = self.ContainerWithData(data=dataset, str="hello")
-            obj.read_io = io
-
-            html = obj._repr_html_()
+        with HDF5IO('test_open.h5', manager=get_manager(), mode='r') as io:
+            read_smc = io.read()
+            html = read_smc._repr_html_()
             self.assertNotIn("Warning", html)
             self.assertNotIn("unable to render", html)
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -624,8 +624,8 @@ class TestHTMLRepr(TestCase):
         html = obj._repr_html_()
         self.assertNotIn("Warning", html)
 
-    def test_repr_html_array_error_shows_exception_message(self):
-        """Test that a non-closed-file error in _generate_array_html shows the exception message."""
+    def test_repr_html_field_rendering_error_shows_exception_message(self):
+        """Test that an error rendering a field in _generate_field_html shows the exception message."""
         obj = self.ContainerWithData(data=np.array([1, 2, 3]), str="hello")
 
         # Patch _generate_array_html to raise a non-file-closed error

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -589,6 +589,52 @@ class TestHTMLRepr(TestCase):
         # Cleanup
         os.remove('array_data.h5')
 
+    def test_repr_html_hdf5_dataset_closed_file(self):
+        """Test that _repr_html_ shows a warning banner and gracefully renders when the file is closed."""
+        with HDF5IO('array_data.h5', mode='w') as io:
+            dataset = io._file.create_dataset(name='my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+            obj = self.ContainerWithData(data=dataset, str="hello")
+            obj.read_io = io
+
+        # File is now closed
+        html = obj._repr_html_()
+        self.assertIn("<b>Warning:</b>", html)
+        self.assertIn("The file backing this object is closed", html)
+        self.assertIn("unable to render", html)
+        self.assertIn("file backing this object is closed", html)
+
+        os.remove('array_data.h5')
+
+    def test_repr_html_no_warning_banner_when_file_open(self):
+        """Test that _repr_html_ does not show a warning banner when the file is open."""
+        with HDF5IO('array_data.h5', mode='w') as io:
+            dataset = io._file.create_dataset(name='my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+            obj = self.ContainerWithData(data=dataset, str="hello")
+            obj.read_io = io
+
+            html = obj._repr_html_()
+            self.assertNotIn("Warning", html)
+            self.assertNotIn("unable to render", html)
+
+        os.remove('array_data.h5')
+
+    def test_repr_html_no_warning_banner_without_io(self):
+        """Test that _repr_html_ does not show a warning banner when there is no read_io."""
+        obj = self.ContainerWithData(data=np.array([1, 2, 3]), str="hello")
+        html = obj._repr_html_()
+        self.assertNotIn("Warning", html)
+
+    def test_repr_html_array_error_shows_exception_message(self):
+        """Test that a non-closed-file error in _generate_array_html shows the exception message."""
+        obj = self.ContainerWithData(data=np.array([1, 2, 3]), str="hello")
+
+        # Patch _generate_array_html to raise a non-file-closed error
+        from unittest.mock import patch
+        with patch.object(type(obj), '_generate_array_html', side_effect=ValueError("custom error")):
+            html = obj._repr_html_()
+        self.assertIn("unable to render", html)
+        self.assertIn("custom error", html)
+
 
 class TestData(TestCase):
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,6 +1,7 @@
 import numpy as np
 from uuid import uuid4, UUID
 from unittest.mock import patch, PropertyMock
+import h5py
 import os
 
 from hdmf.container import AbstractContainer, Container, Data, HERDManager
@@ -540,7 +541,6 @@ class TestHTMLRepr(TestCase):
 
     def test_repr_html_lindi_dataset(self):
         """Test HTML repr for datasets without get_storage_size method (e.g., LINDI datasets)."""
-        import h5py
 
         # Create a regular HDF5 dataset using h5py
         with h5py.File('array_data.h5', 'w') as f:
@@ -591,7 +591,6 @@ class TestHTMLRepr(TestCase):
 
     def test_repr_html_hdf5_dataset_closed_file(self):
         """Test that _repr_html_ shows a warning banner and gracefully renders when the file is closed."""
-        import h5py
 
         with h5py.File('test_closed.h5', 'w') as f:
             f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
@@ -612,7 +611,6 @@ class TestHTMLRepr(TestCase):
 
     def test_repr_html_no_warning_banner_when_file_open(self):
         """Test that _repr_html_ does not show a warning banner when the file is open."""
-        import h5py
 
         with h5py.File('test_open.h5', 'w') as f:
             f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,5 +1,6 @@
 import numpy as np
 from uuid import uuid4, UUID
+from unittest.mock import patch, PropertyMock
 import os
 
 from hdmf.container import AbstractContainer, Container, Data, HERDManager
@@ -539,7 +540,6 @@ class TestHTMLRepr(TestCase):
 
     def test_repr_html_lindi_dataset(self):
         """Test HTML repr for datasets without get_storage_size method (e.g., LINDI datasets)."""
-        from unittest.mock import PropertyMock, patch
         import h5py
 
         # Create a regular HDF5 dataset using h5py
@@ -591,24 +591,34 @@ class TestHTMLRepr(TestCase):
 
     def test_repr_html_hdf5_dataset_closed_file(self):
         """Test that _repr_html_ shows a warning banner and gracefully renders when the file is closed."""
-        with HDF5IO('array_data.h5', mode='w') as io:
-            dataset = io._file.create_dataset(name='my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
-            obj = self.ContainerWithData(data=dataset, str="hello")
-            obj.read_io = io
+        import h5py
+
+        with h5py.File('test_closed.h5', 'w') as f:
+            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+
+        io = HDF5IO('test_closed.h5', mode='r')
+        dataset = io._file['my_dataset']
+        obj = self.ContainerWithData(data=dataset, str="hello")
+        obj.read_io = io
+        io.close()
 
         # File is now closed
         html = obj._repr_html_()
         self.assertIn("<b>Warning:</b>", html)
         self.assertIn("The file backing this object is closed", html)
         self.assertIn("unable to render", html)
-        self.assertIn("file backing this object is closed", html)
 
-        os.remove('array_data.h5')
+        os.remove('test_closed.h5')
 
     def test_repr_html_no_warning_banner_when_file_open(self):
         """Test that _repr_html_ does not show a warning banner when the file is open."""
-        with HDF5IO('array_data.h5', mode='w') as io:
-            dataset = io._file.create_dataset(name='my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+        import h5py
+
+        with h5py.File('test_open.h5', 'w') as f:
+            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+
+        with HDF5IO('test_open.h5', mode='r') as io:
+            dataset = io._file['my_dataset']
             obj = self.ContainerWithData(data=dataset, str="hello")
             obj.read_io = io
 
@@ -616,7 +626,7 @@ class TestHTMLRepr(TestCase):
             self.assertNotIn("Warning", html)
             self.assertNotIn("unable to render", html)
 
-        os.remove('array_data.h5')
+        os.remove('test_open.h5')
 
     def test_repr_html_no_warning_banner_without_io(self):
         """Test that _repr_html_ does not show a warning banner when there is no read_io."""
@@ -629,7 +639,6 @@ class TestHTMLRepr(TestCase):
         obj = self.ContainerWithData(data=np.array([1, 2, 3]), str="hello")
 
         # Patch _generate_array_html to raise a non-file-closed error
-        from unittest.mock import patch
         with patch.object(type(obj), '_generate_array_html', side_effect=ValueError("custom error")):
             html = obj._repr_html_()
         self.assertIn("unable to render", html)

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -607,6 +607,26 @@ class TestHTMLRepr(TestCase):
 
         os.remove('test_closed.h5')
 
+    def test_repr_html_hdf5_dataset_field_closed_file(self):
+        """Test that _repr_html_ gracefully renders a closed h5py dataset field."""
+        with h5py.File('test_closed_field.h5', 'w') as f:
+            f.create_dataset('my_dataset', data=np.array([1, 2, 3, 4], dtype=np.int64))
+
+        io = HDF5IO('test_closed_field.h5', mode='r')
+        dataset = io._file['my_dataset']
+        obj = self.ContainerWithData(data=dataset, str="hello")
+        # Set read_io manually to simulate this container being read from disk
+        obj.read_io = io
+        io.close()
+
+        # File is now closed — accessing dataset.shape raises RuntimeError
+        html = obj._repr_html_()
+        self.assertIn("<b>Warning:</b>", html)
+        self.assertIn("unable to render", html)
+        self.assertIn("file backing this object is closed", html)
+
+        os.remove('test_closed_field.h5')
+
     def test_repr_html_no_warning_banner_when_file_open(self):
         """Test that _repr_html_ does not show a warning banner when the file is open."""
         smc = SimpleMultiContainer(name='root')

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -998,6 +998,24 @@ class TestHDF5IO(TestCase):
             self.assertEqual(io.manager, self.manager)
             self.assertEqual(io.source, self.path)
 
+    def test_is_open_true(self):
+        """Test that is_open returns True when the file is open."""
+        with HDF5IO(self.path, manager=self.manager, mode='w') as io:
+            self.assertTrue(io.is_open())
+
+    def test_is_open_false_after_close(self):
+        """Test that is_open returns False after the file is closed."""
+        io = HDF5IO(self.path, manager=self.manager, mode='w')
+        io.close()
+        self.assertFalse(io.is_open())
+
+    def test_is_open_false_before_open(self):
+        """Test that is_open returns False before the file is opened."""
+        io = HDF5IO(self.path, manager=self.manager, mode='w')
+        io.close()
+        io._HDF5IO__file = None
+        self.assertFalse(io.is_open())
+
     def test_delete_with_incomplete_construction_missing_file(self):
         """
         Here we test what happens when `close` is called before `HDF5IO.__init__` has


### PR DESCRIPTION
When an NWB file is read then closed, calling `_repr_html_` on the container raises `RuntimeError` from HDF5 operations on closed file IDs. It is not obvious from the error that the file is closed.

## Summary
- Add `HDF5IO.is_open()` method to check whether the HDF5 file handle is still valid
    - In HDMF 6.0, we will add this as an abstract method to HDMFIO. I did not want to do this now because it will break compatibility with HDMF Zarr.
- Add `Container._file_is_closed()` helper that uses `is_open()` (with `hasattr` guard for backends that don't implement it yet)
- Show a warning banner at the top of `_repr_html_` when the backing file is closed
- Wrap `_generate_field_html`, `_generate_array_html`, and `DynamicTable.generate_html_repr` in try/except -- failed renders show "the file backing this object is closed" or the exception message

Fixes #1423

<img width="706" height="521" alt="image" src="https://github.com/user-attachments/assets/608b0748-e3ab-4d26-ab06-c232fd0917f1" />


## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
