### PR TITLE
Make `expandable` a list; default expands only DynamicTable columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+- `HDF5IO` `expandable` argument is now a list of data type names instead of a boolean. The default is `("VectorData", "ElementIdentifiers")`, so only `DynamicTable` columns and id are expandable out of the box — previously every dataset with a matching spec shape was expanded. Datasets of types outside this list that previously were expandable by default will now default to fixed-shape on-disk layout; add the relevant type to `expandable` to restore prior behavior. Replace `expandable=True` with an explicit list (e.g. `["VectorData", "ElementIdentifiers", "MyType"]`) and `expandable=False` with `[]`; passing `True`/`False` now raises a `TypeError`. @bendichter @rly [#1439](https://github.com/hdmf-dev/hdmf/pull/1439)
+
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
-- Changed the `expandable` argument of `HDF5IO.write` / `write_builder` / `write_group` / `write_dataset` from a boolean to a list (or tuple) of data type names. Only datasets whose type (or an ancestor) is in the list are created as expandable; the default is `("VectorData", "ElementIdentifiers")`, so out of the box only `DynamicTable` columns and id are made expandable instead of every dataset with a matching spec shape. Pass an empty list/tuple to disable automatic expansion entirely. @rly
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
-- Changed the default of `HDF5IO.write` / `write_builder` / `write_group` / `write_dataset` `expandable` argument from `True` to `None`. The new default only makes datasets of type `VectorData`, `ElementIdentifiers`, or their subclasses expandable (i.e., the columns and id of `DynamicTable`), instead of every dataset with a matching spec shape. `expandable=True` and `expandable=False` continue to force expansion for all or none of the datasets, respectively. @rly
+- Changed the `expandable` argument of `HDF5IO.write` / `write_builder` / `write_group` / `write_dataset` from a boolean to a list (or tuple) of data type names. Only datasets whose type (or an ancestor) is in the list are created as expandable; the default is `("VectorData", "ElementIdentifiers")`, so out of the box only `DynamicTable` columns and id are made expandable instead of every dataset with a matching spec shape. Pass an empty list/tuple to disable automatic expansion entirely. @rly
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
+- Changed the default of `HDF5IO.write` / `write_builder` / `write_group` / `write_dataset` `expandable` argument from `True` to `None`. The new default only makes datasets of type `VectorData`, `ElementIdentifiers`, or their subclasses expandable (i.e., the columns and id of `DynamicTable`), instead of every dataset with a matching spec shape. `expandable=True` and `expandable=False` continue to force expansion for all or none of the datasets, respectively. @rly
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -311,7 +311,7 @@ class HDF5IO(HDMFIO):
              'doc': 'A HERD object to populate with references.',
              'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
                      'will be created as expandable. If True, all datasets will be created as expandable. '
                      'If False, no datasets will be automatically made expandable. Expandable datasets have '
                      'maxshape set based on the matching shape defined in the spec.')})
@@ -762,7 +762,7 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
                      'will be created as expandable. If True, all datasets will be created as expandable. '
                      'If False, no datasets will be automatically made expandable. Expandable datasets have '
                      'maxshape set based on the matching shape defined in the spec.')})
@@ -944,7 +944,7 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
                      'will be created as expandable. If True, all datasets will be created as expandable. '
                      'If False, no datasets will be automatically made expandable. Expandable datasets have '
                      'maxshape set based on the matching shape defined in the spec.')},
@@ -1049,7 +1049,7 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
                      'will be created as expandable. If True, all datasets will be created as expandable. '
                      'If False, no datasets will be automatically made expandable. Expandable datasets have '
                      'maxshape set based on the matching shape defined in the spec.')},
@@ -1080,7 +1080,7 @@ class HDF5IO(HDMFIO):
             options['io_settings'] = {}
 
         # Set maxshape to make datasets expandable. When expandable is None (default), only
-        # VectorData (and subclasses) and ElementIdentifiers are made expandable — these are the
+        # VectorData, ElementIdentifiers, and their subclasses are made expandable — these are the
         # column and id datasets of DynamicTable, which users commonly need to append to. When
         # expandable is True, all datasets are made expandable. When False, none are.
         if (
@@ -1096,7 +1096,7 @@ class HDF5IO(HDMFIO):
                 if builder_dt is not None:
                     should_expand = (
                         self.manager.is_sub_data_type(builder, 'VectorData')
-                        or builder_dt == 'ElementIdentifiers'
+                        or self.manager.is_sub_data_type(builder, 'ElementIdentifiers')
                     )
             if should_expand:
                 options['io_settings']['maxshape'] = matched_spec_shape

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -310,9 +310,11 @@ class HDF5IO(HDMFIO):
             {'name': 'herd', 'type': 'hdmf.common.resources.HERD',
              'doc': 'A HERD object to populate with references.',
              'default': None},
-            {'name': 'expandable', 'type': bool, 'default': True,
-             'doc': ('If True (default), datasets will be created as expandable by setting the maxshape '
-                     'based on the matching shape defined in the spec.')})
+            {'name': 'expandable', 'type': bool, 'default': None,
+             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+                     'will be created as expandable. If True, all datasets will be created as expandable. '
+                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
+                     'maxshape set based on the matching shape defined in the spec.')})
     def write(self, **kwargs):
         """Write the container to an HDF5 file."""
         if self.__mode == 'r':
@@ -759,9 +761,11 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': True,
-             'doc': ('If True (default), datasets will be created as expandable by setting the maxshape '
-                     'based on the matching shape defined in the spec.')})
+            {'name': 'expandable', 'type': bool, 'default': None,
+             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+                     'will be created as expandable. If True, all datasets will be created as expandable. '
+                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
+                     'maxshape set based on the matching shape defined in the spec.')})
     def write_builder(self, **kwargs):
         f_builder = popargs('builder', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to path '%s' with kwargs=%s"
@@ -939,9 +943,11 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': True,
-             'doc': ('If True (default), datasets will be created as expandable by setting the maxshape '
-                     'based on the matching shape defined in the spec.')},
+            {'name': 'expandable', 'type': bool, 'default': None,
+             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+                     'will be created as expandable. If True, all datasets will be created as expandable. '
+                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
+                     'maxshape set based on the matching shape defined in the spec.')},
             returns='the Group that was created', rtype=Group)
     def write_group(self, **kwargs):
         parent, builder = popargs('parent', 'builder', kwargs)
