### PR TITLE
Refactor spec_ext phase 3: parse isodatetime/datetime values on read via matched_spec

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -5,7 +5,6 @@ import warnings
 from collections import OrderedDict
 from copy import copy
 
-import h5py
 import numpy as np
 
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, BaseBuilder
@@ -24,7 +23,7 @@ from ..utils import _is_collection, _get_length, _unwrap_scalar
 from ..query import ReferenceResolver
 from ..spec import Spec, AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, RefSpec
 from ..spec.spec import BaseStorageSpec
-from ..utils import docval, getargs, ExtenderMeta, get_docval, get_data_shape, is_zarr_array, StrDataset
+from ..utils import docval, getargs, ExtenderMeta, get_docval, get_data_shape, is_array_like, is_zarr_array, StrDataset
 
 
 _const_arg = '__constructor_arg'
@@ -1396,7 +1395,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             elif isinstance(attr_val, ReferenceBuilder):
                 ret[attr_spec] = manager.construct(attr_val.builder)
             else:
-                ret[attr_spec] = self.__parse_datetime_on_read(attr_val, attr_spec)
+                ret[attr_spec] = self.__parse_if_datetime(attr_val, attr_spec)
         if isinstance(spec, GroupSpec):
             if not isinstance(builder, GroupBuilder):  # pragma: no cover
                 raise ValueError("__get_subspec_values - must pass GroupBuilder with GroupSpec")
@@ -1443,7 +1442,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # matched_spec is set by the parent matcher when this builder was paired to a subspec
             # position; fall back to spec for top-level / direct-construct callers that bypass it.
             data_spec = builder.matched_spec or spec
-            ret[spec] = self.__parse_datetime_on_read(self.__check_ref_resolver(builder.data), data_spec)
+            ret[spec] = self.__parse_if_datetime(self.__check_ref_resolver(builder.data), data_spec)
         return ret
 
     @staticmethod
@@ -1456,14 +1455,16 @@ class ObjectMapper(metaclass=ExtenderMeta):
         return data
 
     @staticmethod
-    def __parse_datetime_on_read(value, spec):
+    def __parse_if_datetime(value, spec):
         """For specs with isodatetime/datetime dtype, parse stored ISO str/bytes back to datetime/date.
 
-        Handles scalars, lists/tuples, numpy arrays, and h5py datasets (eagerly materialized).
-        Idempotent: values whose elements are already parsed (or whose container type is
-        unknown, e.g., a DataIO wrapper) pass through unchanged.
+        Returns ``value`` unchanged when ``spec`` is not an attribute or dataset spec, or when its
+        dtype is not isodatetime/datetime — so callers can invoke this unconditionally on every
+        attribute/dataset value without first inspecting the dtype.
 
-        TODO: implement lazy decoder for large datasets.
+        Handles scalars, lists/tuples, numpy arrays, h5py datasets, and zarr arrays (eagerly
+        materialized via the numpy array protocol). Idempotent: values whose elements are already
+        parsed (or whose container type is unknown, e.g., a DataIO wrapper) pass through unchanged.
         """
         if not isinstance(spec, (AttributeSpec, DatasetSpec)):
             return value
@@ -1473,9 +1474,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
             return _parse_isoformat(value)
         if isinstance(value, (list, tuple)):
             return type(value)(_parse_isoformat(v) for v in value)
-        if isinstance(value, np.ndarray) or isinstance(value, h5py.Dataset) or is_zarr_array(value):
+        if is_array_like(value):
             # Use the numpy array protocol so this works uniformly across numpy ndarrays,
             # h5py datasets, and zarr v2/v3 arrays without per-backend slicing.
+            # TODO: wrap the dataset to parse values on read instead of materializing the whole
+            # dataset in memory here. This becomes important for large isodatetime VectorData
+            # columns.
             materialized = np.asarray(value).tolist()
             if isinstance(materialized, list):
                 return [_parse_isoformat(v) for v in materialized]
@@ -1557,7 +1561,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # matched_spec is set by the parent matcher when this builder was paired to a subspec
             # position; fall back to self.spec for top-level / direct-construct callers that bypass it.
             data_spec = builder.matched_spec or self.spec
