### PR TITLE
Set reasonable default chunk sizes (~4 MB) when chunks=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking changes
 - `HDF5IO` `expandable` argument is now a list of data type names instead of a boolean. The default is `("VectorData", "ElementIdentifiers")`, so only `DynamicTable` columns and id are expandable out of the box — previously every dataset with a matching spec shape was expanded. Datasets of types outside this list that previously were expandable by default will now default to fixed-shape on-disk layout; add the relevant type to `expandable` to restore prior behavior. Replace `expandable=True` with an explicit list (e.g. `["VectorData", "ElementIdentifiers", "MyType"]`) and `expandable=False` with `[]`; passing `True`/`False` now raises a `TypeError`. @bendichter @rly [#1439](https://github.com/hdmf-dev/hdmf/pull/1439)
 
+### Enhancements
+- Set sensible default chunk sizes (~4 MB, in the recommended 2-16 MB range for cloud-hosted files) when `chunks=True`, replacing h5py's much smaller defaults. Added public `HDF5IO.compute_default_chunk_shape()` so users can inspect or override the chunk shape that would be used. @bendichter [#1440](https://github.com/hdmf-dev/hdmf/pull/1440)
+
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1102,7 +1102,7 @@ class HDF5IO(HDMFIO):
             options['io_settings']['maxshape'] = matched_spec_shape
 
         # Ensure chunking is explicitly enabled when maxshape requires it, so that
-        # _compute_chunk_shape can replace it with appropriately-sized chunks later.
+        # compute_default_chunk_shape can replace it with appropriately-sized chunks later.
         if 'maxshape' in options['io_settings'] and 'chunks' not in options['io_settings']:
             options['io_settings']['chunks'] = True
 
@@ -1345,7 +1345,7 @@ class HDF5IO(HDMFIO):
                 io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
         # Replace chunks=True with computed chunk shape for better cloud access performance
         if io_settings.get('chunks') is True and 'shape' in io_settings and len(io_settings['shape']) > 0:
-            io_settings['chunks'] = HDF5IO._compute_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
+            io_settings['chunks'] = HDF5IO.compute_default_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:
@@ -1377,7 +1377,7 @@ class HDF5IO(HDMFIO):
             io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
         # Replace chunks=True with computed chunk shape for better cloud access performance
         if io_settings.get('chunks') is True and 'shape' in io_settings and len(io_settings['shape']) > 0:
-            io_settings['chunks'] = HDF5IO._compute_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
+            io_settings['chunks'] = HDF5IO.compute_default_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:
@@ -1431,7 +1431,7 @@ class HDF5IO(HDMFIO):
 
         # Replace chunks=True with computed chunk shape for better cloud access performance
         if io_settings.get('chunks') is True and data_shape is not None and len(data_shape) > 0:
-            io_settings['chunks'] = HDF5IO._compute_chunk_shape(data_shape, dtype)
+            io_settings['chunks'] = HDF5IO.compute_default_chunk_shape(data_shape, dtype)
 
         # Create the dataset
         try:
@@ -1482,16 +1482,18 @@ class HDF5IO(HDMFIO):
         return self.__get_ref(**kwargs)
 
     @staticmethod
-    def _compute_chunk_shape(data_shape, dtype, target_chunk_bytes=4 * 1024 * 1024):
+    def compute_default_chunk_shape(data_shape, dtype, target_chunk_bytes=4 * 1024 * 1024, neurodata_type=None):
         """Compute a chunk shape targeting a given number of bytes per chunk.
 
-        h5py's default auto-chunking targets 8-500 KB chunks for datasets under 100 GB, depending on 
-        dataset size. This is too small for cloud access where each
-        chunk may require a separate HTTP range request. This method targets larger chunks (default
-        4 MB) in the recommended 2-16 MB range for cloud-hosted files.
+        h5py's default auto-chunking targets 8-500 KB chunks for datasets under 100 GB, depending on
+        dataset size. This is too small for cloud access where each chunk may require a separate
+        HTTP range request. This method targets larger chunks (default 4 MB) in the recommended
+        2-16 MB range for cloud-hosted files.
 
         The algorithm keeps all dimensions except the first at their full size and adjusts the first
-        dimension to reach the target chunk size.
+        dimension to reach the target chunk size. When a single slice along the first dimension
+        already exceeds the target (e.g. mesoscale imaging frames), trailing dimensions are halved
+        in place of the largest axis until the chunk fits within the target.
 
         Parameters
         ----------
@@ -1501,12 +1503,18 @@ class HDF5IO(HDMFIO):
             The data type, used to determine bytes per element.
         target_chunk_bytes : int, optional
             Target chunk size in bytes. Default is 4 MB.
+        neurodata_type : str, optional
+            Name of the neurodata type for this dataset. Unused by the default implementation;
+            provided as a hook so subclasses can specialize chunking per type.
 
         Returns
         -------
-        tuple
-            The computed chunk shape.
+        tuple or True
+            The computed chunk shape, or ``True`` to fall back to h5py auto-chunking when a shape
+            cannot be computed (unsupported dtype or zero-length trailing dimension).
         """
+        del neurodata_type  # extension hook for overrides; unused by default
+
         try:
             itemsize = np.dtype(dtype).itemsize
         except TypeError:
@@ -1520,6 +1528,17 @@ class HDF5IO(HDMFIO):
 
         if bytes_per_row == 0:
             return True
+
+        if bytes_per_row > target_chunk_bytes:
+            # A single slice along the first axis already exceeds the target. Halve the largest
+            # trailing dimension repeatedly until the chunk fits within the target.
+            chunks = [1] + list(data_shape[1:])
+            while int(np.prod(chunks)) * itemsize > target_chunk_bytes:
+                idx = 1 + int(np.argmax(chunks[1:]))
+                if chunks[idx] <= 1:
+                    break
+                chunks[idx] = max(1, chunks[idx] // 2)
+            return tuple(chunks)
 
         # Compute first dimension to reach target chunk size
         first_dim = max(1, target_chunk_bytes // bytes_per_row)

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1464,7 +1464,8 @@ class HDF5IO(HDMFIO):
     def _compute_chunk_shape(data_shape, dtype, target_chunk_bytes=4 * 1024 * 1024):
         """Compute a chunk shape targeting a given number of bytes per chunk.
 
-        h5py's default auto-chunking targets ~32 KB, which is too small for cloud access where each
+        h5py's default auto-chunking targets 8-500 KB chunks for datasets under 100 GB, depending on 
+        dataset size. This is too small for cloud access where each
         chunk may require a separate HTTP range request. This method targets larger chunks (default
         4 MB) in the recommended 2-16 MB range for cloud-hosted files.
 

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1080,6 +1080,11 @@ class HDF5IO(HDMFIO):
         ):
             options['io_settings']['maxshape'] = matched_spec_shape
 
+        # Ensure chunking is explicitly enabled when maxshape requires it, so that
+        # _compute_chunk_shape can replace it with appropriately-sized chunks later.
+        if 'maxshape' in options['io_settings'] and 'chunks' not in options['io_settings']:
+            options['io_settings']['chunks'] = True
+
         attributes = builder.attributes
         options['dtype'] = builder.dtype
         dset = None
@@ -1317,6 +1322,9 @@ class HDF5IO(HDMFIO):
             if isinstance(io_settings['dtype'], str):
                 # map to real dtype if we were given a string
                 io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
+        # Replace chunks=True with computed chunk shape for better cloud access performance
+        if io_settings.get('chunks') is True and 'shape' in io_settings and len(io_settings['shape']) > 0:
+            io_settings['chunks'] = HDF5IO._compute_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:
@@ -1346,6 +1354,9 @@ class HDF5IO(HDMFIO):
         if isinstance(io_settings['dtype'], str):
             # map to real dtype if we were given a string
             io_settings['dtype'] = cls.__dtypes.get(io_settings['dtype'])
+        # Replace chunks=True with computed chunk shape for better cloud access performance
+        if io_settings.get('chunks') is True and 'shape' in io_settings and len(io_settings['shape']) > 0:
+            io_settings['chunks'] = HDF5IO._compute_chunk_shape(io_settings['shape'], io_settings.get('dtype'))
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:
@@ -1397,6 +1408,10 @@ class HDF5IO(HDMFIO):
         else:
             data_shape = get_data_shape(data)
 
+        # Replace chunks=True with computed chunk shape for better cloud access performance
+        if io_settings.get('chunks') is True and data_shape is not None and len(data_shape) > 0:
+            io_settings['chunks'] = HDF5IO._compute_chunk_shape(data_shape, dtype)
+
         # Create the dataset
         try:
             dset = parent.create_dataset(name, shape=data_shape, dtype=dtype, **io_settings)
@@ -1444,6 +1459,52 @@ class HDF5IO(HDMFIO):
             returns='the reference', rtype=Reference)
     def _create_ref(self, **kwargs):
         return self.__get_ref(**kwargs)
+
+    @staticmethod
+    def _compute_chunk_shape(data_shape, dtype, target_chunk_bytes=4 * 1024 * 1024):
+        """Compute a chunk shape targeting a given number of bytes per chunk.
+
+        h5py's default auto-chunking targets ~32 KB, which is too small for cloud access where each
+        chunk may require a separate HTTP range request. This method targets larger chunks (default
+        4 MB) in the recommended 2-16 MB range for cloud-hosted files.
+
+        The algorithm keeps all dimensions except the first at their full size and adjusts the first
+        dimension to reach the target chunk size.
+
+        Parameters
+        ----------
+        data_shape : tuple
+            The shape of the dataset.
+        dtype : numpy.dtype or type
+            The data type, used to determine bytes per element.
+        target_chunk_bytes : int, optional
+            Target chunk size in bytes. Default is 4 MB.
+
+        Returns
+        -------
+        tuple
+            The computed chunk shape.
+        """
+        try:
+            itemsize = np.dtype(dtype).itemsize
+        except TypeError:
+            return True  # fall back to h5py auto-chunking for unsupported dtypes
+
+        # Elements per "row" (all dimensions except the first)
+        elements_per_row = 1
+        for s in data_shape[1:]:
+            elements_per_row *= s
+        bytes_per_row = elements_per_row * itemsize
+
+        if bytes_per_row == 0:
+            return True
+
+        # Compute first dimension to reach target chunk size
+        first_dim = max(1, target_chunk_bytes // bytes_per_row)
+        # Don't exceed the actual data size in the first dimension, but always at least 1
+        first_dim = max(1, min(first_dim, data_shape[0]))
+
+        return (first_dim,) + tuple(data_shape[1:])
 
     def __is_ref(self, dtype):
         if isinstance(dtype, DtypeSpec):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -4230,7 +4230,7 @@ class TestComputeChunkShape(TestCase):
         """Computed chunks should be close to the target size."""
         # 10000x100 float64: 8 bytes/element, target 4 MB
         shape = (10000, 100)
-        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.float64)
         chunk_bytes = np.prod(chunks) * np.dtype(np.float64).itemsize
         self.assertGreater(chunk_bytes, 1 * 1024 * 1024)  # > 1 MB
         self.assertLessEqual(chunk_bytes, 8 * 1024 * 1024)  # <= 8 MB
@@ -4240,19 +4240,26 @@ class TestComputeChunkShape(TestCase):
     def test_small_dataset_uses_data_shape(self):
         """Datasets smaller than the target should use their full shape as chunks."""
         shape = (100,)
-        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.float64)
         self.assertEqual(chunks, (100,))
 
     def test_empty_dataset(self):
         """Empty datasets should get chunk shape with 1 in first dimension."""
         shape = (0,)
-        chunks = HDF5IO._compute_chunk_shape(shape, np.int32)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.int32)
         self.assertEqual(chunks, (1,))
+
+    def test_zero_trailing_dimension_falls_back(self):
+        """A zero-length trailing dimension can't be chunked by us — fall back to h5py auto-chunking."""
+        # bytes_per_row == 0 branch: product of trailing dims is 0
+        shape = (10, 0, 5)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.float64)
+        self.assertIs(chunks, True)
 
     def test_1d_large(self):
         """Large 1D dataset should get chunks targeting ~4 MB."""
         shape = (10_000_000,)
-        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.float64)
         chunk_bytes = chunks[0] * 8
         self.assertGreater(chunk_bytes, 2 * 1024 * 1024)
         self.assertLessEqual(chunk_bytes, 8 * 1024 * 1024)
@@ -4260,10 +4267,22 @@ class TestComputeChunkShape(TestCase):
     def test_custom_target(self):
         """Custom target_chunk_bytes should be respected."""
         shape = (10_000_000,)
-        chunks = HDF5IO._compute_chunk_shape(shape, np.float64, target_chunk_bytes=16 * 1024 * 1024)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.float64, target_chunk_bytes=16 * 1024 * 1024)
         chunk_bytes = chunks[0] * 8
         self.assertGreater(chunk_bytes, 8 * 1024 * 1024)
         self.assertLessEqual(chunk_bytes, 32 * 1024 * 1024)
