### PR TITLE
Fix _is_collection crash on closed h5py datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `_unwrap_scalar` helper in `hdmf.utils` to convert 0-d ndarrays to numpy scalars via `.item()`. This fixes `isinstance` checks against Python scalar types that fail on 0-d ndarrays returned by array-API-conforming libraries (e.g., zarr v3 scalar indexing). @h-mayorquin [#1415](https://github.com/hdmf-dev/hdmf/pull/1415)
 
 ### Fixed
+- Fixed `_is_collection` raising `RuntimeError` when accessing `ndim` on closed h5py datasets, which caused `__repr__` to crash on containers read from closed HDF5 files. @rly [#1426](https://github.com/hdmf-dev/hdmf/pull/1426)
 - Fixed writing compound dtype datasets with a single field. @rly [#1420](https://github.com/hdmf-dev/hdmf/pull/1420)
 - Replaced undeclared `pyyaml` dependency with `ruamel.yaml` (a declared core dependency) in `test_common_io.py`. The test relied on PyYAML being transitively installed by pip's `h5py`, which is not the case in conda environments. @rly [#1418](https://github.com/hdmf-dev/hdmf/pull/1418)
 

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -867,9 +867,16 @@ def _is_collection(data):
     """
     if isinstance(data, (str, bytes)):
         return False
-    if hasattr(data, "ndim"):
-        return data.ndim > 0
-    return hasattr(data, "__len__")
+    try:
+        ndim = data.ndim
+        return ndim > 0
+    except AttributeError:
+        # No ndim attribute (e.g. list, tuple, dict). Fall back to __len__.
+        return hasattr(data, "__len__")
+    except Exception:
+        # Accessing ndim on a closed h5py dataset raises RuntimeError.
+        # Treat inaccessible data as non-collection.
+        return False
 
 
 def _get_length(data) -> int:

--- a/tests/unit/utils_test/test_utils.py
+++ b/tests/unit/utils_test/test_utils.py
@@ -70,6 +70,23 @@ class TestIsCollection(TestCase):
             shape = ()
         self.assertFalse(_is_collection(FakeScalar()))
 
+    def test_ndim_raises_runtime_error(self):
+        """Simulate closed h5py dataset where accessing ndim raises RuntimeError."""
+        class ClosedDataset:
+            @property
+            def ndim(self):
+                raise RuntimeError("File is closed")
+        self.assertFalse(_is_collection(ClosedDataset()))
+
+    def test_closed_h5py_dataset(self):
+        """Test that a real closed h5py dataset is handled gracefully."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
+            hfile = h5py.File(f.name, "w")
+            ds = hfile.create_dataset("data", data=[1, 2, 3])
+            hfile.close()
+            self.assertFalse(_is_collection(ds))
+
 
 class TestGetLength(TestCase):
     """Tests for _get_length helper that gets first-dimension length."""

--- a/tests/unit/utils_test/test_utils.py
+++ b/tests/unit/utils_test/test_utils.py
@@ -6,6 +6,7 @@ from hdmf.container import Data
 from hdmf.data_utils import DataChunkIterator, DataIO
 from hdmf.testing import TestCase
 from hdmf.utils import get_data_shape, to_uint_array, is_newer_version, _is_collection, _get_length, _unwrap_scalar
+from tests.unit.helpers.utils import get_temp_filepath
 
 
 class TestIsCollection(TestCase):
@@ -80,12 +81,15 @@ class TestIsCollection(TestCase):
 
     def test_closed_h5py_dataset(self):
         """Test that a real closed h5py dataset is handled gracefully."""
-        import tempfile
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            hfile = h5py.File(f.name, "w")
+        path = get_temp_filepath()
+        try:
+            hfile = h5py.File(path, "w")
             ds = hfile.create_dataset("data", data=[1, 2, 3])
             hfile.close()
             self.assertFalse(_is_collection(ds))
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
 
 
 class TestGetLength(TestCase):


### PR DESCRIPTION
## Summary
- Fix `_is_collection` raising `RuntimeError` when called on closed h5py datasets
- `ndim` on h5py datasets is a property that accesses the HDF5 file; when the file is closed, it raises `RuntimeError` which `hasattr` does not catch
- Wrap `data.ndim` access in try/except: `AttributeError` falls back to `__len__` (plain containers), other exceptions return `False`
- Add tests with both a mock and a real closed h5py dataset

Fix #1425

## Test plan
- [x] `test_ndim_raises_runtime_error` — mock class simulating closed dataset
- [x] `test_closed_h5py_dataset` — real closed h5py dataset
- [x] All existing `TestIsCollection` and `TestGetLength` tests pass
- [x] All container tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)