### PR TITLE
Prepare HDMF 6.0.0 release

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -167,8 +167,8 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install .
-          pip list
+          python -m pip install .
+          python -m pip list
 
       - name: Conda reporting
         run: |
@@ -178,4 +178,4 @@ jobs:
 
       - name: Run ros3 tests  # TODO include gallery tests after they are written
         run: |
-          pytest tests/unit/test_io_hdf5_streaming.py
+          python -m pytest tests/unit/test_io_hdf5_streaming.py

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -163,7 +163,7 @@ jobs:
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          auto-activate: false
 
       - name: Install run dependencies
         run: |

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -106,8 +106,8 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install .
-          pip list
+          python -m pip install .
+          python -m pip list
 
       - name: Conda reporting
         run: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Run ros3 tests  # TODO include gallery tests after they are written
         run: |
-          pytest --cov --cov-report=xml --cov-report=term tests/unit/test_io_hdf5_streaming.py
+          python -m pytest --cov --cov-report=xml --cov-report=term tests/unit/test_io_hdf5_streaming.py
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -102,7 +102,7 @@ jobs:
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          auto-activate: false
 
       - name: Install run dependencies
         run: |

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip list
           git clone https://github.com/hdmf-dev/hdmf-zarr.git
           cd hdmf-zarr
-          python -m pip install ".[test]"  # this will install a different version of hdmf from the current one
+          python -m pip install . --group test  # this will install a different version of hdmf from the current one
           cd ..
           python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -182,7 +182,7 @@ jobs:
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          auto-activate: false
 
       - name: Install run dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -186,8 +186,8 @@ jobs:
 
       - name: Install run dependencies
         run: |
-          pip install .
-          pip list
+          python -m pip install .
+          python -m pip list
 
       - name: Conda reporting
         run: |
@@ -197,4 +197,4 @@ jobs:
 
       - name: Run ros3 tests  # TODO include gallery tests after they are written
         run: |
-          pytest tests/unit/test_io_hdf5_streaming.py
+          python -m pytest tests/unit/test_io_hdf5_streaming.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## Unreleased
+## HDMF 6.0.0 (May 4, 2026)
 
 ### Breaking changes
 - `HDF5IO` `expandable` argument is now a list of data type names instead of a boolean. The default is `("VectorData", "ElementIdentifiers")`, so only `DynamicTable` columns and id are expandable out of the box — previously every dataset with a matching spec shape was expanded. Datasets of types outside this list that previously were expandable by default will now default to fixed-shape on-disk layout; add the relevant type to `expandable` to restore prior behavior. Replace `expandable=True` with an explicit list (e.g. `["VectorData", "ElementIdentifiers", "MyType"]`) and `expandable=False` with `[]`; passing `True`/`False` now raises a `TypeError`. @bendichter @rly [#1439](https://github.com/hdmf-dev/hdmf/pull/1439)

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - python==3.14
+  - pip
   - h5py==3.15.1
   - matplotlib==3.10.8
   - numpy==2.4.2

--- a/tests/unit/test_io_hdf5_streaming.py
+++ b/tests/unit/test_io_hdf5_streaming.py
@@ -72,7 +72,7 @@ class TestRos3(TestCase):
         ns_builder.export(self.ns_filename, outdir=self.output_dir)
         ns_path = os.path.join(self.output_dir, self.ns_filename)
 
-        ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
+        ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=["core"])
         type_map = TypeMap(ns_catalog)
         type_map.merge(get_type_map(), ns_catalog=True)
         type_map.load_namespaces(ns_path)
@@ -123,22 +123,37 @@ class TestRos3(TestCase):
         namespaces = HDF5IO.get_namespaces(s3_path, driver="ros3", aws_region="us-east-2")
         self.assertEqual(namespaces, {'core': '2.3.0', 'hdmf-common': '1.5.0', 'hdmf-experimental': '0.1.0'})
 