@@ -1042,9 +1048,11 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': True,
-             'doc': ('If True (default), datasets will be created as expandable by setting the maxshape '
-                     'based on the matching shape defined in the spec.')},
+            {'name': 'expandable', 'type': bool, 'default': None,
+             'doc': ('If None (default), only VectorData (and subclasses) and ElementIdentifiers datasets '
+                     'will be created as expandable. If True, all datasets will be created as expandable. '
+                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
+                     'maxshape set based on the matching shape defined in the spec.')},
             returns='the Dataset that was created', rtype=Dataset)
     def write_dataset(self, **kwargs):  # noqa: C901
         """ Write a dataset to HDF5
@@ -1071,14 +1079,27 @@ class HDF5IO(HDMFIO):
         else:
             options['io_settings'] = {}
 
-        # Set maxshape to make a non-scalar dataset expandable but do not override existing settings
+        # Set maxshape to make datasets expandable. When expandable is None (default), only
+        # VectorData (and subclasses) and ElementIdentifiers are made expandable — these are the
+        # column and id datasets of DynamicTable, which users commonly need to append to. When
+        # expandable is True, all datasets are made expandable. When False, none are.
         if (
-            expandable
+            expandable is not False
             and 'maxshape' not in options['io_settings']
             and np.ndim(data) != 0
             and matched_spec_shape is not None
         ):
-            options['io_settings']['maxshape'] = matched_spec_shape
+            should_expand = expandable is True
+            if not should_expand:
+                # expandable is None (default): only expand VectorData and ElementIdentifiers
+                builder_dt = self.manager.get_builder_dt(builder)
+                if builder_dt is not None:
+                    should_expand = (
+                        self.manager.is_sub_data_type(builder, 'VectorData')
+                        or builder_dt == 'ElementIdentifiers'
+                    )
+            if should_expand:
+                options['io_settings']['maxshape'] = matched_spec_shape
 
         attributes = builder.attributes
         options['dtype'] = builder.dtype

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -311,10 +311,10 @@ class HDF5IO(HDMFIO):
              'doc': 'A HERD object to populate with references.',
              'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
-                     'will be created as expandable. If True, all datasets will be created as expandable. '
-                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
-                     'maxshape set based on the matching shape defined in the spec.')})
+             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
+                     'subclasses will be created as expandable. If True, all datasets will be created as '
+                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
+                     'datasets have maxshape set based on the matching shape defined in the spec.')})
     def write(self, **kwargs):
         """Write the container to an HDF5 file."""
         if self.__mode == 'r':
@@ -762,10 +762,10 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
-                     'will be created as expandable. If True, all datasets will be created as expandable. '
-                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
-                     'maxshape set based on the matching shape defined in the spec.')})
+             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
+                     'subclasses will be created as expandable. If True, all datasets will be created as '
+                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
+                     'datasets have maxshape set based on the matching shape defined in the spec.')})
     def write_builder(self, **kwargs):
         f_builder = popargs('builder', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to path '%s' with kwargs=%s"
@@ -944,10 +944,10 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
-                     'will be created as expandable. If True, all datasets will be created as expandable. '
-                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
-                     'maxshape set based on the matching shape defined in the spec.')},
+             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
+                     'subclasses will be created as expandable. If True, all datasets will be created as '
+                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
+                     'datasets have maxshape set based on the matching shape defined in the spec.')},
             returns='the Group that was created', rtype=Group)
     def write_group(self, **kwargs):
         parent, builder = popargs('parent', 'builder', kwargs)
@@ -1049,10 +1049,10 @@ class HDF5IO(HDMFIO):
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
             {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only VectorData, ElementIdentifiers, and their subclasses datasets '
-                     'will be created as expandable. If True, all datasets will be created as expandable. '
-                     'If False, no datasets will be automatically made expandable. Expandable datasets have '
-                     'maxshape set based on the matching shape defined in the spec.')},
+             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
+                     'subclasses will be created as expandable. If True, all datasets will be created as '
+                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
+                     'datasets have maxshape set based on the matching shape defined in the spec.')},
             returns='the Dataset that was created', rtype=Dataset)
     def write_dataset(self, **kwargs):  # noqa: C901
         """ Write a dataset to HDF5

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -310,11 +310,13 @@ class HDF5IO(HDMFIO):
             {'name': 'herd', 'type': 'hdmf.common.resources.HERD',
              'doc': 'A HERD object to populate with references.',
              'default': None},
-            {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
-                     'subclasses will be created as expandable. If True, all datasets will be created as '
-                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
-                     'datasets have maxshape set based on the matching shape defined in the spec.')})
+            {'name': 'expandable', 'type': (list, tuple),
+             'default': ("VectorData", "ElementIdentifiers"),
+             'doc': ('A list of data type names whose datasets (and subclasses) will be created as '
+                     'expandable — maxshape is set based on the matching shape defined in the spec. '
+                     'Default is ("VectorData", "ElementIdentifiers"), so only DynamicTable columns '
+                     'and id are expandable. Pass an empty list/tuple to disable automatic expansion '
+                     'entirely.')})
     def write(self, **kwargs):
         """Write the container to an HDF5 file."""
         if self.__mode == 'r':
@@ -761,11 +763,13 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
-                     'subclasses will be created as expandable. If True, all datasets will be created as '
-                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
-                     'datasets have maxshape set based on the matching shape defined in the spec.')})
+            {'name': 'expandable', 'type': (list, tuple),
+             'default': ("VectorData", "ElementIdentifiers"),
+             'doc': ('A list of data type names whose datasets (and subclasses) will be created as '
+                     'expandable — maxshape is set based on the matching shape defined in the spec. '
+                     'Default is ("VectorData", "ElementIdentifiers"), so only DynamicTable columns '
+                     'and id are expandable. Pass an empty list/tuple to disable automatic expansion '
+                     'entirely.')})
     def write_builder(self, **kwargs):
         f_builder = popargs('builder', kwargs)
         self.logger.debug("Writing GroupBuilder '%s' to path '%s' with kwargs=%s"
@@ -943,11 +947,13 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
-                     'subclasses will be created as expandable. If True, all datasets will be created as '
-                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
-                     'datasets have maxshape set based on the matching shape defined in the spec.')},
+            {'name': 'expandable', 'type': (list, tuple),
+             'default': ("VectorData", "ElementIdentifiers"),
+             'doc': ('A list of data type names whose datasets (and subclasses) will be created as '
+                     'expandable — maxshape is set based on the matching shape defined in the spec. '
+                     'Default is ("VectorData", "ElementIdentifiers"), so only DynamicTable columns '
+                     'and id are expandable. Pass an empty list/tuple to disable automatic expansion '
+                     'entirely.')},
             returns='the Group that was created', rtype=Group)
     def write_group(self, **kwargs):
         parent, builder = popargs('parent', 'builder', kwargs)