-            const_args['data'] = self.__parse_datetime_on_read(
+            const_args['data'] = self.__parse_if_datetime(
                 self.__check_ref_resolver(builder.data), data_spec
             )
         for subspec, value in subspecs.items():

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1,9 +1,11 @@
+import datetime
 import logging
 import re
 import warnings
 from collections import OrderedDict
 from copy import copy
 
+import h5py
 import numpy as np
 
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, BaseBuilder
@@ -92,6 +94,28 @@ def _ascii(s):
         return s
     else:
         raise ValueError("Expected unicode or ascii string, got %s" % type(s))
+
+
+def _parse_isoformat(value: str | bytes | datetime.datetime | datetime.date):
+    """Parse an ISO 8601 str/bytes back into a datetime or date.
+
+    Returns a datetime if the string carries a time component (contains 'T' or a space),
+    otherwise a date. Non-str/bytes inputs pass through unchanged so the helper is
+    idempotent when a value has already been parsed.
+
+    :param value: the value to parse. ASCII-encoded bytes are decoded first; str values are
+        parsed via ``datetime.fromisoformat`` or ``date.fromisoformat``; anything else
+        (e.g., a ``datetime``/``date`` already produced by an earlier call) is returned as-is.
+    :return: a ``datetime.datetime`` or ``datetime.date`` for parseable str/bytes input; the
+        unchanged ``value`` otherwise.
+    """
+    if isinstance(value, bytes):
+        value = value.decode('ascii')
+    if not isinstance(value, str):
+        return value
+    if 'T' in value or ' ' in value:
+        return datetime.datetime.fromisoformat(value)
+    return datetime.date.fromisoformat(value)
 
 
 class ObjectMapper(metaclass=ExtenderMeta):
@@ -1372,7 +1396,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             elif isinstance(attr_val, ReferenceBuilder):
                 ret[attr_spec] = manager.construct(attr_val.builder)
             else:
-                ret[attr_spec] = attr_val
+                ret[attr_spec] = self.__parse_datetime_on_read(attr_val, attr_spec)
         if isinstance(spec, GroupSpec):
             if not isinstance(builder, GroupBuilder):  # pragma: no cover
                 raise ValueError("__get_subspec_values - must pass GroupBuilder with GroupSpec")
@@ -1416,7 +1440,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     type(builder.data[0]) is not np.void):
                 # if a scalar dataset is expected and a 1-element non-compound dataset is given, then read the dataset
                 builder['data'] = builder.data[0]  # use dictionary reference instead of .data to bypass error
-            ret[spec] = self.__check_ref_resolver(builder.data)
+            # matched_spec is set by the parent matcher when this builder was paired to a subspec
+            # position; fall back to spec for top-level / direct-construct callers that bypass it.
+            data_spec = builder.matched_spec or spec
+            ret[spec] = self.__parse_datetime_on_read(self.__check_ref_resolver(builder.data), data_spec)
         return ret
 
     @staticmethod
@@ -1427,6 +1454,34 @@ class ObjectMapper(metaclass=ExtenderMeta):
         if isinstance(data, ReferenceResolver):
             return data.invert()
         return data
+
+    @staticmethod
+    def __parse_datetime_on_read(value, spec):
+        """For specs with isodatetime/datetime dtype, parse stored ISO str/bytes back to datetime/date.
+
+        Handles scalars, lists/tuples, numpy arrays, and h5py datasets (eagerly materialized).
+        Idempotent: values whose elements are already parsed (or whose container type is
+        unknown, e.g., a DataIO wrapper) pass through unchanged.
+
+        TODO: implement lazy decoder for large datasets.
+        """
+        if not isinstance(spec, (AttributeSpec, DatasetSpec)):
+            return value
+        if getattr(spec, 'dtype', None) not in ('isodatetime', 'datetime'):
+            return value
+        if isinstance(value, (str, bytes)):
+            return _parse_isoformat(value)
+        if isinstance(value, (list, tuple)):
+            return type(value)(_parse_isoformat(v) for v in value)
+        if isinstance(value, np.ndarray) or isinstance(value, h5py.Dataset) or is_zarr_array(value):
+            # Use the numpy array protocol so this works uniformly across numpy ndarrays,
+            # h5py datasets, and zarr v2/v3 arrays without per-backend slicing.
+            materialized = np.asarray(value).tolist()
+            if isinstance(materialized, list):
+                return [_parse_isoformat(v) for v in materialized]
+            # 0-d array: tolist() returns a Python scalar, not a list.
+            return _parse_isoformat(materialized)
+        return value
 
     def __get_sub_builders(self, sub_builders, subspecs, manager, ret):
         # index builders by data_type