+    # The setUp loads a stub "core" namespace at version 0.1.0 to mimic PyNWB. The remote test
+    # file caches "core" at 2.3.0, so loading its namespaces emits a UserWarning that the cached
+    # core is being ignored because another version is already loaded.
+    _ignored_core_re = (
+        r"Ignoring the following cached namespace\(s\) because another version is already loaded:"
+        r"\ncore - cached version: 2\.3\.0, loaded version: 0\.1\.0"
+    )
+
     def test_load_namespaces(self):
         s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
-        HDF5IO.load_namespaces(self.manager.namespace_catalog, path=s3_path, driver="ros3")
+        with self.assertWarnsRegex(UserWarning, self._ignored_core_re):
+            HDF5IO.load_namespaces(self.manager.namespace_catalog, path=s3_path, driver="ros3")
         assert set(self.manager.namespace_catalog.namespaces) == set(["core", "hdmf-common", "hdmf-experimental"])
 
     def test_load_namespaces_with_aws_region(self):
         s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
-        HDF5IO.load_namespaces(self.manager.namespace_catalog, path=s3_path, driver="ros3", aws_region="us-east-2")
+        with self.assertWarnsRegex(UserWarning, self._ignored_core_re):
+            HDF5IO.load_namespaces(
+                self.manager.namespace_catalog, path=s3_path, driver="ros3", aws_region="us-east-2"
+            )
         assert set(self.manager.namespace_catalog.namespaces) == set(["core", "hdmf-common", "hdmf-experimental"])
 
     def test_load_namespaces_s3_with_aws_region(self):
         s3_path = "s3://dandiarchive/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
-        HDF5IO.load_namespaces(self.manager.namespace_catalog, path=s3_path, driver="ros3", aws_region="us-east-2")
+        with self.assertWarnsRegex(UserWarning, self._ignored_core_re):
+            HDF5IO.load_namespaces(
+                self.manager.namespace_catalog, path=s3_path, driver="ros3", aws_region="us-east-2"
+            )
         assert set(self.manager.namespace_catalog.namespaces) == set(["core", "hdmf-common", "hdmf-experimental"])
 
 


### PR DESCRIPTION
Prepare for release of HDMF 6.0.0

Plus minor fixes on CI workflows and test warnings.

NOTE: Tests that include "optional" continue to fail because installing the released version of pynwb is incompatible with installing hdmf 5 or hdmf 6.

NOTE: hdmf-zarr dev tests are expected to fail due to compatibility issues that will be resolved there.

### Before merging:
- [x] Make sure all PRs to be included in this release have been merged to `dev`.
- [x] Major and minor releases: Update dependency ranges in `pyproject.toml` as needed.
- [x] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `pyproject.toml` as needed
- [x] Update `README.rst` as needed
- [x] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number and commit SHA
  manually. Make sure we are using the latest release and not the latest commit on the `main` branch.
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs
  (`pytest && python test_gallery.py`). Try to remove all warnings.
- [x] Run PyNWB tests locally including gallery and validation tests, and inspect all warnings and outputs
  (`cd pynwb; git checkout dev; git pull; python test.py -v > out.txt 2>&1`)
- [x] Run HDMF-Zarr tests locally including gallery and validation tests, and inspect all warnings and outputs
  (`cd hdmf-zarr; git checkout dev; git pull; pytest && python test_gallery.py`)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
- [x] After pushing this branch to GitHub, manually trigger the "Run all tests" GitHub Actions workflow on this
  branch by going to https://github.com/hdmf-dev/hdmf/actions/workflows/run_all_tests.yml, selecting
  "Run workflow" on the right, selecting this branch, and clicking "Run workflow". Make sure all tests pass.
    - https://github.com/hdmf-dev/hdmf/actions/runs/25261251928
- [x] Check that the readthedocs build for this PR succeeds (see the PR check)

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
   [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
3. Check that the readthedocs "stable" build runs and succeeds
4. Either monitor [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock) for the
   regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within
   24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number
   and SHA256 retrieved from PyPI > HDMF > Download Files > View hashes for the `.tar.gz` file. Re-render and
   update the dependencies as needed.