@@ -1048,11 +1054,13 @@ class HDF5IO(HDMFIO):
              'default': True},
             {'name': 'export_source', 'type': str,
              'doc': 'The source of the builders when exporting', 'default': None},
-            {'name': 'expandable', 'type': bool, 'default': None,
-             'doc': ('If None (default), only datasets of type VectorData, ElementIdentifiers, or their '
-                     'subclasses will be created as expandable. If True, all datasets will be created as '
-                     'expandable. If False, no datasets will be automatically made expandable. Expandable '
-                     'datasets have maxshape set based on the matching shape defined in the spec.')},
+            {'name': 'expandable', 'type': (list, tuple),
+             'default': ("VectorData", "ElementIdentifiers"),
+             'doc': ('A list of data type names whose datasets (and subclasses) will be created as '
+                     'expandable — maxshape is set based on the matching shape defined in the spec. '
+                     'Default is ("VectorData", "ElementIdentifiers"), so only DynamicTable columns '
+                     'and id are expandable. Pass an empty list/tuple to disable automatic expansion '
+                     'entirely.')},
             returns='the Dataset that was created', rtype=Dataset)
     def write_dataset(self, **kwargs):  # noqa: C901
         """ Write a dataset to HDF5
@@ -1079,27 +1087,19 @@ class HDF5IO(HDMFIO):
         else:
             options['io_settings'] = {}
 
-        # Set maxshape to make datasets expandable. When expandable is None (default), only
-        # VectorData, ElementIdentifiers, and their subclasses are made expandable — these are the
-        # column and id datasets of DynamicTable, which users commonly need to append to. When
-        # expandable is True, all datasets are made expandable. When False, none are.
+        # Set maxshape to make datasets expandable. `expandable` is a list/tuple of data type names:
+        # a dataset is made expandable if its data type (or an ancestor) is in the list. The default
+        # list ("VectorData", "ElementIdentifiers") covers DynamicTable columns and id, which users
+        # commonly need to append to. An empty list disables automatic expansion.
         if (
-            expandable is not False
+            expandable
             and 'maxshape' not in options['io_settings']
             and np.ndim(data) != 0
             and matched_spec_shape is not None
+            and self.manager.get_builder_dt(builder) is not None
+            and any(self.manager.is_sub_data_type(builder, dt) for dt in expandable)
         ):
-            should_expand = expandable is True
-            if not should_expand:
-                # expandable is None (default): only expand VectorData and ElementIdentifiers
-                builder_dt = self.manager.get_builder_dt(builder)
-                if builder_dt is not None:
-                    should_expand = (
-                        self.manager.is_sub_data_type(builder, 'VectorData')
-                        or self.manager.is_sub_data_type(builder, 'ElementIdentifiers')
-                    )
-            if should_expand:
-                options['io_settings']['maxshape'] = matched_spec_shape
+            options['io_settings']['maxshape'] = matched_spec_shape
 
         attributes = builder.attributes
         options['dtype'] = builder.dtype

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3211,6 +3211,86 @@ class TestDataIOReferences(H5RoundTripMixin, TestCase):
 
         self.assertContainerEqual(read_container['table']['y'][-1], group1)
 
+class TestDefaultExpandable(H5RoundTripMixin, TestCase):
+    """Test that VectorData, VectorIndex, and ElementIdentifiers datasets are expandable by default."""
+
+    def setUpContainer(self):
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='foo', description='an int column')
+        table.add_column(name='bar', description='an indexed column', index=True)
+        table.add_row(foo=1, bar=[1, 2, 3])
+        table.add_row(foo=2, bar=[4, 5])
+        return table
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            # VectorData columns should be expandable (maxshape has None in first dim)
+            self.assertEqual(f['foo'].maxshape, (None,))
+            self.assertIsNotNone(f['foo'].chunks)
+
+            # VectorIndex columns should be expandable
+            self.assertEqual(f['bar_index'].maxshape, (None,))
+            self.assertIsNotNone(f['bar_index'].chunks)
+
+            # Indexed VectorData should be expandable
+            self.assertEqual(f['bar'].maxshape, (None,))
+            self.assertIsNotNone(f['bar'].chunks)
+
+            # ElementIdentifiers (id column) should be expandable
+            self.assertEqual(f['id'].maxshape, (None,))
+            self.assertIsNotNone(f['id'].chunks)
+
+
+class TestDefaultExpandableWithReferences(H5RoundTripMixin, TestCase):
+    """Test that a VectorData column of references is expandable by default."""
+
+    def setUpContainer(self):
+        group1 = Container('group1')
+        group2 = Container('group2')
+
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='ref', description='a reference column')
+        table.add_row(ref=group1)
+        table.add_row(ref=group2)
+
+        multi = SimpleMultiContainer(name='multi')
+        multi.add_container(group1)
+        multi.add_container(group2)
+        multi.add_container(table)
+        return multi
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            table_grp = f['table0']
+            self.assertEqual(table_grp['ref'].maxshape, (None,))
+            self.assertIsNotNone(table_grp['ref'].chunks)
+
+
+class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
+    """Test that explicit H5DataIO settings are not overridden by the default expandable behavior."""
+
+    def setUpContainer(self):
+        # User explicitly sets maxshape — should be respected
+        foo = VectorData(
+            name='foo',
+            description='a column with explicit maxshape',
+            data=H5DataIO(data=[1, 2, 3], maxshape=(10,)),
+        )
+        table = DynamicTable(name='table0', description='an example table', columns=[foo])
+        return table
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            # User's explicit maxshape should be preserved, not overridden
+            self.assertEqual(f['foo'].maxshape, (10,))
+
+
 class TestVectorIndexDtype(TestCase):
 
     def set_up_array_index(self):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3,12 +3,15 @@ import h5py
 import numpy as np
 import os
 import pandas as pd
+import shutil
+import tempfile
 import unittest
 
 from hdmf import Container
 from hdmf import TermSet, TermSetWrapper
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 from hdmf.backends.hdf5.h5tools import H5_TEXT, H5PY_3
+from hdmf.build import BuildManager
 from hdmf.common import (
     DynamicTable,
     VectorData,
@@ -18,12 +21,16 @@ from hdmf.common import (
     DynamicTableRegion,
     MeaningsTable,
     get_manager,
+    get_type_map,
     SimpleMultiContainer)
+from hdmf.spec import DatasetSpec
 from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 from hdmf.utils import StrDataset
 from hdmf.data_utils import DataChunkIterator
 
 from tests.unit.helpers.utils import (
+    CORE_NAMESPACE,
+    create_load_namespace_yaml,
     get_temp_filepath,
     FooExtendDynamicTable0,
     FooExtendDynamicTable1,
@@ -3289,6 +3296,69 @@ class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
         with h5py.File(self.filename, 'r') as f:
             # User's explicit maxshape should be preserved, not overridden
             self.assertEqual(f['foo'].maxshape, (10,))
+
+
+class TestDefaultExpandableSubclasses(TestCase):
+    """Test that subclasses of VectorData and ElementIdentifiers are expandable by default."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        custom_ei_spec = DatasetSpec(
+            data_type_def='CustomElementIdentifiers',
+            data_type_inc='ElementIdentifiers',
+            doc='a custom ElementIdentifiers subclass',
+        )
+        custom_vd_spec = DatasetSpec(
+            data_type_def='CustomVectorData',
+            data_type_inc='VectorData',
+            doc='a custom VectorData subclass',
+        )
+
+        self.type_map = get_type_map()
+        create_load_namespace_yaml(
+            namespace_name=CORE_NAMESPACE,
+            specs=[custom_ei_spec, custom_vd_spec],
+            output_dir=self.test_dir,
+            incl_types={'hdmf-common': ['ElementIdentifiers', 'VectorData', 'DynamicTable']},
+            type_map=self.type_map,
+        )
+        self.manager = BuildManager(self.type_map)
+
+        self.CustomElementIdentifiers = self.type_map.get_dt_container_cls(
+            'CustomElementIdentifiers', CORE_NAMESPACE
+        )
+        self.CustomVectorData = self.type_map.get_dt_container_cls(
+            'CustomVectorData', CORE_NAMESPACE
+        )
+
+        self.filename = os.path.join(self.test_dir, 'test_expandable_subclasses.h5')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_subclasses_are_expandable(self):
+        custom_ids = self.CustomElementIdentifiers(name='id', data=[10, 20])
+        custom_col = self.CustomVectorData(
+            name='custom_col', description='a custom column', data=[1.0, 2.0]
+        )
+        table = DynamicTable(
+            name='table0',
+            description='an example table',
+            id=custom_ids,
+            columns=[custom_col],
+        )
+
+        with HDF5IO(self.filename, manager=self.manager, mode='w') as write_io:
+            write_io.write(table)
+
+        with h5py.File(self.filename, 'r') as f:
+            # ElementIdentifiers subclass (id) should be expandable
+            self.assertEqual(f['id'].maxshape, (None,))
+            self.assertIsNotNone(f['id'].chunks)
+            # VectorData subclass (custom_col) should be expandable
+            self.assertEqual(f['custom_col'].maxshape, (None,))
+            self.assertIsNotNone(f['custom_col'].chunks)
 
 
 class TestVectorIndexDtype(TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3298,8 +3298,8 @@ class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
             self.assertEqual(f['foo'].maxshape, (10,))
 
 
-class TestExpandableFalse(TestCase):
-    """Test that expandable=False disables maxshape for all datasets, including VectorData and id."""
+class TestExpandableEmpty(TestCase):
+    """Test that expandable=[] disables maxshape for all datasets, including VectorData and id."""
 
     def setUp(self):
         self.filename = get_temp_filepath()
@@ -3307,18 +3307,43 @@ class TestExpandableFalse(TestCase):
     def tearDown(self):
         remove_test_file(self.filename)
 
-    def test_expandable_false_no_maxshape(self):
+    def test_expandable_empty_no_maxshape(self):
         table = DynamicTable(name='table0', description='an example table')
         table.add_column(name='foo', description='an int column')
         table.add_row(foo=1)
         table.add_row(foo=2)
 
         with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
-            io.write(table, expandable=False)
+            io.write(table, expandable=[])
 
         with h5py.File(self.filename, 'r') as f:
-            # With expandable=False, non-scalar datasets get a fixed shape, not (None,).
+            # With an empty expandable list, non-scalar datasets get a fixed shape, not (None,).
             self.assertEqual(f['foo'].maxshape, (2,))
+            self.assertEqual(f['id'].maxshape, (2,))
+
+
+class TestExpandableCustomList(TestCase):
+    """Test that a custom expandable list expands only listed types."""
+
+    def setUp(self):
+        self.filename = get_temp_filepath()
+
+    def tearDown(self):
+        remove_test_file(self.filename)
+
+    def test_expandable_only_vectordata(self):
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='foo', description='an int column')
+        table.add_row(foo=1)
+        table.add_row(foo=2)
+
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
+            io.write(table, expandable=['VectorData'])
+
+        with h5py.File(self.filename, 'r') as f:
+            # VectorData column 'foo' is in the list → expandable.
+            self.assertEqual(f['foo'].maxshape, (None,))
+            # ElementIdentifiers 'id' is NOT in the list → fixed shape.
             self.assertEqual(f['id'].maxshape, (2,))
 
 

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3,15 +3,12 @@ import h5py
 import numpy as np
 import os
 import pandas as pd