@@ -1499,7 +1554,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
         if issubclass(cls, Data):
             if not isinstance(builder, DatasetBuilder):  # pragma: no cover
                 raise ValueError('Can only construct a Data object from a DatasetBuilder - got %s' % type(builder))
-            const_args['data'] = self.__check_ref_resolver(builder.data)
+            # matched_spec is set by the parent matcher when this builder was paired to a subspec
+            # position; fall back to self.spec for top-level / direct-construct callers that bypass it.
+            data_spec = builder.matched_spec or self.spec
+            const_args['data'] = self.__parse_datetime_on_read(
+                self.__check_ref_resolver(builder.data), data_spec
+            )
         for subspec, value in subspecs.items():
             const_arg = self.get_const_arg(subspec)
             if const_arg is not None:

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -26,6 +26,11 @@ except ImportError:
 def is_zarr_array(value):
     return ZARR_INSTALLED and isinstance(value, ZarrArray)
 
+
+def is_array_like(value):
+    """Return True if ``value`` is a numpy ndarray, h5py Dataset, or zarr Array."""
+    return isinstance(value, np.ndarray) or isinstance(value, h5py.Dataset) or is_zarr_array(value)
+
 if ZARR_INSTALLED:
     # optionally accept zarr.Array as array data to support conversion of data from Zarr to HDMF
     __macros['array_data'].append(ZarrArray)