+
+    def test_large_trailing_dims_get_split(self):
+        """When a single first-dim slice exceeds the target, trailing dims are reduced."""
+        # (1000, 4096, 4096) uint16 -> a single (1, 4096, 4096) slice is 32 MB, way over target
+        shape = (1000, 4096, 4096)
+        chunks = HDF5IO.compute_default_chunk_shape(shape, np.uint16)
+        chunk_bytes = int(np.prod(chunks)) * np.dtype(np.uint16).itemsize
+        # Should stay within the recommended 2-16 MB range, not balloon to 32 MB
+        self.assertLessEqual(chunk_bytes, 8 * 1024 * 1024)
+        self.assertGreater(chunk_bytes, 1 * 1024 * 1024)
+        # First dim must stay at 1 since even one full slice was already over target
+        self.assertEqual(chunks[0], 1)
 
 
 class TestDefaultExpandable(H5RoundTripMixin, TestCase):

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -4215,3 +4215,45 @@ class TestExpand(TestCase):
                                  [7, 8, 9]])
             npt.assert_array_equal(read_quxbucket.qux_data.data[:], expected)
             self.assertEqual(read_quxbucket.qux_data.data.maxshape, (None, 3))
+
+
+class TestComputeChunkShape(TestCase):
+
+    def test_target_chunk_size(self):
+        """Computed chunks should be close to the target size."""
+        # 10000x100 float64: 8 bytes/element, target 4 MB
+        shape = (10000, 100)
+        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        chunk_bytes = np.prod(chunks) * np.dtype(np.float64).itemsize
+        self.assertGreater(chunk_bytes, 1 * 1024 * 1024)  # > 1 MB
+        self.assertLessEqual(chunk_bytes, 8 * 1024 * 1024)  # <= 8 MB
+        # Second dimension should be preserved
+        self.assertEqual(chunks[1], 100)
+
+    def test_small_dataset_uses_data_shape(self):
+        """Datasets smaller than the target should use their full shape as chunks."""
+        shape = (100,)
+        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        self.assertEqual(chunks, (100,))
+
+    def test_empty_dataset(self):
+        """Empty datasets should get chunk shape with 1 in first dimension."""
+        shape = (0,)
+        chunks = HDF5IO._compute_chunk_shape(shape, np.int32)
+        self.assertEqual(chunks, (1,))
+
+    def test_1d_large(self):
+        """Large 1D dataset should get chunks targeting ~4 MB."""
+        shape = (10_000_000,)
+        chunks = HDF5IO._compute_chunk_shape(shape, np.float64)
+        chunk_bytes = chunks[0] * 8
+        self.assertGreater(chunk_bytes, 2 * 1024 * 1024)
+        self.assertLessEqual(chunk_bytes, 8 * 1024 * 1024)
+
+    def test_custom_target(self):
+        """Custom target_chunk_bytes should be respected."""
+        shape = (10_000_000,)
+        chunks = HDF5IO._compute_chunk_shape(shape, np.float64, target_chunk_bytes=16 * 1024 * 1024)
+        chunk_bytes = chunks[0] * 8
+        self.assertGreater(chunk_bytes, 8 * 1024 * 1024)
+        self.assertLessEqual(chunk_bytes, 32 * 1024 * 1024)


### PR DESCRIPTION
## Summary
- Add `_compute_chunk_shape()` static method that computes chunk shapes targeting ~4 MB per chunk, replacing h5py's default ~32 KB auto-chunking which is too small for cloud access (each chunk = one HTTP range request).
- Applied in `__list_fill__`, `__setup_chunked_dset__`, and `__setup_empty_dset__` whenever `chunks=True` (boolean, not a user-specified tuple).
- When `maxshape` forces chunking, explicitly sets `chunks=True` so the compute logic triggers instead of falling through to h5py's small defaults.
- The algorithm keeps all dimensions except the first at their full size and adjusts the first dimension to reach the target. Small datasets that fit within the target use their full shape.

Before (h5py defaults):
```
10000x100 float64: chunks=(63, 63),  chunk_bytes=31,752  (0.03 MB)
```

After:
```
10000x100 float64: chunks=(5242, 100), chunk_bytes=4,193,600 (4.00 MB)
```

Closes #1438

## Test plan
- [x] `TestComputeChunkShape` — unit tests for the chunk computation: target size, small datasets, empty datasets, 1D large, custom target
- [x] Full test suite passes (566 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)