-import shutil
-import tempfile
 import unittest
 
 from hdmf import Container
 from hdmf import TermSet, TermSetWrapper
 from hdmf.backends.hdf5 import H5DataIO, HDF5IO
 from hdmf.backends.hdf5.h5tools import H5_TEXT, H5PY_3
-from hdmf.build import BuildManager
 from hdmf.common import (
     DynamicTable,
     VectorData,
@@ -21,16 +18,12 @@ from hdmf.common import (
     DynamicTableRegion,
     MeaningsTable,
     get_manager,
-    get_type_map,
     SimpleMultiContainer)
-from hdmf.spec import DatasetSpec
 from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 from hdmf.utils import StrDataset
 from hdmf.data_utils import DataChunkIterator
 
 from tests.unit.helpers.utils import (
-    CORE_NAMESPACE,
-    create_load_namespace_yaml,
     get_temp_filepath,
     FooExtendDynamicTable0,
     FooExtendDynamicTable1,
@@ -3217,197 +3210,6 @@ class TestDataIOReferences(H5RoundTripMixin, TestCase):
         read_container['table'].add_row(id=103, x=3, y=group1)
 
         self.assertContainerEqual(read_container['table']['y'][-1], group1)
-
-class TestDefaultExpandable(H5RoundTripMixin, TestCase):
-    """Test that VectorData, VectorIndex, and ElementIdentifiers datasets are expandable by default."""
-
-    def setUpContainer(self):
-        table = DynamicTable(name='table0', description='an example table')
-        table.add_column(name='foo', description='an int column')
-        table.add_column(name='bar', description='an indexed column', index=True)
-        table.add_row(foo=1, bar=[1, 2, 3])
-        table.add_row(foo=2, bar=[4, 5])
-        return table
-
-    def test_roundtrip(self):
-        super().test_roundtrip()
-
-        with h5py.File(self.filename, 'r') as f:
-            # VectorData columns should be expandable (maxshape has None in first dim)
-            self.assertEqual(f['foo'].maxshape, (None,))
-            self.assertIsNotNone(f['foo'].chunks)
-
-            # VectorIndex columns should be expandable
-            self.assertEqual(f['bar_index'].maxshape, (None,))
-            self.assertIsNotNone(f['bar_index'].chunks)
-
-            # Indexed VectorData should be expandable
-            self.assertEqual(f['bar'].maxshape, (None,))
-            self.assertIsNotNone(f['bar'].chunks)
-
-            # ElementIdentifiers (id column) should be expandable
-            self.assertEqual(f['id'].maxshape, (None,))
-            self.assertIsNotNone(f['id'].chunks)
-
-
-class TestDefaultExpandableWithReferences(H5RoundTripMixin, TestCase):
-    """Test that a VectorData column of references is expandable by default."""
-
-    def setUpContainer(self):
-        group1 = Container('group1')
-        group2 = Container('group2')
-
-        table = DynamicTable(name='table0', description='an example table')
-        table.add_column(name='ref', description='a reference column')
-        table.add_row(ref=group1)
-        table.add_row(ref=group2)
-
-        multi = SimpleMultiContainer(name='multi')
-        multi.add_container(group1)
-        multi.add_container(group2)
-        multi.add_container(table)
-        return multi
-
-    def test_roundtrip(self):
-        super().test_roundtrip()
-
-        with h5py.File(self.filename, 'r') as f:
-            table_grp = f['table0']
-            self.assertEqual(table_grp['ref'].maxshape, (None,))
-            self.assertIsNotNone(table_grp['ref'].chunks)
-
-
-class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
-    """Test that explicit H5DataIO settings are not overridden by the default expandable behavior."""
-
-    def setUpContainer(self):
-        # User explicitly sets maxshape — should be respected
-        foo = VectorData(
-            name='foo',
-            description='a column with explicit maxshape',
-            data=H5DataIO(data=[1, 2, 3], maxshape=(10,)),
-        )
-        table = DynamicTable(name='table0', description='an example table', columns=[foo])
-        return table
-
-    def test_roundtrip(self):
-        super().test_roundtrip()
-
-        with h5py.File(self.filename, 'r') as f:
-            # User's explicit maxshape should be preserved, not overridden
-            self.assertEqual(f['foo'].maxshape, (10,))
-
-
-class TestExpandableEmpty(TestCase):
-    """Test that expandable=[] disables maxshape for all datasets, including VectorData and id."""
-
-    def setUp(self):
-        self.filename = get_temp_filepath()
-
-    def tearDown(self):
-        remove_test_file(self.filename)
-
-    def test_expandable_empty_no_maxshape(self):
-        table = DynamicTable(name='table0', description='an example table')
-        table.add_column(name='foo', description='an int column')
-        table.add_row(foo=1)
-        table.add_row(foo=2)
-
-        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
-            io.write(table, expandable=[])
-
-        with h5py.File(self.filename, 'r') as f:
-            # With an empty expandable list, non-scalar datasets get a fixed shape, not (None,).
-            self.assertEqual(f['foo'].maxshape, (2,))
-            self.assertEqual(f['id'].maxshape, (2,))
-
-
-class TestExpandableCustomList(TestCase):
-    """Test that a custom expandable list expands only listed types."""
-
-    def setUp(self):
-        self.filename = get_temp_filepath()
-
-    def tearDown(self):
-        remove_test_file(self.filename)
-
-    def test_expandable_only_vectordata(self):
-        table = DynamicTable(name='table0', description='an example table')
-        table.add_column(name='foo', description='an int column')
-        table.add_row(foo=1)
-        table.add_row(foo=2)
-
-        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
-            io.write(table, expandable=['VectorData'])
-
-        with h5py.File(self.filename, 'r') as f:
-            # VectorData column 'foo' is in the list → expandable.
-            self.assertEqual(f['foo'].maxshape, (None,))
-            # ElementIdentifiers 'id' is NOT in the list → fixed shape.
-            self.assertEqual(f['id'].maxshape, (2,))
-
-
-class TestDefaultExpandableSubclasses(TestCase):
-    """Test that subclasses of VectorData and ElementIdentifiers are expandable by default."""
-
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-
-        custom_ei_spec = DatasetSpec(
-            data_type_def='CustomElementIdentifiers',
-            data_type_inc='ElementIdentifiers',
-            doc='a custom ElementIdentifiers subclass',
-        )
-        custom_vd_spec = DatasetSpec(
-            data_type_def='CustomVectorData',
-            data_type_inc='VectorData',
-            doc='a custom VectorData subclass',
-        )
-
-        self.type_map = get_type_map()
-        create_load_namespace_yaml(
-            namespace_name=CORE_NAMESPACE,
-            specs=[custom_ei_spec, custom_vd_spec],
-            output_dir=self.test_dir,
-            incl_types={'hdmf-common': ['ElementIdentifiers', 'VectorData', 'DynamicTable']},
-            type_map=self.type_map,
-        )
-        self.manager = BuildManager(self.type_map)
-
-        self.CustomElementIdentifiers = self.type_map.get_dt_container_cls(
-            'CustomElementIdentifiers', CORE_NAMESPACE
-        )
-        self.CustomVectorData = self.type_map.get_dt_container_cls(
-            'CustomVectorData', CORE_NAMESPACE
-        )
-
-        self.filename = os.path.join(self.test_dir, 'test_expandable_subclasses.h5')
-
-    def tearDown(self):
-        shutil.rmtree(self.test_dir)
-
-    def test_subclasses_are_expandable(self):
-        custom_ids = self.CustomElementIdentifiers(name='id', data=[10, 20])
-        custom_col = self.CustomVectorData(
-            name='custom_col', description='a custom column', data=[1.0, 2.0]
-        )
-        table = DynamicTable(
-            name='table0',
-            description='an example table',
-            id=custom_ids,
-            columns=[custom_col],
-        )
-
-        with HDF5IO(self.filename, manager=self.manager, mode='w') as write_io:
-            write_io.write(table)
-
-        with h5py.File(self.filename, 'r') as f:
-            # ElementIdentifiers subclass (id) should be expandable
-            self.assertEqual(f['id'].maxshape, (None,))
-            self.assertIsNotNone(f['id'].chunks)
-            # VectorData subclass (custom_col) should be expandable
-            self.assertEqual(f['custom_col'].maxshape, (None,))
-            self.assertIsNotNone(f['custom_col'].chunks)
 
 
 class TestVectorIndexDtype(TestCase):

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3298,6 +3298,30 @@ class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
             self.assertEqual(f['foo'].maxshape, (10,))
 
 
+class TestExpandableFalse(TestCase):
+    """Test that expandable=False disables maxshape for all datasets, including VectorData and id."""
+
+    def setUp(self):
+        self.filename = get_temp_filepath()
+
+    def tearDown(self):
+        remove_test_file(self.filename)
+
+    def test_expandable_false_no_maxshape(self):
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='foo', description='an int column')
+        table.add_row(foo=1)
+        table.add_row(foo=2)
+
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
+            io.write(table, expandable=False)
+
+        with h5py.File(self.filename, 'r') as f:
+            # With expandable=False, non-scalar datasets get a fixed shape, not (None,).
+            self.assertEqual(f['foo'].maxshape, (2,))
+            self.assertEqual(f['id'].maxshape, (2,))
+
+
 class TestDefaultExpandableSubclasses(TestCase):
     """Test that subclasses of VectorData and ElementIdentifiers are expandable by default."""
 

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -23,19 +23,22 @@ from hdmf.backends.errors import UnsupportedOperation
 from hdmf.build import GroupBuilder, DatasetBuilder, BuildManager, TypeMap, OrphanContainerBuildError, LinkBuilder
 from hdmf.container import Container, HERDManager
 from hdmf import Data, docval
-from hdmf.common import SimpleMultiContainer, get_hdf5io
+from hdmf.common import (DynamicTable, VectorData, SimpleMultiContainer, get_hdf5io, get_manager,
+                         get_type_map)
 from hdmf.data_utils import DataChunkIterator, GenericDataChunkIterator, InvalidDataIOError, append_data
+from hdmf.spec import DatasetSpec
 from hdmf.spec.catalog import SpecCatalog
 from hdmf.spec.namespace import NamespaceCatalog, SpecNamespace
 from hdmf.spec.spec import GroupSpec, DtypeSpec
-from hdmf.testing import TestCase, remove_test_file
+from hdmf.testing import TestCase, H5RoundTripMixin, remove_test_file
 from hdmf.common.resources import HERD
 from hdmf.term_set import TermSet, TermSetWrapper
 from hdmf.utils import get_data_shape
 
 from tests.unit.helpers.utils import (Foo, FooBucket, FooFile, get_foo_buildmanager,
                               Baz, BazData, BazCpdData, BazBucket, get_baz_buildmanager,
-                              CORE_NAMESPACE, get_temp_filepath, CacheSpecTestHelper,
+                              CORE_NAMESPACE, create_load_namespace_yaml, get_temp_filepath,
+                              CacheSpecTestHelper,
                               CustomGroupSpec, CustomDatasetSpec, CustomSpecNamespace,
                               QuxData, QuxBucket, get_qux_buildmanager)
 from tests.unit.helpers.io import DoNothingIO
@@ -4219,3 +4222,196 @@ class TestExpand(TestCase):
                                  [7, 8, 9]])
             npt.assert_array_equal(read_quxbucket.qux_data.data[:], expected)
             self.assertEqual(read_quxbucket.qux_data.data.maxshape, (None, 3))
