### PR TITLE
Refactor spec_ext phase 1: add matched_spec slot to Builder

### DIFF
--- a/src/hdmf/build/builders.py
+++ b/src/hdmf/build/builders.py
@@ -28,6 +28,7 @@ class Builder(dict, metaclass=ABCMeta):
             self.__source = parent.source
         else:
             self.__source = None
+        self.__matched_spec = None
 
     @property
     def path(self):
@@ -67,6 +68,21 @@ class Builder(dict, metaclass=ABCMeta):
         self.__parent = p
         if self.__source is None:
             self.source = p.source
+
+    @property
+    def matched_spec(self):
+        """The subspec this builder was matched to, or None if unset.
+
+        Set by the matcher that pairs builders to subspecs (build and read paths).
+        Consumers should fall back to the type's def-site spec when this is None.
+        """
+        return self.__matched_spec
+
+    @matched_spec.setter
+    def matched_spec(self, spec):
+        if self.__matched_spec is not None:
+            raise AttributeError('Cannot overwrite matched_spec.')
+        self.__matched_spec = spec
 
     def __repr__(self):
         ret = "%s %s %s" % (self.path, self.__class__.__name__, super().__repr__())

--- a/tests/unit/build_tests/test_builder.py
+++ b/tests/unit/build_tests/test_builder.py
@@ -55,6 +55,34 @@ class TestGroupBuilder(TestCase):
         gb1.location = 'new location'
         self.assertEqual(gb1.location, 'new location')
 
+    def test_matched_spec_default_none(self):
+        gb = GroupBuilder('gb')
+        db = DatasetBuilder('db', list(range(3)))
+        lb = LinkBuilder(gb, 'lb')
+        self.assertIsNone(gb.matched_spec)
+        self.assertIsNone(db.matched_spec)
+        self.assertIsNone(lb.matched_spec)
+
+    def test_set_matched_spec(self):
+        gb = GroupBuilder('gb')
+        sentinel = object()
+        gb.matched_spec = sentinel
+        self.assertIs(gb.matched_spec, sentinel)
+
+    def test_overwrite_matched_spec_raises(self):
+        gb = GroupBuilder('gb')
+        gb.matched_spec = object()
+        with self.assertRaisesRegex(AttributeError, 'Cannot overwrite matched_spec.'):
+            gb.matched_spec = object()
+
+    def test_matched_spec_independent_per_builder(self):
+        gb1 = GroupBuilder('gb1')
+        gb2 = GroupBuilder('gb2')
+        spec1 = object()
+        gb1.matched_spec = spec1
+        self.assertIs(gb1.matched_spec, spec1)
+        self.assertIsNone(gb2.matched_spec)
+
 
 class TestGroupBuilderSetters(TestCase):
 


### PR DESCRIPTION
First phase of the resolved-specs-on-builders refactor. See epic issue #1448 for the full plan, design rationale, affected sites, risks, and downstream audits (pynwb, hdmf-zarr).

## Summary

Adds a write-once `matched_spec` property to the base `Builder` class (`src/hdmf/build/builders.py`). The slot defaults to `None`, accepts a one-time assignment, and raises `AttributeError` on overwrite, matching the existing `parent` and `source` setter discipline.

No callers are wired up yet. Subsequent phases (tracked in #1448):

- Phase 2: have `ObjectMapper.__get_subspec_values` set `sub_builder.matched_spec = subspec` after the match.
- Phase 3: migrate read consumers off the `spec_ext` kwarg and onto `builder.matched_spec`.
- Phase 4-5: same for the write path.
- Phase 6: drop `spec_ext` plumbing entirely.

This refactor supersedes the `spec_ext` plumbing introduced in #1313.

## Test plan

- [x] `pytest tests/unit/build_tests/test_builder.py` (4 new tests, all passing)
- [x] `pytest tests/unit/build_tests/` (no regressions)
- [x] CI green

## Notes for reviewers

Naming: `matched_spec` was chosen to pair with the existing `resolve_inc_spec` machinery in `src/hdmf/spec/spec.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
