### PR TITLE
Refactor spec_ext phase 5: route write-time override via builder.resolved_spec

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -797,6 +797,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                               % (container.__class__.__name__, container.name, repr(source)))
             if builder is None:
                 builder = GroupBuilder(name, parent=parent, source=source)
+            if spec_ext is not None:
+                self.__set_resolved_spec(builder, spec_ext)
             self.__add_datasets(builder, self.__spec.datasets, container, manager, source)
             self.__add_groups(builder, self.__spec.groups, container, manager, source)
             self.__add_links(builder, self.__spec.links, container, manager, source)
@@ -805,6 +807,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 if not isinstance(container, Data):
                     msg = "'container' must be of type Data with DatasetSpec"
                     raise ValueError(msg)
+                # Position override info has to be consumed before the dataset builder is created.
+                # After creation, downstream code reads the override from builder.resolved_spec instead.
                 spec_dtype, spec_shape, spec_dims, spec = self.__check_dset_spec(self.spec, spec_ext)
                 dimension_labels, matched_shape = self.__get_spec_info(
                     container.data, spec_shape, spec_dims, spec_dtype
@@ -882,14 +886,20 @@ class ObjectMapper(metaclass=ExtenderMeta):
                             matched_spec_shape=matched_shape,
                             dimension_labels=dimension_labels,
                         )
+                if spec_ext is not None:
+                    self.__set_resolved_spec(builder, spec_ext)
 
-        # Add attributes from the specification extension to the list of attributes
-        all_attrs = self.__spec.attributes + getattr(spec_ext, 'attributes', tuple())
-        # If the spec_ext refines an existing attribute it will now appear twice in the list. The
+        # Add attributes from the specification extension to the list of attributes.
+        # The resolved spec on the builder carries the same refinement info as the original spec_ext.
+        if builder.resolved_spec is not None:
+            ext_attrs = getattr(builder.resolved_spec, 'attributes', tuple())
+        else:
+            ext_attrs = tuple()
+        all_attrs = self.__spec.attributes + ext_attrs
+        # If the resolved_spec refines an existing attribute it will now appear twice in the list. The
         # refinement should only be relevant for validation (not for write). To avoid problems with the
         # write we here remove duplicates and keep the original spec of the two to make write work.
         # TODO: We should add validation in the AttributeSpec to make sure refinements are valid
-        # TODO: Check the BuildManager as refinements should probably be resolved rather than be passed in via spec_ext
         all_attrs = list({a.name: a for a in all_attrs[::-1]}.values())
         self.__add_attributes(builder, all_attrs, container, manager)
         return builder
@@ -1348,13 +1358,11 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     self.logger.debug("    Adding dataset %s '%s' to %s '%s'"
                                       % (new_builder.__class__.__name__, new_builder.name,
                                          builder.__class__.__name__, builder.name))
-                    self.__set_resolved_spec(new_builder, spec)
                     builder.set_dataset(new_builder)
                 else:
                     self.logger.debug("    Adding subgroup %s '%s' to %s '%s'"
                                       % (new_builder.__class__.__name__, new_builder.name,
                                          builder.__class__.__name__, builder.name))
-                    self.__set_resolved_spec(new_builder, spec)
                     builder.set_group(new_builder)
             elif value.container_source:  # make a link to an existing container
                 if (value.container_source != parent_container.container_source

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1277,6 +1277,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                         dimension_labels=dimension_labels
                     )
                     builder.set_dataset(sub_builder)