+
+
+class TestDefaultExpandable(H5RoundTripMixin, TestCase):
+    """Test that VectorData, VectorIndex, and ElementIdentifiers datasets are expandable by default."""
+
+    def setUpContainer(self):
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='foo', description='an int column')
+        table.add_column(name='bar', description='an indexed column', index=True)
+        table.add_row(foo=1, bar=[1, 2, 3])
+        table.add_row(foo=2, bar=[4, 5])
+        return table
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            # VectorData columns should be expandable (maxshape has None in first dim)
+            self.assertEqual(f['foo'].maxshape, (None,))
+            self.assertIsNotNone(f['foo'].chunks)
+
+            # VectorIndex columns should be expandable
+            self.assertEqual(f['bar_index'].maxshape, (None,))
+            self.assertIsNotNone(f['bar_index'].chunks)
+
+            # Indexed VectorData should be expandable
+            self.assertEqual(f['bar'].maxshape, (None,))
+            self.assertIsNotNone(f['bar'].chunks)
+
+            # ElementIdentifiers (id column) should be expandable
+            self.assertEqual(f['id'].maxshape, (None,))
+            self.assertIsNotNone(f['id'].chunks)
+
+
+class TestDefaultExpandableWithReferences(H5RoundTripMixin, TestCase):
+    """Test that a VectorData column of references is expandable by default."""
+
+    def setUpContainer(self):
+        group1 = Container('group1')
+        group2 = Container('group2')
+
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='ref', description='a reference column')
+        table.add_row(ref=group1)
+        table.add_row(ref=group2)
+
+        multi = SimpleMultiContainer(name='multi')
+        multi.add_container(group1)
+        multi.add_container(group2)
+        multi.add_container(table)
+        return multi
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            ref_ds = f['table0/ref']
+            self.assertEqual(ref_ds.maxshape, (None,))
+            self.assertIsNotNone(ref_ds.chunks)
+            # Reference dtype should not bypass the expandable branch.
+            self.assertTrue(h5py.check_ref_dtype(ref_ds.dtype))
+            # Stored refs resolve to the expected target groups.
+            self.assertIsInstance(ref_ds[0], h5py.Reference)
+            self.assertEqual(f[ref_ds[0]].name, '/group1')
+            self.assertEqual(f[ref_ds[1]].name, '/group2')
+
+
+class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
+    """Test that explicit H5DataIO settings are not overridden by the default expandable behavior."""
+
+    def setUpContainer(self):
+        # User explicitly sets maxshape — should be respected
+        foo = VectorData(
+            name='foo',
+            description='a column with explicit maxshape',
+            data=H5DataIO(data=[1, 2, 3], maxshape=(10,)),
+        )
+        table = DynamicTable(name='table0', description='an example table', columns=[foo])
+        return table
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            # User's explicit maxshape should be preserved, not overridden
+            self.assertEqual(f['foo'].maxshape, (10,))
+
+
+class TestExpandableArg(TestCase):
+    """Test explicit values of the `expandable` argument to HDF5IO.write."""
+
+    def setUp(self):
+        self.filename = get_temp_filepath()
+
+    def tearDown(self):
+        remove_test_file(self.filename)
+
+    def _make_table(self):
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='foo', description='an int column')
+        table.add_row(foo=1)
+        table.add_row(foo=2)
+        return table
+
+    def test_empty_disables_expansion(self):
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
+            io.write(self._make_table(), expandable=[])
+
+        with h5py.File(self.filename, 'r') as f:
+            # With an empty expandable list, non-scalar datasets get a fixed shape, not (None,).
+            self.assertEqual(f['foo'].maxshape, (2,))
+            self.assertEqual(f['id'].maxshape, (2,))
+
+    def test_custom_list_expands_only_listed(self):
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
+            io.write(self._make_table(), expandable=['VectorData'])
+
+        with h5py.File(self.filename, 'r') as f:
+            # VectorData column 'foo' is in the list → expandable.
+            self.assertEqual(f['foo'].maxshape, (None,))
+            # ElementIdentifiers 'id' is NOT in the list → fixed shape.
+            self.assertEqual(f['id'].maxshape, (2,))
+
+    def test_bool_raises_type_error(self):
+        """Passing the old boolean API must fail loudly, per the 5.2.0 breaking change."""
+        with HDF5IO(self.filename, manager=get_manager(), mode='w') as io:
+            with self.assertRaises(TypeError):
+                io.write(self._make_table(), expandable=True)
+            with self.assertRaises(TypeError):
+                io.write(self._make_table(), expandable=False)
+
+
+class TestDefaultExpandableSubclasses(TestCase):
+    """Test that subclasses of VectorData and ElementIdentifiers are expandable by default."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        custom_ei_spec = DatasetSpec(
+            data_type_def='CustomElementIdentifiers',
+            data_type_inc='ElementIdentifiers',
+            doc='a custom ElementIdentifiers subclass',
+        )
+        custom_vd_spec = DatasetSpec(
+            data_type_def='CustomVectorData',
+            data_type_inc='VectorData',
+            doc='a custom VectorData subclass',
+        )
+
+        self.type_map = get_type_map()
+        create_load_namespace_yaml(
+            namespace_name=CORE_NAMESPACE,
+            specs=[custom_ei_spec, custom_vd_spec],
+            output_dir=self.test_dir,
+            incl_types={'hdmf-common': ['ElementIdentifiers', 'VectorData', 'DynamicTable']},
+            type_map=self.type_map,
+        )
+        self.manager = BuildManager(self.type_map)
+
+        self.CustomElementIdentifiers = self.type_map.get_dt_container_cls(
+            'CustomElementIdentifiers', CORE_NAMESPACE
+        )
+        self.CustomVectorData = self.type_map.get_dt_container_cls(
+            'CustomVectorData', CORE_NAMESPACE
+        )
+
+        self.filename = os.path.join(self.test_dir, 'test_expandable_subclasses.h5')
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_subclasses_are_expandable(self):
+        custom_ids = self.CustomElementIdentifiers(name='id', data=[10, 20])
+        custom_col = self.CustomVectorData(
+            name='custom_col', description='a custom column', data=[1.0, 2.0]
+        )
+        table = DynamicTable(
+            name='table0',
+            description='an example table',
+            id=custom_ids,
+            columns=[custom_col],
+        )
+
+        with HDF5IO(self.filename, manager=self.manager, mode='w') as write_io:
+            write_io.write(table)
+
+        with h5py.File(self.filename, 'r') as f:
+            # ElementIdentifiers subclass (id) should be expandable
+            self.assertEqual(f['id'].maxshape, (None,))
+            self.assertIsNotNone(f['id'].chunks)
+            # VectorData subclass (custom_col) should be expandable
+            self.assertEqual(f['custom_col'].maxshape, (None,))
+            self.assertIsNotNone(f['custom_col'].chunks)

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -884,7 +884,7 @@ class TestRoundTrip(TestCase):
         foofile = FooFile(buckets=[foobucket])
 
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile)
+            io.write(foofile, expandable=True)
 
         with HDF5IO(self.path, manager=self.manager, mode='a') as io:
             read_foofile = io.read()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -883,8 +883,13 @@ class TestRoundTrip(TestCase):
         foobucket = FooBucket('bucket1', [foo1])
         foofile = FooFile(buckets=[foobucket])
 
+        # expandable=True forces all datasets with a matching spec shape to be expandable,
+        # including Foo.my_data which is not a VectorData/ElementIdentifiers subclass.
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
             io.write(foofile, expandable=True)
+
+        with h5py.File(self.path, 'r') as f:
+            self.assertEqual(f['buckets/bucket1/foo_holder/foo1/my_data'].maxshape, (None,))
 
         with HDF5IO(self.path, manager=self.manager, mode='a') as io:
             read_foofile = io.read()

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -878,15 +878,14 @@ class TestRoundTrip(TestCase):
                                  read_foofile.buckets['bucket1'].foos['foo1'].my_data[:].tolist())
 
     def test_roundtrip_basic_append(self):
-        # Setup all the data we need
-        foo1 = Foo('foo1', [1, 2, 3, 4, 5], "I am foo1", 17, 3.14)
+        # Foo.my_data is an anonymous (untyped) dataset, so the default `expandable` list does
+        # not cover it. Wrap its data in H5DataIO with an explicit maxshape to make it expandable.
+        foo1 = Foo('foo1', H5DataIO(data=[1, 2, 3, 4, 5], maxshape=(None,)), "I am foo1", 17, 3.14)
         foobucket = FooBucket('bucket1', [foo1])
         foofile = FooFile(buckets=[foobucket])
 
-        # expandable=True forces all datasets with a matching spec shape to be expandable,
-        # including Foo.my_data which is not a VectorData/ElementIdentifiers subclass.
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile, expandable=True)
+            io.write(foofile)
 
         with h5py.File(self.path, 'r') as f:
             self.assertEqual(f['buckets/bucket1/foo_holder/foo1/my_data'].maxshape, (None,))
@@ -4180,7 +4179,7 @@ class TestExpand(TestCase):
         foofile = FooFile(buckets=[foobucket])
 
         with HDF5IO(self.path, manager=self.manager, mode='w') as io:
-            io.write(foofile, expandable=False)
+            io.write(foofile, expandable=[])
 
         with HDF5IO(self.path, manager=self.manager, mode='r') as io:
             read_foofile = io.read()
@@ -4196,7 +4195,7 @@ class TestExpand(TestCase):
         manager = get_qux_buildmanager([[None, None], [None, 3]])
 
         with HDF5IO(self.path, manager=manager, mode='w') as io:
-            io.write(quxbucket, expandable=True)
+            io.write(quxbucket, expandable=['QuxData'])
 
         with HDF5IO(self.path, manager=manager, mode='r') as io:
             read_quxbucket = io.read()
@@ -4209,7 +4208,7 @@ class TestExpand(TestCase):
         manager = get_qux_buildmanager([None, 3])
 
         with HDF5IO(self.path, manager=manager, mode='w') as io:
-            io.write(quxbucket, expandable=True)
+            io.write(quxbucket, expandable=['QuxData'])
 
         with HDF5IO(self.path, manager=manager, mode='r+') as io:
             read_quxbucket = io.read()

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -295,22 +295,6 @@ class TestDocValidator(TestCase):
         with self.assertRaisesWith(TypeError, msg):
             self.test_obj_sub.basic_add2_kw('a string', 100, 'another string', None, arg6=True)
 
-    def test_docval_none_default_with_non_none_type(self):
-        """Test that docval accepts default=None even when the declared type excludes NoneType,
-        and that the runtime type check still rejects wrongly-typed values.
-        """
-        class Foo:
-            @docval({'name': 'flag', 'type': bool, 'doc': 'a bool flag', 'default': None})
-            def run(self, **kwargs):
-                return kwargs['flag']
-
-        f = Foo()
-        self.assertIsNone(f.run())  # default None is accepted despite type=bool
-        self.assertIs(f.run(flag=True), True)
-        self.assertIs(f.run(flag=False), False)
-        with self.assertRaisesRegex(TypeError, r"incorrect type for 'flag' \(got 'str', expected 'bool'\)"):
-            f.run(flag='not a bool')
-
     def test_only_kw_no_args(self):
         """Test that docval parses arguments when only keyword
            arguments exist, and no arguments are specified

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -295,6 +295,22 @@ class TestDocValidator(TestCase):
         with self.assertRaisesWith(TypeError, msg):
             self.test_obj_sub.basic_add2_kw('a string', 100, 'another string', None, arg6=True)
 
