### PR TITLE
Fix link target being included as a column on DynamicTable read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
-- Fixed reading a `DynamicTable` that contains a named link to a `VectorData` (e.g., `MeaningsTable.target`). The link target was being picked up as an extra column, causing a `"Columns must be the same length"` error when the target column's row count differed from the table's own row count. @rly [#1444](https://github.com/hdmf-dev/hdmf/issues/1444)
+- Fixed reading a `DynamicTable` that contains a named link to a `VectorData` (e.g., `MeaningsTable.target`). The link target was being picked up as an extra column, causing a `"Columns must be the same length"` error when the target column's row count differed from the table's own row count. @rly [#1445](https://github.com/hdmf-dev/hdmf/pull/1445)
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Added missing validation for dataset reference target types to ensure correct `RefSpec.target_type` matching. @sejalpunwatkar [#1429](https://github.com/hdmf-dev/hdmf/pull/1429)
+- Fixed reading a `DynamicTable` that contains a named link to a `VectorData` (e.g., `MeaningsTable.target`). The link target was being picked up as an extra column, causing a `"Columns must be the same length"` error when the target column's row count differed from the table's own row count. @rly [#1444](https://github.com/hdmf-dev/hdmf/issues/1444)
 
 
 ## HDMF 5.1.0 (March 24, 2026)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1392,13 +1392,20 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 if dt is not None:
                     link_dt.setdefault(dt, list()).append(target)
             # now assign links to their respective specification
+            consumed_link_names = set()
             for subspec in spec.links:
                 if subspec.name is not None and subspec.name in links:
                     ret[subspec] = manager.construct(links[subspec.name].builder)
+                    consumed_link_names.add(subspec.name)
                 else:
                     sub_builder = link_dt.get(subspec.target_type)
                     if sub_builder is not None:
                         ret[subspec] = self.__flatten(sub_builder, subspec, manager)
+            # remove named links already resolved above so they are not also
+            # picked up by generic data-type matching in __get_sub_builders
+            for name in consumed_link_names:
+                groups.pop(name, None)
+                datasets.pop(name, None)
             # now process groups and datasets
             self.__get_sub_builders(groups, spec.groups, manager, ret)
             self.__get_sub_builders(datasets, spec.datasets, manager, ret)

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3495,6 +3495,40 @@ class TestMeaningsTableRoundTrip(H5RoundTripMixin, TestCase):
         self.assertEqual(list(mt['meaning'].data), ['stimulus A', 'stimulus B', 'stimulus C'])
 
 
+class TestMeaningsTableLengthMismatchRoundTrip(H5RoundTripMixin, TestCase):
+    """Roundtrip when MeaningsTable row count differs from the target column row count.
+
+    Regression test: the target link's VectorData was being included as an extra
+    column of the MeaningsTable during read, which failed the equal-length check
+    when the target column had more (or fewer) rows than the MeaningsTable.
+    """
+
+    def setUpContainer(self):
+        table = DynamicTable(name='test_table', description='a test table')
+        table.add_column(name='stimulus_type', description='stimulus type')
+        # three rows in the target column
+        table.add_row(stimulus_type='a')
+        table.add_row(stimulus_type='b')
+        table.add_row(stimulus_type='a')
+
+        # two rows in the MeaningsTable (unique values only)
+        mt = MeaningsTable(target=table['stimulus_type'])
+        mt.add_row(value='a', meaning='stimulus A')
+        mt.add_row(value='b', meaning='stimulus B')
+        table.add_meanings_table(mt)
+
+        return table
+
+    def test_roundtrip_mismatched_lengths(self):
+        read_container = self.roundtripContainer()
+        mt = read_container.get_meanings_table('stimulus_type_meanings')
+        self.assertEqual(len(mt), 2)
+        self.assertEqual(tuple(mt.colnames), ('value', 'meaning'))
+        self.assertEqual(list(mt['value'].data), ['a', 'b'])
+        self.assertEqual(list(mt['meaning'].data), ['stimulus A', 'stimulus B'])
+        self.assertEqual(mt.target.name, 'stimulus_type')
+
+
 class TestMultipleMeaningsTablesRoundTrip(H5RoundTripMixin, TestCase):
     """Test roundtrip of DynamicTable with multiple MeaningsTables."""
 


### PR DESCRIPTION
## Summary

- Remove named-link targets from the local `groups`/`datasets` maps after they are resolved via `spec.links`, so they are not re-matched by `DynamicTable`'s generic `columns → VectorData` mapping.
- Adds a regression test (`TestMeaningsTableLengthMismatchRoundTrip`) that roundtrips a `MeaningsTable` with fewer rows than its target column.

## Motivation

Fixes #1444. The `MeaningsTable.target` link points to a `VectorData` on the parent table. On read, that linked `VectorData` was picked up as an extra column of the `MeaningsTable`, causing:

```
ConstructError: Could not construct MeaningsTable object due to: Columns must be the same length
```

whenever the target column and the `MeaningsTable` had different row counts — which is the normal case (events × unique values).

When lengths happened to match, the bug was silent (existing roundtrip tests all used matching row counts, so coverage did not catch it).

## Test plan

- [x] New regression test `TestMeaningsTableLengthMismatchRoundTrip` (passes on this branch; fails on `dev`)
- [x] Full HDMF test suite: 1834 passed, 22 skipped
- [x] Full PyNWB test suite: 806 passed, 7 skipped (verified end-to-end via `docs/gallery/general/plot_file.py`, which builds a `MeaningsTable` on top of an `EventsTable` with mismatched lengths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)