+                self.__set_resolved_spec(sub_builder, spec)
                 self.__add_attributes(sub_builder, spec.attributes, container, build_manager)
             else:
                 self.logger.debug("        Adding typed dataset for spec name: %s, %s: %s, %s: %s"
@@ -1297,6 +1298,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 sub_builder = builder.groups.get(spec.name)
                 if sub_builder is None:
                     sub_builder = GroupBuilder(spec.name, source=source)
+                self.__set_resolved_spec(sub_builder, spec)
                 self.__add_attributes(sub_builder, spec.attributes, container, build_manager)
                 self.__add_datasets(sub_builder, spec.datasets, container, build_manager, source)
                 self.__add_links(sub_builder, spec.links, container, build_manager, source)
@@ -1346,11 +1348,13 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     self.logger.debug("    Adding dataset %s '%s' to %s '%s'"
                                       % (new_builder.__class__.__name__, new_builder.name,
                                          builder.__class__.__name__, builder.name))
+                    self.__set_resolved_spec(new_builder, spec)
                     builder.set_dataset(new_builder)
                 else:
                     self.logger.debug("    Adding subgroup %s '%s' to %s '%s'"
                                       % (new_builder.__class__.__name__, new_builder.name,
                                          builder.__class__.__name__, builder.name))
+                    self.__set_resolved_spec(new_builder, spec)
                     builder.set_group(new_builder)
             elif value.container_source:  # make a link to an existing container
                 if (value.container_source != parent_container.container_source

--- a/tests/unit/build_tests/mapper_tests/test_resolved_spec_write.py
+++ b/tests/unit/build_tests/mapper_tests/test_resolved_spec_write.py
@@ -1,0 +1,192 @@
+"""Tests for resolved_spec wiring in ObjectMapper build (write) path.
+
+When the build path creates a sub-builder for a position in the parent's spec
+tree (a typed dataset, a typed group, or an untyped named dataset/group), it
+records that subspec on the sub-builder via builder.resolved_spec. Build-time
+consumers read this slot to honor inc-site overrides without re-deriving the
+position pairing.
+"""
+
+from hdmf import Container, Data
+from hdmf.build import BuildManager, TypeMap
+from hdmf.spec import (AttributeSpec, DatasetSpec, GroupSpec, NamespaceCatalog, SpecCatalog,
+                       SpecNamespace)
+from hdmf.testing import TestCase
+from hdmf.utils import docval, getargs
+
+from tests.unit.helpers.utils import CORE_NAMESPACE
+
+
+class Child(Data):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'name'},
+            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'data'})
+    def __init__(self, **kwargs):
+        name, data = getargs('name', 'data', kwargs)
+        super().__init__(name=name, data=data)
+
+    @property
+    def data_type(self):
+        return 'Child'
+
+
+class ChildGroup(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'name'})
+    def __init__(self, **kwargs):
+        name = getargs('name', kwargs)
+        super().__init__(name=name)
+
+    @property
+    def data_type(self):
+        return 'ChildGroup'
+
+
+class Parent(Container):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'name'},
+            {'name': 'attr1', 'type': str, 'doc': 'an attribute', 'default': 'v'},
+            {'name': 'named_child', 'type': Child, 'doc': 'a typed dataset child', 'default': None},
+            {'name': 'group_child', 'type': ChildGroup, 'doc': 'a typed group child', 'default': None},
+            {'name': 'inline_data', 'type': ('array_data', 'data'), 'doc': 'untyped dataset',
+             'default': None})
+    def __init__(self, **kwargs):
+        name, attr1, named_child, group_child, inline_data = getargs(
+            'name', 'attr1', 'named_child', 'group_child', 'inline_data', kwargs)
+        super().__init__(name=name)
+        self.__attr1 = attr1
+        self.__named_child = named_child
+        self.__group_child = group_child
+        self.__inline_data = inline_data
+        for c in (named_child, group_child):
+            if c is not None and c.parent is None:
+                c.parent = self
+
+    @property
+    def data_type(self):
+        return 'Parent'
+
+    @property
+    def attr1(self):
+        return self.__attr1
+
+    @property
+    def named_child(self):
+        return self.__named_child
+
+    @property
+    def group_child(self):
+        return self.__group_child
+
+    @property
+    def inline_data(self):
+        return self.__inline_data
+
+
+_TYPE_TO_CLASS = {'Parent': Parent, 'Child': Child, 'ChildGroup': ChildGroup}
+
+
+def _build_type_map(parent_spec, child_specs=()):
+    catalog = SpecCatalog()
+    catalog.register_spec(parent_spec, 'test.yaml')
+    for s in child_specs:
+        catalog.register_spec(s, 'test.yaml')
+    namespace = SpecNamespace('a test namespace', CORE_NAMESPACE,
+                              [{'source': 'test.yaml'}], version='0.1.0', catalog=catalog)
+    namespace_catalog = NamespaceCatalog()
+    namespace_catalog.add_namespace(CORE_NAMESPACE, namespace)
+    namespace_catalog.resolve_all_specs()
+    type_map = TypeMap(namespace_catalog)
+    for s in [parent_spec] + list(child_specs):
+        dt = getattr(s, 'data_type_def', None)
+        if dt is not None and dt in _TYPE_TO_CLASS:
+            type_map.register_container_type(CORE_NAMESPACE, dt, _TYPE_TO_CLASS[dt])
+    return type_map
+
+
+class TestResolvedSpecOnWrite(TestCase):
+
+    def _make_parent_spec(self, datasets=(), groups=(), links=()):
+        return GroupSpec(
+            doc='parent', data_type_def='Parent',
+            attributes=[AttributeSpec('attr1', 'a', 'text')],
+            datasets=list(datasets), groups=list(groups), links=list(links),
+        )
+
+    def _build(self, parent_spec, child_specs, container):
+        type_map = _build_type_map(parent_spec, child_specs)
+        manager = BuildManager(type_map)
+        return manager.build(container), manager
+
+    def test_typed_dataset_child(self):
+        """A typed DatasetSpec child gets resolved_spec set to its parent's subspec."""
+        child_def = DatasetSpec(doc='child', data_type_def='Child', dtype='int', shape=(None,))
+        named_subspec = DatasetSpec(doc='named child', data_type_inc='Child', name='named_child')
+        parent_spec = self._make_parent_spec(datasets=[named_subspec])
+
+        c = Child('named_child', [1, 2, 3])
+        p = Parent('p', named_child=c)
+
+        builder, _ = self._build(parent_spec, [child_def], p)
+        child_builder = builder.datasets['named_child']
+        self.assertIs(child_builder.resolved_spec, named_subspec)
+
+    def test_typed_group_child(self):
+        """A typed GroupSpec child gets resolved_spec set to its parent's subspec."""
+        child_def = GroupSpec(doc='child group', data_type_def='ChildGroup')
+        group_subspec = GroupSpec(doc='gc', data_type_inc='ChildGroup', name='group_child')
+        parent_spec = self._make_parent_spec(groups=[group_subspec])
+
+        gc = ChildGroup('group_child')
+        p = Parent('p', group_child=gc)
+
+        builder, _ = self._build(parent_spec, [child_def], p)
+        gc_builder = builder.groups['group_child']
+        self.assertIs(gc_builder.resolved_spec, group_subspec)
+
+    def test_untyped_named_dataset(self):
+        """An untyped, named dataset gets resolved_spec set to its position subspec."""
+        inline_subspec = DatasetSpec(doc='inline data', name='inline_data',
+                                     dtype='int', shape=(None,))
+        parent_spec = self._make_parent_spec(datasets=[inline_subspec])
+
+        p = Parent('p', inline_data=[1, 2, 3])
+
+        builder, _ = self._build(parent_spec, [], p)
+        ds_builder = builder.datasets['inline_data']
+        self.assertIs(ds_builder.resolved_spec, inline_subspec)
+
+    def test_untyped_named_group(self):
+        """An untyped, named *required* group gets resolved_spec set to its position subspec.
+
+        The build path skips empty optional named groups, so a required group with no
+        sub-elements is the minimal way to exercise this branch.
+        """
+        # Default quantity=1 makes this required; required=False would let the build path skip it.
+        nested_subspec = GroupSpec(doc='nested', name='nested')
+        parent_spec = self._make_parent_spec(groups=[nested_subspec])
+
+        p = Parent('p', attr1='v')
+
+        builder, _ = self._build(parent_spec, [], p)
+        nested_builder = builder.groups['nested']
+        self.assertIs(nested_builder.resolved_spec, nested_subspec)
+
+    def test_dynamic_table_column_dtype_override(self):
+        """Inc-site dtype override (DynamicTable column case) on the build side.
+
+        The parent's subspec carries the override (dtype=isodatetime), and the column
+        builder produced by the build path records that subspec on resolved_spec.
+        """
+        col_def = DatasetSpec(doc='generic column', data_type_def='Child')
+        col_subspec = DatasetSpec(doc='date column', data_type_inc='Child',
+                                  name='named_child', dtype='isodatetime')
+        parent_spec = self._make_parent_spec(datasets=[col_subspec])
+
+        c = Child('named_child', ['2020-01-01', '2021-06-15'])
+        p = Parent('p', named_child=c)
+
+        builder, _ = self._build(parent_spec, [col_def], p)
+        child_builder = builder.datasets['named_child']
+        self.assertIs(child_builder.resolved_spec, col_subspec)
+        self.assertEqual(child_builder.resolved_spec.dtype, 'isodatetime')


