### PR TITLE
Fix Sphinx nitpick warnings in compute_default_chunk_shape docstring

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,7 @@ nitpick_ignore = [('py:class', 'Intracomm'),
                   ('py:class', 'h5py._hl.dataset.Dataset'),
                   ('py:class', 'function'),
                   ('py:class', 'unittest.case.TestCase'),
+                  ('py:class', 'optional'),
                   ]
 
 suppress_warnings = ["config.cache"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,6 @@ nitpick_ignore = [('py:class', 'Intracomm'),
                   ('py:class', 'h5py._hl.dataset.Dataset'),
                   ('py:class', 'function'),
                   ('py:class', 'unittest.case.TestCase'),
-                  ('py:class', 'optional'),
                   ]
 
 suppress_warnings = ["config.cache"]

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1509,7 +1509,7 @@ class HDF5IO(HDMFIO):
 
         Returns
         -------
-        tuple or True
+        tuple or bool
             The computed chunk shape, or ``True`` to fall back to h5py auto-chunking when a shape
             cannot be computed (unsupported dtype or zero-length trailing dimension).
         """

--- a/src/hdmf/backends/hdf5/h5tools.py
+++ b/src/hdmf/backends/hdf5/h5tools.py
@@ -1501,9 +1501,9 @@ class HDF5IO(HDMFIO):
             The shape of the dataset.
         dtype : numpy.dtype or type
             The data type, used to determine bytes per element.
-        target_chunk_bytes : int, optional
+        target_chunk_bytes : int
             Target chunk size in bytes. Default is 4 MB.
-        neurodata_type : str, optional
+        neurodata_type : str
             Name of the neurodata type for this dataset. Unused by the default implementation;
             provided as a hook so subclasses can specialize chunking per type.
 


### PR DESCRIPTION
## Summary
- The scheduled Sphinx link check on `dev` ([run 24924421854](https://github.com/hdmf-dev/hdmf/actions/runs/24924421854)) failed with 3 nitpicky warnings (treated as errors) from the new `compute_default_chunk_shape` docstring added in #1440.
- Removed the redundant `, optional` annotations from the two parameter lines (defaults in the signature already convey optionality, and this is the only docstring in the codebase using that numpy-style annotation).
- Changed the Returns type from `tuple or True` to `tuple or bool` so the literal `True` is no longer parsed as a class ref. The `True` fallback is still documented in the surrounding description.

## Test plan
- [x] `sphinx-build -W -b linkcheck ./docs/source ./test_build` succeeds locally
- [x] CI `Check Sphinx links` job passes