### PR TITLE
Fix building typed datasets with dtype isodatetime/datetime

### DIFF
--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -96,7 +96,12 @@ def _ascii(s):
 
 
 def _isoformat(s):
-    """Convert datetime/date/str to ASCII-encoded ISO 8601 bytes; pass through bytes unchanged."""
+    """Convert datetime/date/str to ASCII-encoded ISO 8601 bytes; pass through bytes unchanged.
+
+    Strings are encoded with strict ASCII (no error handler) since ISO 8601 values are
+    always ASCII. Non-ASCII input raises UnicodeEncodeError, in contrast to ``_ascii`` which
+    uses ``'backslashreplace'`` to preserve general string content.
+    """
     if isinstance(s, (datetime.datetime, datetime.date)):
         return s.isoformat().encode('ascii')
     if isinstance(s, str):

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -95,6 +95,17 @@ def _ascii(s):
         raise ValueError("Expected unicode or ascii string, got %s" % type(s))
 
 
+def _isoformat(s):
+    """Convert datetime/date/str to ASCII-encoded ISO 8601 bytes; pass through bytes unchanged."""
+    if isinstance(s, (datetime.datetime, datetime.date)):
+        return s.isoformat().encode('ascii')
+    if isinstance(s, str):
+        return s.encode('ascii')
+    if isinstance(s, bytes):
+        return s
+    raise ValueError("Expected datetime, date, str, or bytes, got %s" % type(s))
+
+
 def _parse_isoformat(value: str | bytes | datetime.datetime | datetime.date):
     """Parse an ISO 8601 str/bytes back into a datetime or date.
 
@@ -150,8 +161,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
         "utf-8": _unicode,
         "ascii": _ascii,
         "bytes": _ascii,
-        "isodatetime": _ascii,
-        "datetime": _ascii,
+        "isodatetime": _isoformat,
+        "datetime": _isoformat,
     }
 
     __no_convert = set()
@@ -251,7 +262,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 # Zarr stores strings as objects, so we cannot convert to unicode dtype
                 ret = value
                 ret_dtype = "utf8"
-            elif spec_dtype_type is _ascii:
+            elif spec_dtype_type in (_ascii, _isoformat):
                 # Zarr stores strings as objects, so we cannot convert to ascii dtype
                 ret = value
                 ret_dtype = "ascii"
@@ -269,7 +280,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 else:
                     ret = value.astype('U')
                 ret_dtype = "utf8"
-            elif spec_dtype_type is _ascii:
+            elif spec_dtype_type in (_ascii, _isoformat):
+                # numpy.astype('S') on an object array of datetime/date produces ISO-formatted ASCII bytes
                 ret = value.astype('S')
                 ret_dtype = "ascii"
             else:
@@ -284,7 +296,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             if len(value) == 0:
                 if spec_dtype_type is _unicode:
                     ret_dtype = 'utf8'
-                elif spec_dtype_type is _ascii:
+                elif spec_dtype_type in (_ascii, _isoformat):
                     ret_dtype = 'ascii'
                 else:
                     ret_dtype = spec_dtype_type
@@ -300,12 +312,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
             ret = value
             if spec_dtype_type is _unicode:
                 ret_dtype = "utf8"
-            elif spec_dtype_type is _ascii:
+            elif spec_dtype_type in (_ascii, _isoformat):
                 ret_dtype = "ascii"
             else:
                 ret_dtype, warning_msg = cls.__resolve_numeric_dtype(value.dtype, spec_dtype_type)
         else:
-            if spec_dtype_type in (_unicode, _ascii):
+            if spec_dtype_type in (_unicode, _ascii, _isoformat):
                 ret_dtype = 'ascii'
                 if spec_dtype_type is _unicode:
                     ret_dtype = 'utf8'

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -280,8 +280,17 @@ class ObjectMapper(metaclass=ExtenderMeta):
                 else:
                     ret = value.astype('U')
                 ret_dtype = "utf8"
-            elif spec_dtype_type in (_ascii, _isoformat):
-                # numpy.astype('S') on an object array of datetime/date produces ISO-formatted ASCII bytes
+            elif spec_dtype_type is _isoformat:
+                if value.dtype.kind == 'O':
+                    # Apply _isoformat elementwise so datetime/date objects use the ISO 8601
+                    # 'T' separator. numpy's astype('S') would fall back to str(dt), which
+                    # produces a space-separated form.
+                    flat = np.array([_isoformat(v) for v in value.ravel()], dtype='S')
+                    ret = flat.reshape(value.shape)
+                else:
+                    ret = value.astype('S')
+                ret_dtype = "ascii"
+            elif spec_dtype_type is _ascii:
                 ret = value.astype('S')
                 ret_dtype = "ascii"
             else:
@@ -713,6 +722,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     string_type = bytes
                 elif 'isodatetime' in spec.dtype:
                     def string_type(x):
+                        if isinstance(x, (str, bytes)):
+                            return x  # already an ISO 8601 string, pass through
                         return x.isoformat()  # method works for both date and datetime
                 if string_type is not None:
                     if spec.shape is not None or spec.dims is not None:

--- a/tests/unit/build_tests/mapper_tests/test_build_datetime.py
+++ b/tests/unit/build_tests/mapper_tests/test_build_datetime.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from hdmf.utils import docval, getargs
 from hdmf import Container, Data
 from hdmf.spec import GroupSpec, DatasetSpec
@@ -28,60 +30,58 @@ class Bar(Container):
 class TestBuildDatasetDateTime(TestCase):
     """Test that building a dataset with dtype isodatetime works with datetime and date objects."""
 
-    def test_datetime_scalar(self):
+    def _build(self, data, spec_dims=None):
+        dataset_kwargs = dict(doc='an example dataset', name='data', dtype='isodatetime')
+        if spec_dims is not None:
+            dataset_kwargs['dims'] = spec_dims
         bar_spec = GroupSpec(
             doc='A test group specification with a data type',
             data_type_def='Bar',
-            datasets=[DatasetSpec(doc='an example dataset', name='data', dtype='isodatetime')],
+            datasets=[DatasetSpec(**dataset_kwargs)],
         )
         type_map = create_test_type_map([bar_spec], {'Bar': Bar})
+        return type_map.build(Bar(name='my_bar', data=data)).get('data')
 
-        bar_inst = Bar(name='my_bar', data=datetime(2023, 7, 9))
-        builder = type_map.build(bar_inst)
-        ret = builder.get('data')
+    def test_datetime_scalar(self):
+        ret = self._build(datetime(2023, 7, 9))
         assert ret.data == b'2023-07-09T00:00:00'
         assert ret.dtype == 'ascii'
 
     def test_date_scalar(self):
-        bar_spec = GroupSpec(
-            doc='A test group specification with a data type',
-            data_type_def='Bar',
-            datasets=[DatasetSpec(doc='an example dataset', name='data', dtype='isodatetime')],
-        )
-        type_map = create_test_type_map([bar_spec], {'Bar': Bar})
-
-        bar_inst = Bar(name='my_bar', data=date(2023, 7, 9))
-        builder = type_map.build(bar_inst)
-        ret = builder.get('data')
+        ret = self._build(date(2023, 7, 9))
         assert ret.data == b'2023-07-09'
         assert ret.dtype == 'ascii'
 
     def test_datetime_array(self):
-        bar_spec = GroupSpec(
-            doc='A test group specification with a data type',
-            data_type_def='Bar',
-            datasets=[DatasetSpec(doc='an example dataset', name='data', dtype='isodatetime', dims=(None,))],
-        )
-        type_map = create_test_type_map([bar_spec], {'Bar': Bar})
-
-        bar_inst = Bar(name='my_bar', data=[datetime(2023, 7, 9), datetime(2023, 7, 10)])
-        builder = type_map.build(bar_inst)
-        ret = builder.get('data')
+        ret = self._build([datetime(2023, 7, 9), datetime(2023, 7, 10)], spec_dims=(None,))
         assert ret.data == [b'2023-07-09T00:00:00', b'2023-07-10T00:00:00']
         assert ret.dtype == 'ascii'
 
     def test_date_array(self):
-        bar_spec = GroupSpec(
-            doc='A test group specification with a data type',
-            data_type_def='Bar',
-            datasets=[DatasetSpec(doc='an example dataset', name='data', dtype='isodatetime', dims=(None,))],
-        )
-        type_map = create_test_type_map([bar_spec], {'Bar': Bar})
-
-        bar_inst = Bar(name='my_bar', data=[date(2023, 7, 9), date(2023, 7, 10)])
-        builder = type_map.build(bar_inst)
-        ret = builder.get('data')
+        ret = self._build([date(2023, 7, 9), date(2023, 7, 10)], spec_dims=(None,))
         assert ret.data == [b'2023-07-09', b'2023-07-10']
+        assert ret.dtype == 'ascii'
+
+    def test_datetime_object_ndarray(self):
+        """An ndarray(dtype=object) of datetimes must serialize with the ISO 8601 'T' separator,
+        not the space form that numpy.astype('S') would produce via str(datetime).
+        """
+        arr = np.array([datetime(2023, 7, 9), datetime(2023, 7, 10)], dtype=object)
+        ret = self._build(arr, spec_dims=(None,))
+        assert list(ret.data) == [b'2023-07-09T00:00:00', b'2023-07-10T00:00:00']
+        assert ret.dtype == 'ascii'
+
+    def test_date_object_ndarray(self):
+        arr = np.array([date(2023, 7, 9), date(2023, 7, 10)], dtype=object)
+        ret = self._build(arr, spec_dims=(None,))
+        assert list(ret.data) == [b'2023-07-09', b'2023-07-10']
+        assert ret.dtype == 'ascii'
+
+    def test_string_ndarray(self):
+        """An ndarray of pre-formatted ISO strings should pass through astype('S') unchanged."""
+        arr = np.array(['2023-07-09T00:00:00', '2023-07-10T00:00:00'])
+        ret = self._build(arr, spec_dims=(None,))
+        assert list(ret.data) == [b'2023-07-09T00:00:00', b'2023-07-10T00:00:00']
         assert ret.dtype == 'ascii'
 
 
@@ -168,4 +168,38 @@ class TestBuildTypedDatasetDatetime(TestCase):
         builder = self._build(holder, dtype="datetime")
         col_builder = builder.datasets["date_of_birth"]
         assert col_builder.data == [b"2023-07-09T00:00:00"]
+        assert col_builder.dtype == "ascii"
+
+    def test_typed_datetime_object_ndarray(self):
+        """An ndarray(dtype=object) of datetimes through the typed path must serialize with the
+        ISO 8601 'T' separator. The typed path skips __convert_string, so this exercises the
+        convert_dtype ndarray-of-objects branch directly.
+        """
+        arr = np.array([datetime(2023, 7, 9), datetime(2023, 7, 10)], dtype=object)
+        col = StampedColumn(name="date_of_birth", data=arr)
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="isodatetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert list(col_builder.data) == [b"2023-07-09T00:00:00", b"2023-07-10T00:00:00"]
+        assert col_builder.dtype == "ascii"
+
+    def test_typed_date_object_ndarray(self):
+        arr = np.array([date(2023, 7, 9), date(2023, 7, 10)], dtype=object)
+        col = StampedColumn(name="date_of_birth", data=arr)
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="isodatetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert list(col_builder.data) == [b"2023-07-09", b"2023-07-10"]
+        assert col_builder.dtype == "ascii"
+
+    def test_typed_string_ndarray(self):
+        """An ndarray of pre-formatted ISO strings through the typed path takes the non-object
+        branch (value.astype('S')) in convert_dtype.
+        """
+        arr = np.array(["2023-07-09T00:00:00", "2023-07-10T00:00:00"])
+        col = StampedColumn(name="date_of_birth", data=arr)
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="isodatetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert list(col_builder.data) == [b"2023-07-09T00:00:00", b"2023-07-10T00:00:00"]
         assert col_builder.dtype == "ascii"

--- a/tests/unit/build_tests/mapper_tests/test_build_datetime.py
+++ b/tests/unit/build_tests/mapper_tests/test_build_datetime.py
@@ -1,5 +1,5 @@
 from hdmf.utils import docval, getargs
-from hdmf import Container
+from hdmf import Container, Data
 from hdmf.spec import GroupSpec, DatasetSpec
 from hdmf.testing import TestCase
 from datetime import datetime, date
@@ -83,3 +83,89 @@ class TestBuildDatasetDateTime(TestCase):
         ret = builder.get('data')
         assert ret.data == [b'2023-07-09', b'2023-07-10']
         assert ret.dtype == 'ascii'
+
+
+class StampedColumn(Data):
+    """A typed Data subclass with no fixed dtype, like VectorData."""
+
+    @docval(
+        {"name": "name", "type": str, "doc": "name"},
+        {"name": "data", "type": ("array_data", "data", datetime, date), "doc": "data"},
+    )
+    def __init__(self, **kwargs):
+        name, data = getargs("name", "data", kwargs)
+        super().__init__(name=name, data=data)
+
+    @property
+    def data_type(self):
+        return "StampedColumn"
+
+
+class StampedHolder(Container):
+
+    @docval(
+        {"name": "name", "type": str, "doc": "name"},
+        {"name": "date_of_birth", "type": StampedColumn, "doc": "a typed column"},
+    )
+    def __init__(self, **kwargs):
+        name, date_of_birth = getargs("name", "date_of_birth", kwargs)
+        super().__init__(name=name)
+        self.__date_of_birth = date_of_birth
+        if date_of_birth.parent is None:
+            date_of_birth.parent = self
+
+    @property
+    def data_type(self):
+        return "StampedHolder"
+
+    @property
+    def date_of_birth(self):
+        return self.__date_of_birth
+
+
+class TestBuildTypedDatasetDatetime(TestCase):
+    """Regression test for #1311.
+
+    A typed dataset (data_type_inc=StampedColumn) whose def-site has no dtype, with the
+    inc-site declaring dtype='isodatetime', must accept datetime/date values on build.
+    Before this fix, `convert_dtype` failed on raw datetime objects because the typed
+    branch (via `__add_containers` -> `build_manager.build`) skips `__convert_string`
+    preprocessing.
+    """
+
+    def _build(self, holder, dtype):
+        col_def = DatasetSpec(doc="a column", data_type_def="StampedColumn")
+        col_subspec = DatasetSpec(
+            doc="date column", data_type_inc="StampedColumn", name="date_of_birth", dtype=dtype, dims=(None,)
+        )
+        holder_spec = GroupSpec(doc="a holder", data_type_def="StampedHolder", datasets=[col_subspec])
+        type_map = create_test_type_map(
+            [col_def, holder_spec],
+            {"StampedColumn": StampedColumn, "StampedHolder": StampedHolder},
+        )
+        return type_map.build(holder)
+
+    def test_typed_isodatetime_array(self):
+        col = StampedColumn(name="date_of_birth", data=[datetime(2023, 7, 9), datetime(2023, 7, 10)])
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="isodatetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert col_builder.data == [b"2023-07-09T00:00:00", b"2023-07-10T00:00:00"]
+        assert col_builder.dtype == "ascii"
+
+    def test_typed_isodatetime_date_array(self):
+        col = StampedColumn(name="date_of_birth", data=[date(2023, 7, 9), date(2023, 7, 10)])
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="isodatetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert col_builder.data == [b"2023-07-09", b"2023-07-10"]
+        assert col_builder.dtype == "ascii"
+
+    def test_typed_datetime_alias(self):
+        """The 'datetime' dtype alias maps to the same converter as 'isodatetime'."""
+        col = StampedColumn(name="date_of_birth", data=[datetime(2023, 7, 9)])
+        holder = StampedHolder(name="holder", date_of_birth=col)
+        builder = self._build(holder, dtype="datetime")
+        col_builder = builder.datasets["date_of_birth"]
+        assert col_builder.data == [b"2023-07-09T00:00:00"]
+        assert col_builder.dtype == "ascii"

--- a/tests/unit/build_tests/test_convert_dtype.py
+++ b/tests/unit/build_tests/test_convert_dtype.py
@@ -548,6 +548,72 @@ class TestConvertDtype(TestCase):
         self.assertIs(type(ret), bytes)
         self.assertEqual(ret_dtype, 'ascii')
 
+    def test_isodatetime_spec_datetime_value(self):
+        """Raw datetime/date values must convert directly (typed-dataset path skips __convert_string)."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data')
+
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, datetime(2020, 11, 10))
+        self.assertEqual(ret, b'2020-11-10T00:00:00')
+        self.assertEqual(ret_dtype, 'ascii')
+
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, date(2020, 11, 10))
+        self.assertEqual(ret, b'2020-11-10')
+        self.assertEqual(ret_dtype, 'ascii')
+
+    def test_isodatetime_spec_bytes_value(self):
+        """Bytes input passes through _isoformat unchanged."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data')
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, b'2020-11-10T00:00:00')
+        self.assertEqual(ret, b'2020-11-10T00:00:00')
+        self.assertEqual(ret_dtype, 'ascii')
+
+    def test_isodatetime_spec_invalid_type(self):
+        """Non-datetime/str/bytes input to _isoformat raises ValueError."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data')
+        with self.assertRaisesRegex(ValueError, "Expected datetime, date, str, or bytes"):
+            ObjectMapper.convert_dtype(spec, 12345)
+
+    def test_isodatetime_spec_empty_list(self):
+        """Empty list/tuple branch returns 'ascii' for isodatetime spec."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, [])
+        self.assertEqual(ret, [])
+        self.assertEqual(ret_dtype, 'ascii')
+
+    def test_isodatetime_spec_ndarray_object(self):
+        """ndarray(dtype=object) of datetimes goes through the elementwise _isoformat branch."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        value = np.array([datetime(2020, 11, 10), datetime(2020, 11, 11)], dtype=object)
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(list(ret), [b'2020-11-10T00:00:00', b'2020-11-11T00:00:00'])
+        self.assertEqual(ret_dtype, 'ascii')
+
+    def test_isodatetime_spec_ndarray_string(self):
+        """ndarray of pre-formatted ISO strings takes the non-object astype('S') branch."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        value = np.array(['2020-11-10T00:00:00', '2020-11-11T00:00:00'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertEqual(list(ret), [b'2020-11-10T00:00:00', b'2020-11-11T00:00:00'])
+        self.assertEqual(ret_dtype, 'ascii')
+
+    def test_isodatetime_spec_data_chunk_iterator(self):
+        """DataChunkIterator with isodatetime spec returns 'ascii' ret_dtype."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        value = DataChunkIterator(data=[datetime(2020, 11, 10), datetime(2020, 11, 11)])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertIs(ret, value)
+        self.assertEqual(ret_dtype, 'ascii')
+
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_isodatetime_spec_zarr_array(self):
+        """Zarr arrays with isodatetime spec pass through with 'ascii' ret_dtype."""
+        import zarr
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        value = zarr.array(['2020-11-10T00:00:00', '2020-11-11T00:00:00'])
+        ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
+        self.assertIs(type(ret), zarr.Array)
+        self.assertEqual(ret_dtype, 'ascii')
+
     @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_zarr_array_spec_vlen_utf8(self):
         """Test that converting a zarr array with utf8 dtype for a variable length utf8 dtype spec


### PR DESCRIPTION
Closes #1311. Stacked on the matched-spec helper-cleanups branch (#1455).

## Bug

Building a typed dataset whose inc-site declares `dtype: isodatetime` (e.g., a `VectorData` column refined as a date column) failed with:
```
Exception: could not resolve dtype for VectorData 'date_of_birth':
Expected unicode or ascii string, got <class 'datetime.date'>
```

The typed-dataset path (`__add_containers` → `build_manager.build` → inner mapper's `build` → `convert_dtype`) skips the `__convert_string` preprocessing that the untyped-dataset path applies. `convert_dtype` mapped `isodatetime` and `datetime` dtypes to `_ascii`, which only accepts `str` / `bytes`. So raw `datetime` / `date` values reached `_ascii(value)` and raised.

## Fix

- Added an `_isoformat(s)` module helper that converts `datetime` / `date` to ASCII-encoded ISO 8601 bytes (`s.isoformat().encode('ascii')`) and passes `str` / `bytes` through unchanged.
- Routed `isodatetime` and `datetime` in `ObjectMapper.__dtypes` to `_isoformat` instead of `_ascii`.
- Updated the four branches in `convert_dtype` that compared `spec_dtype_type is _ascii` to also accept `_isoformat`. Both produce ASCII output, so the `ret_dtype = 'ascii'` bookkeeping is identical.

The untyped-dataset path is unaffected: `__convert_string` still preprocesses datetime → ISO string before `convert_dtype` runs, and the new `_isoformat` accepts the resulting string just as `_ascii` did.

## Test plan

- [x] New `TestBuildTypedDatasetDatetime` class in `test_build_datetime.py` covers the regression from #1311 with three cases:
  - Typed column with `datetime` data and `dtype='isodatetime'`.
  - Typed column with `date` data and `dtype='isodatetime'`.
  - Typed column with `datetime` data and the `dtype='datetime'` alias.
- [x] Existing `TestBuildDatasetDateTime` tests (untyped-dataset path) continue to pass.
- [x] `pytest tests/unit/` (1863 passed, 3 new tests).
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)