### PR TITLE
Add validation for dataset reference target types (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
 - Made `HERDManager` an abstract interface (ABC) with an abstract `external_resources` property. Subclasses must now declare `external_resources` in their `__fields__` to satisfy the interface. Updated `__gather_fields` to allow auto-generated properties to override inherited abstract properties. Added `link_resources` and `get_external_resources` methods to `HERDManager` for managing a linked HERD separate from the primary one. @rly [#1431](https://github.com/hdmf-dev/hdmf/pull/1431)
 
+
 ## HDMF 5.0.1 (March 16, 2026)
 
 ### Enhancements
@@ -23,6 +24,7 @@
 - Fixed `_repr_html_` raising `RuntimeError` when the backing HDF5 file is closed. A warning banner is now shown and failed renders display a descriptive message instead of raising. @rly [#1423](https://github.com/hdmf-dev/hdmf/pull/1423)
 - Fixed writing compound dtype datasets with a single field. @rly [#1420](https://github.com/hdmf-dev/hdmf/pull/1420)
 - Replaced undeclared `pyyaml` dependency with `ruamel.yaml` (a declared core dependency) in `test_common_io.py`. The test relied on PyYAML being transitively installed by pip's `h5py`, which is not the case in conda environments. @rly [#1418](https://github.com/hdmf-dev/hdmf/pull/1418)
+
 
 ## HDMF 5.0.0 (March 2, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## Unreleased
+
+### Fixed
+- Add validation for dataset reference target types to ensure correct RefSpec.target_type matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
+
+
 ## HDMF 5.1.0 (March 24, 2026)
 
 ### Enhancements
@@ -265,7 +271,7 @@ is available on build (during the write process), but not on read of a dataset f
 
 ### Bug Fixes
 - Fixed `TermSetWrapper` warning raised during the setters. @mavaylon1 [#1116](https://github.com/hdmf-dev/hdmf/pull/1116)
-- Add validation for dataset reference target types to ensure correct RefSpec.target_type matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
+
 
 ## HDMF 3.13.0 (March 20, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Add validation for dataset reference target types to ensure correct RefSpec.target_type matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
+- Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,7 @@ is available on build (during the write process), but not on read of a dataset f
 
 ### Bug Fixes
 - Fixed `TermSetWrapper` warning raised during the setters. @mavaylon1 [#1116](https://github.com/hdmf-dev/hdmf/pull/1116)
+- Add validation for dataset reference target types to ensure correct RefSpec.target_type matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
 
 ## HDMF 3.13.0 (March 20, 2024)
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -479,7 +479,6 @@ class DatasetValidator(BaseStorageValidator):
     @docval({'name': 'spec', 'type': DatasetSpec, 'doc': 'the specification to use to validate'},
             {'name': 'validator_map', 'type': ValidatorMap, 'doc': 'the ValidatorMap to use during validation'})
     def __init__(self, **kwargs):
-        self.validator_map = getargs('validator_map', kwargs)
         super().__init__(**kwargs)
 
     def _check_ref_target_type(self, val, expected_type, type_key, builder, ret):
@@ -489,10 +488,10 @@ class DatasetValidator(BaseStorageValidator):
             ref_type = target.attributes.get(type_key)
 
             if expected_type is not None and ref_type is not None:
-                hierarchy = self.validator_map.namespace.catalog.get_hierarchy(ref_type)
+                hierarchy = self.vmap.namespace.catalog.get_hierarchy(ref_type)
                 if expected_type not in hierarchy:
                     ret.append(
-                        DtypeError(
+                        IncorrectDataType(
                             self.get_spec_loc(self.spec),
                             f"{expected_type} (or subtype)",
                             ref_type,
@@ -532,7 +531,8 @@ class DatasetValidator(BaseStorageValidator):
                                 location=self.get_builder_loc(builder)
                             )
                         )
-                if isinstance(self.spec.dtype, RefSpec):
+
+                else:
                     if dtype != 'object':
                         ret.append(
                             DtypeError(
@@ -547,6 +547,7 @@ class DatasetValidator(BaseStorageValidator):
                     self._check_ref_target_type(data, expected_target, type_key, builder, ret)
 
             except EmptyArrayError:
+                # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
                 pass
 
         if isinstance(builder.dtype, list) and len(np.shape(builder.data)) == 0:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -429,6 +429,28 @@ class DatasetValidator(BaseStorageValidator):
                         expected = self.spec.dtype
                     ret.append(DtypeError(self.get_spec_loc(self.spec), expected, dtype,
                                           location=self.get_builder_loc(builder)))
+                if isinstance(self.spec.dtype, RefSpec) and check_type(self.spec.dtype, dtype, string_format):
+                    expected_type = self.spec.dtype.target_type
+
+                    def _check_ref(val):
+                        if isinstance(val, ReferenceBuilder):
+                            target = val.builder
+                            ref_type = target.attributes.get("data_type")
+
+                            if ref_type != expected_type:
+                                ret.append(
+                                    DtypeError(
+                                        self.get_spec_loc(self.spec),
+                                        expected_type,
+                                        ref_type,
+                                        location=self.get_builder_loc(builder)
+                                    )
+                                )
+                        elif isinstance(val, (list, tuple)):
+                            for v in val:
+                                _check_ref(v)
+
+                    _check_ref(data)
             except EmptyArrayError:
                 # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
                 pass

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -514,15 +514,16 @@ class DatasetValidator(BaseStorageValidator):
                             target = val.builder
                             ref_type = target.attributes.get("data_type")
 
-                            if ref_type is not None and ref_type != expected_type:
-                                ret.append(
-                                    DtypeError(
-                                        self.get_spec_loc(self.spec),
-                                        expected_type,
-                                        ref_type,
-                                        location=self.get_builder_loc(builder)
+                            if expected_type and ref_type:
+                                if ref_type != expected_type:
+                                    ret.append(
+                                        DtypeError(
+                                            self.get_spec_loc(self.spec),
+                                            expected_type,
+                                            ref_type,
+                                            location=self.get_builder_loc(builder)
+                                        )
                                     )
-                                )
                         elif isinstance(val, (list, tuple, np.ndarray)):
                             for v in val:
                                 _check_ref(v)

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -521,12 +521,13 @@ class DatasetValidator(BaseStorageValidator):
                             )
                         )
                     expected_type = self.spec.dtype.target_type
+                    type_key = self.spec.type_key()
 
                     def _check_ref(val):
                         if isinstance(val, ReferenceBuilder):
                             target = val.builder
-                            ref_type = target.attributes.get(self.spec.type_key())
-
+                            ref_type = target.attributes.get(type_key)
+                            
                             if expected_type is not None and ref_type is not None:
                                 hierarchy = self.vmap.namespace.catalog.get_hierarchy(ref_type)
                                 if expected_type not in hierarchy:
@@ -538,20 +539,10 @@ class DatasetValidator(BaseStorageValidator):
                                             location=self.get_builder_loc(builder)
                                         )
                                     )
+                        
                         elif isinstance(val, (list, tuple, np.ndarray)):
                             for v in val:
                                 _check_ref(v)
-                        else:
-                            if dtype == 'object':
-                                return
-                            ret.append(
-                                DtypeError(
-                                    self.get_spec_loc(self.spec),
-                                    f'{self.spec.dtype.reftype} reference',
-                                    dtype,
-                                    location=self.get_builder_loc(builder)
-                                )
-                            )
 
                     _check_ref(data)
             except EmptyArrayError:

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -410,7 +410,7 @@ class AttributeValidator(Validator):
                 else:
                     target_spec = self.vmap.namespace.catalog.get_spec(spec.dtype.target_type)
                     data_type = value.attributes.get(target_spec.type_key())
-                    hierarchy = self.vmap.namespace.catalog.get_hierarchy(data_type)
+                    hierarchy = self.vmap.namespace.get_hierarchy(data_type)
                     if spec.dtype.target_type not in hierarchy:
                         ret.append(IncorrectDataType(self.get_spec_loc(spec), spec.dtype.target_type, data_type))
 
@@ -488,7 +488,7 @@ class DatasetValidator(BaseStorageValidator):
             ref_type = target.attributes.get(type_key)
 
             if expected_type is not None and ref_type is not None:
-                hierarchy = self.vmap.namespace.catalog.get_hierarchy(ref_type)
+                hierarchy = self.vmap.namespace.get_hierarchy(ref_type)
                 if expected_type not in hierarchy:
                     ret.append(
                         IncorrectDataType(

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -514,7 +514,7 @@ class DatasetValidator(BaseStorageValidator):
                             target = val.builder
                             ref_type = target.attributes.get("data_type")
 
-                            if ref_type != expected_type:
+                            if ref_type is not None and ref_type != expected_type:
                                 ret.append(
                                     DtypeError(
                                         self.get_spec_loc(self.spec),
@@ -523,7 +523,7 @@ class DatasetValidator(BaseStorageValidator):
                                         location=self.get_builder_loc(builder)
                                     )
                                 )
-                        elif isinstance(val, (list, tuple)):
+                        elif isinstance(val, (list, tuple, np.ndarray)):
                             for v in val:
                                 _check_ref(v)
 

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -479,7 +479,29 @@ class DatasetValidator(BaseStorageValidator):
     @docval({'name': 'spec', 'type': DatasetSpec, 'doc': 'the specification to use to validate'},
             {'name': 'validator_map', 'type': ValidatorMap, 'doc': 'the ValidatorMap to use during validation'})
     def __init__(self, **kwargs):
+        self.validator_map = getargs('validator_map', kwargs)
         super().__init__(**kwargs)
+
+    def _check_ref_target_type(self, val, expected_type, type_key, builder, ret):
+        """Helper to recursively validate reference target types and hierarchy."""
+        if isinstance(val, ReferenceBuilder):
+            target = val.builder
+            ref_type = target.attributes.get(type_key)
+
+            if expected_type is not None and ref_type is not None:
+                hierarchy = self.validator_map.namespace.catalog.get_hierarchy(ref_type)
+                if expected_type not in hierarchy:
+                    ret.append(
+                        DtypeError(
+                            self.get_spec_loc(self.spec),
+                            f"{expected_type} (or subtype)",
+                            ref_type,
+                            location=self.get_builder_loc(builder)
+                        )
+                    )
+        elif isinstance(val, (list, tuple, np.ndarray)):
+            for v in val:
+                self._check_ref_target_type(v, expected_type, type_key, builder, ret)
 
     @docval({"name": "builder", "type": DatasetBuilder, "doc": "the builder to validate"},
             returns='a list of Errors', rtype=list)
@@ -520,34 +542,13 @@ class DatasetValidator(BaseStorageValidator):
                                 location=self.get_builder_loc(builder)
                             )
                         )
-                    expected_type = self.spec.dtype.target_type
+                    expected_target = self.spec.dtype.target_type
                     type_key = self.spec.type_key()
+                    self._check_ref_target_type(data, expected_target, type_key, builder, ret)
 
-                    def _check_ref(val):
-                        if isinstance(val, ReferenceBuilder):
-                            target = val.builder
-                            ref_type = target.attributes.get(type_key)
-                            
-                            if expected_type is not None and ref_type is not None:
-                                hierarchy = self.vmap.namespace.catalog.get_hierarchy(ref_type)
-                                if expected_type not in hierarchy:
-                                    ret.append(
-                                        DtypeError(
-                                            self.get_spec_loc(self.spec),
-                                            expected_type,
-                                            ref_type,
-                                            location=self.get_builder_loc(builder)
-                                        )
-                                    )
-                        
-                        elif isinstance(val, (list, tuple, np.ndarray)):
-                            for v in val:
-                                _check_ref(v)
-
-                    _check_ref(data)
             except EmptyArrayError:
-                # do not validate dtype of empty array. HDMF does not yet set dtype when writing a list/tuple
                 pass
+
         if isinstance(builder.dtype, list) and len(np.shape(builder.data)) == 0:
             shape = ()  # scalar compound dataset
         elif isinstance(builder.dtype, list):

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -514,7 +514,7 @@ class DatasetValidator(BaseStorageValidator):
                             target = val.builder
                             ref_type = target.attributes.get("data_type")
 
-                            if expected_type and ref_type:
+                            if expected_type is not None and ref_type is not None:
                                 if ref_type != expected_type:
                                     ret.append(
                                         DtypeError(

--- a/src/hdmf/validate/validator.py
+++ b/src/hdmf/validate/validator.py
@@ -499,23 +499,37 @@ class DatasetValidator(BaseStorageValidator):
                         )
                     )
 
-                if not check_type(self.spec.dtype, dtype, string_format):
-                    if isinstance(self.spec.dtype, RefSpec):
-                        expected = f'{self.spec.dtype.reftype} reference'
-                    else:
+                if not isinstance(self.spec.dtype, RefSpec):
+                    if not check_type(self.spec.dtype, dtype, string_format):
                         expected = self.spec.dtype
-                    ret.append(DtypeError(self.get_spec_loc(self.spec), expected, dtype,
-                                          location=self.get_builder_loc(builder)))
-                if isinstance(self.spec.dtype, RefSpec) and check_type(self.spec.dtype, dtype, string_format):
+                        ret.append(
+                            DtypeError(
+                                self.get_spec_loc(self.spec),
+                                expected,
+                                dtype,
+                                location=self.get_builder_loc(builder)
+                            )
+                        )
+                if isinstance(self.spec.dtype, RefSpec):
+                    if dtype != 'object':
+                        ret.append(
+                            DtypeError(
+                                self.get_spec_loc(self.spec),
+                                "object reference",
+                                dtype,
+                                location=self.get_builder_loc(builder)
+                            )
+                        )
                     expected_type = self.spec.dtype.target_type
 
                     def _check_ref(val):
                         if isinstance(val, ReferenceBuilder):
                             target = val.builder
-                            ref_type = target.attributes.get("data_type")
+                            ref_type = target.attributes.get(self.spec.type_key())
 
                             if expected_type is not None and ref_type is not None:
-                                if ref_type != expected_type:
+                                hierarchy = self.vmap.namespace.catalog.get_hierarchy(ref_type)
+                                if expected_type not in hierarchy:
                                     ret.append(
                                         DtypeError(
                                             self.get_spec_loc(self.spec),
@@ -527,6 +541,17 @@ class DatasetValidator(BaseStorageValidator):
                         elif isinstance(val, (list, tuple, np.ndarray)):
                             for v in val:
                                 _check_ref(v)
+                        else:
+                            if dtype == 'object':
+                                return
+                            ret.append(
+                                DtypeError(
+                                    self.get_spec_loc(self.spec),
+                                    f'{self.spec.dtype.reftype} reference',
+                                    dtype,
+                                    location=self.get_builder_loc(builder)
+                                )
+                            )
 
                     _check_ref(data)
             except EmptyArrayError:

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1765,49 +1765,96 @@ class TestVlenStringData(ValidatorTestBase):
         self.assertIsInstance(results[0], DtypeError)
         self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
 
-def test_dataset_reference_type_validation_failure():
+    def test_dataset_reference_type_validation_failure(self):
+        foo_spec = DatasetSpec(
+            doc='dataset with ref',
+            dtype=RefSpec('Bar', 'object'),
+            data_type_def='Foo',
+            shape=None
+        )
 
-    foo_spec = DatasetSpec(
-        doc='dataset with ref',
-        dtype=RefSpec('Bar', 'object'),
-        data_type_def='Foo',
-        shape=None
-    )
+        bar_spec = DatasetSpec(
+            doc='correct dataset',
+            data_type_def='Bar',
+            dtype='int',
+            shape=None
+        )
 
-    bar_spec = DatasetSpec(
-        doc='correct dataset',
-        data_type_def='Bar',
-        dtype='int',
-        shape=None
-    )
+        baz_spec = DatasetSpec(
+            doc='wrong dataset',
+            data_type_def='Baz',
+            dtype='int',
+            shape=None
+        )
 
-    baz_spec = DatasetSpec(
-        doc='wrong dataset',
-        data_type_def='Baz',
-        dtype='int',
-        shape=None
-    )
+        catalog = SpecCatalog()
+        for spec in [foo_spec, bar_spec, baz_spec]:
+            catalog.register_spec(spec, 'test.yaml')
 
-    catalog = SpecCatalog()
-    for spec in [foo_spec, bar_spec, baz_spec]:
-        catalog.register_spec(spec, 'test.yaml')
+        namespace = SpecNamespace(
+            'test ns', 'test_ns',
+            [{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=catalog
+        )
 
-    namespace = SpecNamespace(
-        'test ns', 'test_ns',
-        [{'source': 'test.yaml'}],
-        version='0.1.0',
-        catalog=catalog
-    )
+        vmap = ValidatorMap(namespace)
 
-    vmap = ValidatorMap(namespace)
+        baz = DatasetBuilder('baz', 5, attributes={'data_type': 'Baz'})
+        foo = DatasetBuilder('foo', ReferenceBuilder(baz), attributes={'data_type': 'Foo'})
 
-    baz = DatasetBuilder('baz', 5, attributes={'data_type': 'Baz'})
-    foo = DatasetBuilder('foo', ReferenceBuilder(baz), attributes={'data_type': 'Foo'})
+        errors = vmap.validate(foo)
 
-    errors = vmap.validate(foo)
+        assert len(errors) == 1
+        assert isinstance(errors[0], DtypeError)
 
-    assert len(errors) == 1
-    assert isinstance(errors[0], DtypeError)
+    def test_dataset_reference_list_mixed(self):
+        foo_spec = DatasetSpec(
+            doc='dataset with ref',
+            dtype=RefSpec('Bar', 'object'),
+            data_type_def='Foo'
+        )
+
+        bar_spec = DatasetSpec(
+            doc='correct dataset',
+            data_type_def='Bar',
+            dtype='int'
+        )
+
+        baz_spec = DatasetSpec(
+            doc='wrong dataset',
+            data_type_def='Baz',
+            dtype='int'
+        )
+
+        catalog = SpecCatalog()
+        for spec in [foo_spec, bar_spec, baz_spec]:
+            catalog.register_spec(spec, 'test.yaml')
+
+        namespace = SpecNamespace(
+            'test ns', 'test_ns',
+            [{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=catalog
+        )
+
+        vmap = ValidatorMap(namespace)
+
+        bar = DatasetBuilder('bar', 5, attributes={'data_type': 'Bar'})
+        baz = DatasetBuilder('baz', 5, attributes={'data_type': 'Baz'})
+
+        foo = DatasetBuilder(
+            'foo',
+            [
+                ReferenceBuilder(bar),
+                ReferenceBuilder(baz)
+            ],
+            attributes={'data_type': 'Foo'}
+        )
+
+        errors = vmap.validate(foo)
+
+        assert len(errors) == 1
 
 
 class TestISODateTimeTimezone(ValidatorTestBase):

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -12,7 +12,7 @@ from hdmf.spec.spec import ONE_OR_MANY, ZERO_OR_MANY, ZERO_OR_ONE
 from hdmf.testing import TestCase, remove_test_file
 from hdmf.validate import ValidatorMap
 from hdmf.validate.errors import (DtypeError, MissingError, ExpectedArrayError, MissingDataType,
-                                  IncorrectQuantityError, IllegalLinkError, ShapeError)
+                                  IncorrectQuantityError, IllegalLinkError, ShapeError, IncorrectDataType)
 from hdmf.backends.hdf5 import HDF5IO
 from hdmf.utils import ZARR_INSTALLED, StrDataset
 from hdmf.validate.errors import Error
@@ -1806,7 +1806,7 @@ class TestVlenStringData(ValidatorTestBase):
         errors = vmap.validate(foo)
 
         assert len(errors) == 1
-        assert isinstance(errors[0], DtypeError)
+        assert isinstance(errors[0], IncorrectDataType) 
 
     def test_dataset_reference_list_mixed(self):
         foo_spec = DatasetSpec(

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1765,6 +1765,51 @@ class TestVlenStringData(ValidatorTestBase):
         self.assertIsInstance(results[0], DtypeError)
         self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
 
+    def test_dataset_reference_type_validation_hierarchy_success(self):
+        """Test that subtype references are accepted via type hierarchy."""
+
+        foo_spec = DatasetSpec(
+            doc='dataset with ref',
+            dtype=RefSpec('Bar', 'object'),
+            data_type_def='Foo',
+            shape=None
+        )
+
+        bar_spec = DatasetSpec(
+            doc='base dataset',
+            data_type_def='Bar',
+            dtype='int',
+            shape=None
+        )
+
+        subbar_spec = DatasetSpec(
+            doc='subtype dataset',
+            data_type_def='SubBar',
+            data_type_inc='Bar',
+            dtype='int',
+            shape=None
+        )
+
+        catalog = SpecCatalog()
+        for spec in [foo_spec, bar_spec, subbar_spec]:
+            catalog.register_spec(spec, 'test.yaml')
+
+        namespace = SpecNamespace(
+            'test ns', 'test_ns',
+            [{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=catalog
+        )
+
+        vmap = ValidatorMap(namespace)
+
+        subbar = DatasetBuilder('subbar', 5, attributes={'data_type': 'SubBar'})
+        foo = DatasetBuilder('foo', ReferenceBuilder(subbar), attributes={'data_type': 'Foo'})
+
+        errors = vmap.validate(foo)
+
+        assert len(errors) == 0
+
     def test_dataset_reference_type_validation_failure(self):
         foo_spec = DatasetSpec(
             doc='dataset with ref',
@@ -1998,48 +2043,3 @@ class TestISODateTimeTimezone(ValidatorTestBase):
                 # This confirms it fails because it lacks the 'T' and timezone
                 self.assertEqual(len(result), 1)
                 self.assertIsInstance(result[0], Error)
-
-    def test_dataset_reference_type_validation_hierarchy_success(self):
-        """Test that subtype references are accepted via type hierarchy."""
-
-        foo_spec = DatasetSpec(
-            doc='dataset with ref',
-            dtype=RefSpec('Bar', 'object'),
-            data_type_def='Foo',
-            shape=None
-        )
-
-        bar_spec = DatasetSpec(
-            doc='base dataset',
-            data_type_def='Bar',
-            dtype='int',
-            shape=None
-        )
-
-        subbar_spec = DatasetSpec(
-            doc='subtype dataset',
-            data_type_def='SubBar',
-            data_type_inc='Bar',
-            dtype='int',
-            shape=None
-        )
-
-        catalog = SpecCatalog()
-        for spec in [foo_spec, bar_spec, subbar_spec]:
-            catalog.register_spec(spec, 'test.yaml')
-
-        namespace = SpecNamespace(
-            'test ns', 'test_ns',
-            [{'source': 'test.yaml'}],
-            version='0.1.0',
-            catalog=catalog
-        )
-
-        vmap = ValidatorMap(namespace)
-
-        subbar = DatasetBuilder('subbar', 5, attributes={'data_type': 'SubBar'})
-        foo = DatasetBuilder('foo', ReferenceBuilder(subbar), attributes={'data_type': 'Foo'})
-
-        errors = vmap.validate(foo)
-
-        assert len(errors) == 0

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1952,4 +1952,3 @@ class TestISODateTimeTimezone(ValidatorTestBase):
                 # This confirms it fails because it lacks the 'T' and timezone
                 self.assertEqual(len(result), 1)
                 self.assertIsInstance(result[0], Error)
-

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -2043,4 +2043,3 @@ class TestISODateTimeTimezone(ValidatorTestBase):
         errors = vmap.validate(foo)
 
         assert len(errors) == 0
-

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1723,3 +1723,52 @@ class TestVlenStringData(ValidatorTestBase):
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], DtypeError)
         self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
+
+def test_dataset_reference_type_validation_failure():
+    from hdmf.spec import DatasetSpec, SpecCatalog, SpecNamespace, RefSpec
+    from hdmf.validate import ValidatorMap
+    from hdmf.build import DatasetBuilder, ReferenceBuilder
+
+    foo_spec = DatasetSpec(
+        doc='dataset with ref',
+        dtype=RefSpec('Bar', 'object'),
+        data_type_def='Foo',
+        shape=None
+    )
+
+    bar_spec = DatasetSpec(
+        doc='correct dataset',
+        data_type_def='Bar',
+        dtype='int',
+        shape=None
+    )
+
+    baz_spec = DatasetSpec(
+        doc='wrong dataset',
+        data_type_def='Baz',
+        dtype='int',
+        shape=None
+    )
+
+    catalog = SpecCatalog()
+    for spec in [foo_spec, bar_spec, baz_spec]:
+        catalog.register_spec(spec, 'test.yaml')
+
+    namespace = SpecNamespace(
+        'test ns', 'test_ns',
+        [{'source': 'test.yaml'}],
+        version='0.1.0',
+        catalog=catalog
+    )
+
+    vmap = ValidatorMap(namespace)
+
+    baz = DatasetBuilder('baz', 5, attributes={'data_type': 'Baz'})
+    foo = DatasetBuilder('foo', ReferenceBuilder(baz), attributes={'data_type': 'Foo'})
+
+    errors = vmap.validate(foo)
+
+    assert errors, "Expected validation error for incorrect reference type"
+
+
+

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1806,7 +1806,7 @@ class TestVlenStringData(ValidatorTestBase):
         errors = vmap.validate(foo)
 
         assert len(errors) == 1
-        assert isinstance(errors[0], IncorrectDataType) 
+        assert isinstance(errors[0], IncorrectDataType)
 
     def test_dataset_reference_list_mixed(self):
         foo_spec = DatasetSpec(

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1766,9 +1766,6 @@ class TestVlenStringData(ValidatorTestBase):
         self.assertEqual("Foo/data (my_foo/data): incorrect type - expected 'bytes', got 'utf'", str(results[0]))
 
 def test_dataset_reference_type_validation_failure():
-    from hdmf.spec import DatasetSpec, SpecCatalog, SpecNamespace, RefSpec
-    from hdmf.validate import ValidatorMap
-    from hdmf.build import DatasetBuilder, ReferenceBuilder
 
     foo_spec = DatasetSpec(
         doc='dataset with ref',
@@ -1809,7 +1806,9 @@ def test_dataset_reference_type_validation_failure():
 
     errors = vmap.validate(foo)
 
-    assert errors, "Expected validation error for incorrect reference type"
+    assert len(errors) == 1
+    assert isinstance(errors[0], DtypeError)
+
 
 class TestISODateTimeTimezone(ValidatorTestBase):
     """Test that isodatetime specs for both Datasets and Attributes require timezone information."""

--- a/tests/unit/validator_tests/test_validate.py
+++ b/tests/unit/validator_tests/test_validate.py
@@ -1998,3 +1998,49 @@ class TestISODateTimeTimezone(ValidatorTestBase):
                 # This confirms it fails because it lacks the 'T' and timezone
                 self.assertEqual(len(result), 1)
                 self.assertIsInstance(result[0], Error)
+
+    def test_dataset_reference_type_validation_hierarchy_success(self):
+        """Test that subtype references are accepted via type hierarchy."""
+
+        foo_spec = DatasetSpec(
+            doc='dataset with ref',
+            dtype=RefSpec('Bar', 'object'),
+            data_type_def='Foo',
+            shape=None
+        )
+
+        bar_spec = DatasetSpec(
+            doc='base dataset',
+            data_type_def='Bar',
+            dtype='int',
+            shape=None
+        )
+
+        subbar_spec = DatasetSpec(
+            doc='subtype dataset',
+            data_type_def='SubBar',
+            data_type_inc='Bar',
+            dtype='int',
+            shape=None
+        )
+
+        catalog = SpecCatalog()
+        for spec in [foo_spec, bar_spec, subbar_spec]:
+            catalog.register_spec(spec, 'test.yaml')
+
+        namespace = SpecNamespace(
+            'test ns', 'test_ns',
+            [{'source': 'test.yaml'}],
+            version='0.1.0',
+            catalog=catalog
+        )
+
+        vmap = ValidatorMap(namespace)
+
+        subbar = DatasetBuilder('subbar', 5, attributes={'data_type': 'SubBar'})
+        foo = DatasetBuilder('foo', ReferenceBuilder(subbar), attributes={'data_type': 'Foo'})
+
+        errors = vmap.validate(foo)
+
+        assert len(errors) == 0
+


### PR DESCRIPTION
## Motivation

The validator currently does not verify that dataset references point to builders with the correct `data_type` as defined by `RefSpec.target_type`.

This can lead to invalid references passing validation. This PR adds validation to ensure that referenced builders match the expected target type.

Fix #632

## How to test the behavior?
Run the validator tests:

pytest tests/unit/validator_tests -k reference

A new test demonstrates that a dataset reference with an incorrect `data_type` now raises a validation error.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