--- a/tests/unit/build_tests/mapper_tests/test_read_datetime.py
+++ b/tests/unit/build_tests/mapper_tests/test_read_datetime.py
@@ -1,0 +1,322 @@
+"""Tests for read-path datetime parsing.
+
+When a builder's spec (or its matched_spec, which captures position-specific
+overrides like inc-site dtype) declares dtype='isodatetime' or dtype='datetime',
+the construct path parses stored ISO 8601 str/bytes back into Python
+datetime/date objects.
+"""
+
+from datetime import date, datetime, timezone
+
+import numpy as np
+
+from hdmf import Container, Data
+from hdmf.build import BuildManager, DatasetBuilder, GroupBuilder, ObjectMapper, TypeMap
+from hdmf.spec import (
+    AttributeSpec,
+    DatasetSpec,
+    GroupSpec,
+    NamespaceCatalog,
+    SpecCatalog,
+    SpecNamespace,
+)
+from hdmf.testing import TestCase
+from hdmf.utils import docval, getargs
+
+from tests.unit.helpers.utils import CORE_NAMESPACE
+
+
+class StampedThing(Data):
+
+    @property
+    def data_type(self):
+        return "StampedThing"
+
+
+class TimestampedRecord(Container):
+
+    @docval(
+        {"name": "name", "type": str, "doc": "name"},
+        {
+            "name": "created_at",
+            "type": (datetime, date, str),
+            "doc": "when",
+            "default": None,
+        },
+        {"name": "tag", "type": str, "doc": "a tag", "default": "t"},
+        {
+            "name": "stamped",
+            "type": StampedThing,
+            "doc": "a stamped child",
+            "default": None,
+        },
+    )
+    def __init__(self, **kwargs):
+        name, created_at, tag, stamped = getargs("name", "created_at", "tag", "stamped", kwargs)
+        super().__init__(name=name)
+        self.__created_at = created_at
+        self.__tag = tag
+        self.__stamped = stamped
+        if stamped is not None and stamped.parent is None:
+            stamped.parent = self
+
+    @property
+    def data_type(self):
+        return "TimestampedRecord"
+
+    @property
+    def created_at(self):
+        return self.__created_at
+
+    @property
+    def tag(self):
+        return self.__tag
+
+    @property
+    def stamped(self):
+        return self.__stamped
+
+
+_TYPE_TO_CLASS = {"TimestampedRecord": TimestampedRecord, "StampedThing": StampedThing}
+
+
+def _build_type_map(parent_spec, child_specs=()):
+    catalog = SpecCatalog()
+    catalog.register_spec(parent_spec, "test.yaml")
+    for s in child_specs:
+        catalog.register_spec(s, "test.yaml")
+    namespace = SpecNamespace(
+        "a test namespace",
+        CORE_NAMESPACE,
+        [{"source": "test.yaml"}],
+        version="0.1.0",
+        catalog=catalog,
+    )
+    namespace_catalog = NamespaceCatalog()
+    namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
+    namespace_catalog.resolve_all_specs()
+    type_map = TypeMap(namespace_catalog)
+    for s in [parent_spec] + list(child_specs):
+        dt = getattr(s, "data_type_def", None)
+        if dt is not None and dt in _TYPE_TO_CLASS:
+            type_map.register_container_type(CORE_NAMESPACE, dt, _TYPE_TO_CLASS[dt])
+    return type_map
+
+
+def _construct(parent_spec, child_specs, parent_builder):
+    type_map = _build_type_map(parent_spec, child_specs)
+    manager = BuildManager(type_map)
+    mapper = ObjectMapper(parent_spec)
+    return mapper.construct(parent_builder, manager)
+
+
+class TestReadAttributeDatetime(TestCase):
+
+    def test_attribute_isodatetime_with_time(self):
+        spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[
+                AttributeSpec("created_at", "when", "isodatetime"),
+                AttributeSpec("tag", "a tag", "text"),
+            ],
+        )
+        gb = GroupBuilder(
+            "r",
+            attributes={
+                "created_at": b"2024-03-15T12:30:00+00:00",
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(spec, [], gb)
+        self.assertEqual(record.created_at, datetime(2024, 3, 15, 12, 30, tzinfo=timezone.utc))
+
+    def test_attribute_isodatetime_date_only(self):
+        spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[
+                AttributeSpec("created_at", "when", "isodatetime"),
+                AttributeSpec("tag", "a tag", "text"),
+            ],
+        )
+        gb = GroupBuilder(
+            "r",
+            attributes={
+                "created_at": "2024-03-15",
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(spec, [], gb)
+        self.assertEqual(record.created_at, date(2024, 3, 15))
+
+    def test_attribute_non_datetime_dtype_unchanged(self):
+        spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[AttributeSpec("tag", "a tag", "text")],
+        )
+        gb = GroupBuilder(
+            "r",
+            attributes={
+                "tag": "2024-03-15",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(spec, [], gb)
+        self.assertEqual(record.tag, "2024-03-15")
+
+    def test_attribute_already_parsed_passes_through(self):
+        """A value that has already been parsed (a datetime object) must not raise."""
+        spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[
+                AttributeSpec("created_at", "when", "isodatetime"),
+                AttributeSpec("tag", "a tag", "text"),
+            ],
+        )
+        already = datetime(2024, 3, 15, 12, 30, tzinfo=timezone.utc)
+        gb = GroupBuilder(
+            "r",
+            attributes={
+                "created_at": already,
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(spec, [], gb)
+        self.assertEqual(record.created_at, already)
+
+
+class TestReadDatasetDatetime(TestCase):
+
+    def test_def_site_isodatetime_array(self):
+        """A typed Data subclass whose def-site declares dtype='isodatetime' parses on construct."""
+        child_def = DatasetSpec(
+            doc="stamped",
+            data_type_def="StampedThing",
+            dtype="isodatetime",
+            shape=(None,),
+        )
+        named_subspec = DatasetSpec(doc="stamped child", data_type_inc="StampedThing", name="stamped")
+        parent_spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[AttributeSpec("tag", "a tag", "text")],
+            datasets=[named_subspec],
+        )
+
+        child_db = DatasetBuilder(
+            "stamped",
+            np.array([b"2024-03-15T00:00:00+00:00", b"2024-04-01T12:00:00+00:00"]),
+            attributes={
+                "data_type": "StampedThing",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "sid",
+            },
+        )
+        gb = GroupBuilder(
+            "r",
+            datasets={"stamped": child_db},
+            attributes={
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(parent_spec, [child_def], gb)
+        self.assertEqual(
+            record.stamped.data,
+            [
+                datetime(2024, 3, 15, tzinfo=timezone.utc),
+                datetime(2024, 4, 1, 12, 0, tzinfo=timezone.utc),
+            ],
+        )
+
+    def test_inc_site_dtype_override(self):
+        """Child def has no dtype; parent's inc-site declares isodatetime.
+
+        The parent's matcher records the inc-site subspec on the child builder's
+        matched_spec, and the construct path honors that subspec's dtype on read.
+        """
+        child_def = DatasetSpec(doc="generic", data_type_def="StampedThing")
+        col_subspec = DatasetSpec(
+            doc="date column",
+            data_type_inc="StampedThing",
+            name="stamped",
+            dtype="isodatetime",
+        )
+        parent_spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[AttributeSpec("tag", "a tag", "text")],
+            datasets=[col_subspec],
+        )
+
+        child_db = DatasetBuilder(
+            "stamped",
+            ["2020-01-01", "2021-06-15"],
+            attributes={
+                "data_type": "StampedThing",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "sid",
+            },
+        )
+        gb = GroupBuilder(
+            "r",
+            datasets={"stamped": child_db},
+            attributes={
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(parent_spec, [child_def], gb)
+        self.assertEqual(record.stamped.data, [date(2020, 1, 1), date(2021, 6, 15)])
+
+    def test_non_datetime_dtype_unchanged(self):
+        """A typed dataset with an unrelated dtype is not mutated by the parser."""
+        child_def = DatasetSpec(doc="stamped", data_type_def="StampedThing", dtype="int", shape=(None,))
+        named_subspec = DatasetSpec(doc="child", data_type_inc="StampedThing", name="stamped")
+        parent_spec = GroupSpec(
+            doc="record",
+            data_type_def="TimestampedRecord",
+            attributes=[AttributeSpec("tag", "a tag", "text")],
+            datasets=[named_subspec],
+        )
+
+        ints = [1, 2, 3]
+        child_db = DatasetBuilder(
+            "stamped",
+            ints,
+            attributes={
+                "data_type": "StampedThing",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "sid",
+            },
+        )
+        gb = GroupBuilder(
+            "r",
+            datasets={"stamped": child_db},
+            attributes={
+                "tag": "t",
+                "data_type": "TimestampedRecord",
+                "namespace": CORE_NAMESPACE,
+                "object_id": "rid",
+            },
+        )
+        record = _construct(parent_spec, [child_def], gb)
+        self.assertEqual(list(record.stamped.data), ints)


### PR DESCRIPTION
Stacked on #1449 (Phase 2). Part of epic #1448.

This PR is the first read-time consumer of `builder.matched_spec`. It implements the inc-site dtype parsing case that motivated the epic, without introducing the `spec_ext` kwarg from #1313.

> Note: assumes #1313 is **not** merged. If #1313 lands first, Phase 3 becomes a migration (replace `spec_ext` reads with `matched_spec` reads, then drop the kwarg) instead of a greenfield consumer.

## Summary

- New module helper `_parse_isoformat(s)`: parses an ISO 8601 str/bytes into `datetime` (when a time component is present) or `date` (date-only). Idempotent for already-parsed values.
- New `ObjectMapper.__parse_datetime_on_read(value, spec)` static method: returns `value` unchanged unless the spec declares `dtype='isodatetime'` or `dtype='datetime'`. Handles scalars, lists, tuples, numpy arrays, h5py datasets, and zarr arrays via the numpy array protocol (`np.asarray(value).tolist()` covers v2 and v3, plus 0-d).
- Wired into three sites in `objectmapper.py`:
  - Attribute reads in `__get_subspec_values` (attribute specs are already position-resolved).
  - The inline DatasetSpec branch in `__get_subspec_values`, using `builder.matched_spec or spec`.
  - `ObjectMapper.construct` for `Data` containers, using `builder.matched_spec or self.spec`.

## What this delivers vs #1313

The motivating DynamicTable-column case (`SubjectsTable.date_of_birth: VectorData(dtype=isodatetime)`) now reads back as `date`/`datetime` values without any `spec_ext` plumbing. The position override flows through Phase 2's matcher writing `matched_spec`, then Phase 3's consumer honors it.

The orthogonal pieces of #1313 not covered here:
- `_isoformat` write helper (the write path already handles datetime → ISO via `__convert_string`, but Phase 5 will deduplicate that with the existing `__check_dset_spec` merge logic).
- `scalar_data` macro widening for datetime/date scalars in `get_class`-generated classes (independent of spec_ext; can ship as a small standalone PR).

## Test plan

- [x] `pytest tests/unit/build_tests/mapper_tests/test_read_datetime.py` (7 new tests, all passing): attribute datetime, attribute date-only, attribute non-datetime untouched, attribute already-parsed idempotent, def-site dtype on typed Data subclass, **inc-site dtype override** (the motivating case), and non-datetime dtype untouched.
- [x] `pytest tests/unit/` (1859 passed, no regressions)
- [x] CI green

## Notes for reviewers

- The base of this PR is `refactor/resolved-spec-read-matcher` (Phase 2). After #1447 and #1449 land, GitHub will rebase this onto `dev`.
- TODO comment on `__parse_datetime_on_read`: implement a lazy decoder for large datasets (currently eagerly materializes). Filed as a follow-up under "Out of scope" in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