### PR DESCRIPTION
Stacked on #1451. Part of epic #1448.

## Summary

`ObjectMapper.build` now sets `builder.resolved_spec = spec_ext` as soon as the builder exists, and post-creation consumers read the override from the builder rather than the kwarg.

* **Group branch**: `resolved_spec` is set immediately after the builder is created (or used, when passed in).
* **Data branch**: `resolved_spec` is set after each of the three sub-paths (RefSpec, compound, regular dtype) has created the dataset builder.
* **Extra-attribute lookup** (line ~889): reads from `builder.resolved_spec` instead of `spec_ext`. The two carry the same value here, so behavior is unchanged.
* **`__add_containers`**: the redundant `__set_resolved_spec(new_builder, spec)` calls added in #1451 are removed. The inner `ObjectMapper.build` now sets the slot before returning.

## What this PR does *not* do

The epic originally framed Phase 5 as "drop the `spec_ext` kwarg." Looking at the code, that's not cleanly possible without further restructuring:

The Data branch needs the override info to compute `dtype` / `shape` / `dims` *before* the dataset builder is created (`__check_dset_spec` runs at the top of the branch, well before the builder exists). So the override has to flow in via a kwarg of some kind. After this PR, the kwarg stays, but its only role is feeding the pre-creation merge. Everything *after* builder creation reads `builder.resolved_spec`.

A future restructure could drop the kwarg by either (a) moving the dtype-merge step out of `ObjectMapper.build` so the caller pre-creates the builder, or (b) splitting `ObjectMapper.build` into a "compute build params" + "do the build" pair. Both are larger refactors than this phase warrants. I'll add a follow-up note to the epic if you want.

## Test plan

- [x] `pytest tests/unit/` (1864 passed, no regressions). The Phase 4 tests already lock in the contract that build-path-produced builders have `resolved_spec` set; this PR migrates *where* the set happens without changing observable behavior, so those tests continue to pass.
- [ ] CI green

## Notes for reviewers

- The base of this PR is `refactor/resolved-spec-write-matcher` (Phase 4). After #1447, #1449, #1450, and #1451 land, GitHub will rebase this onto `dev`.
- I removed an outdated TODO ("Check the BuildManager as refinements should probably be resolved rather than be passed in via spec_ext"). The remaining attribute-merge TODO about validation stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)