+    def test_docval_none_default_with_non_none_type(self):
+        """Test that docval accepts default=None even when the declared type excludes NoneType,
+        and that the runtime type check still rejects wrongly-typed values.
+        """
+        class Foo:
+            @docval({'name': 'flag', 'type': bool, 'doc': 'a bool flag', 'default': None})
+            def run(self, **kwargs):
+                return kwargs['flag']
+
+        f = Foo()
+        self.assertIsNone(f.run())  # default None is accepted despite type=bool
+        self.assertIs(f.run(flag=True), True)
+        self.assertIs(f.run(flag=False), False)
+        with self.assertRaisesRegex(TypeError, r"incorrect type for 'flag' \(got 'str', expected 'bool'\)"):
+            f.run(flag='not a bool')
+
     def test_only_kw_no_args(self):
         """Test that docval parses arguments when only keyword
            arguments exist, and no arguments are specified


### PR DESCRIPTION
## Summary
- Change the default `expandable` behavior in `HDF5IO.write` / `write_builder` / `write_group` / `write_dataset` so that only `DynamicTable` columns and `id` are made expandable out of the box. Datasets of all other types now default to fixed-shape on-disk layout.
- **Breaking change:** `expandable` is now a list (or tuple) of data type names with default `("VectorData", "ElementIdentifiers")`, not a boolean. A dataset is made expandable if its data type (or an ancestor) is in the list — so subclasses of `VectorData` (e.g. `DynamicTableRegion`) and `ElementIdentifiers` are also covered. Pass an empty list/tuple to disable automatic expansion entirely. Passing `True`/`False` now raises a `TypeError` from docval.
- Subclass detection uses `BuildManager.is_sub_data_type`, with a `get_builder_dt` short-circuit so untyped dataset builders don't hit the hierarchy lookup.
- CHANGELOG entry added under a new `Breaking changes` heading with migration guidance.

Closes #1437

## Test plan
- [x] `TestDefaultExpandable` — `VectorData`, `VectorIndex`, indexed `VectorData`, and `ElementIdentifiers` are expandable by default
- [x] `TestDefaultExpandableSubclasses` — user-defined subclasses of `VectorData` / `ElementIdentifiers` are expandable by default (regression test for the `is_sub_data_type` fix)
- [x] `TestDefaultExpandableWithReferences` — reference-column dataset carries a reference dtype, is expandable, and refs resolve round-trip
- [x] `TestDefaultExpandableExplicitOverride` — explicit `H5DataIO(maxshape=...)` is preserved, not overridden
- [x] `TestExpandableArg` — `expandable=[]` disables expansion; custom list expands only listed types; `expandable=True`/`False` raises `TypeError`
- [x] `TestExpand.test_expand_set_shape` — `expandable=['QuxData']` still supports the append path on non-table types
- [x] Existing `TestDTRReferences` — `DynamicTableRegion` with references still works
- [x] Full test suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)