### PR TITLE
Pass aws_region in ros3 tests for libhdf5 2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # HDMF Changelog
 
+## HDMF 6.0.1 (Upcoming)
+
+### Fixed
+- Fixed ROS3 streaming tests that failed against libhdf5 >= 2.0, which now requires `aws_region` for ROS3. Updated `tests/unit/test_io_hdf5_streaming.py` to always pass `aws_region` and bumped `environment-ros3.yml` to install libhdf5 >= 2.0 so CI exercises the new behavior. @rly [#1470](https://github.com/hdmf-dev/hdmf/issues/1470)
+
+
 ## HDMF 6.0.0 (May 4, 2026)
 
 ### Breaking changes

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -6,7 +6,8 @@ channels:
 dependencies:
   - python==3.14
   - pip
-  - h5py==3.15.1
+  - h5py==3.16.0
+  - hdf5>=2.0
   - matplotlib==3.10.8
   - numpy==2.4.2
   - pandas==2.3.3

--- a/tests/unit/test_io_hdf5_streaming.py
+++ b/tests/unit/test_io_hdf5_streaming.py
@@ -85,20 +85,16 @@ class TestRos3(TestCase):
         if hasattr(self, 'ext_filename') and os.path.exists(self.ext_filename):
             os.remove(self.ext_filename)
 
+    # NOTE: libhdf5 >= 2.0 made aws_region a required parameter for the ROS3 driver, so all
+    # tests below pass aws_region. See https://github.com/hdmf-dev/hdmf/issues/1470.
+
     def test_basic_read(self):
-        s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
-
-        with get_hdf5io(s3_path, "r", manager=self.manager, driver="ros3") as io:
-            io.read()
-
-    def test_basic_read_with_aws_region(self):
         s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
         with get_hdf5io(s3_path, "r", manager=self.manager, driver="ros3", aws_region="us-east-2") as io:
             io.read()
 
-    def test_basic_read_s3_with_aws_region(self):
-        # NOTE: if an s3 path is used with ros3 driver, aws_region must be specified
+    def test_basic_read_s3(self):
         s3_path = "s3://dandiarchive/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
         with get_hdf5io(s3_path, "r", manager=self.manager, driver="ros3", aws_region="us-east-2") as io:
@@ -108,16 +104,10 @@ class TestRos3(TestCase):
     def test_get_namespaces(self):
         s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
-        namespaces = HDF5IO.get_namespaces(s3_path, driver="ros3")
-        self.assertEqual(namespaces, {'core': '2.3.0', 'hdmf-common': '1.5.0', 'hdmf-experimental': '0.1.0'})
-
-    def test_get_namespaces_with_aws_region(self):
-        s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
-
         namespaces = HDF5IO.get_namespaces(s3_path, driver="ros3", aws_region="us-east-2")
         self.assertEqual(namespaces, {'core': '2.3.0', 'hdmf-common': '1.5.0', 'hdmf-experimental': '0.1.0'})
 
-    def test_get_namespaces_s3_with_aws_region(self):
+    def test_get_namespaces_s3(self):
         s3_path = "s3://dandiarchive/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
         namespaces = HDF5IO.get_namespaces(s3_path, driver="ros3", aws_region="us-east-2")
@@ -135,19 +125,12 @@ class TestRos3(TestCase):
         s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
         with self.assertWarnsRegex(UserWarning, self._ignored_core_re):
-            HDF5IO.load_namespaces(self.manager.namespace_catalog, path=s3_path, driver="ros3")
-        assert set(self.manager.namespace_catalog.namespaces) == set(["core", "hdmf-common", "hdmf-experimental"])
-
-    def test_load_namespaces_with_aws_region(self):
-        s3_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
-
-        with self.assertWarnsRegex(UserWarning, self._ignored_core_re):
             HDF5IO.load_namespaces(
                 self.manager.namespace_catalog, path=s3_path, driver="ros3", aws_region="us-east-2"
             )
         assert set(self.manager.namespace_catalog.namespaces) == set(["core", "hdmf-common", "hdmf-experimental"])
 
-    def test_load_namespaces_s3_with_aws_region(self):
+    def test_load_namespaces_s3(self):
         s3_path = "s3://dandiarchive/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
 
         with self.assertWarnsRegex(UserWarning, self._ignored_core_re):


### PR DESCRIPTION
## Summary
- Updates the ROS3 streaming tests in `tests/unit/test_io_hdf5_streaming.py` to always pass `aws_region`, since libhdf5 2.0 made it required for the ROS3 driver. The previously redundant no-region tests are removed and the `_with_aws_region` variants are renamed to take their place.
- Bumps `environment-ros3.yml` to `h5py==3.16.0` and pins `hdf5>=2.0` so CI exercises the libhdf5 2.x ROS3 path (the previous pin resolved to libhdf5 1.14.x and never tripped the new region check).
- Adds a 6.0.1 CHANGELOG entry.

Fixes #1470.

## Test plan
- [x] `linux-python3.14-ros3` CI job passes against libhdf5 2.x.
- [ ] Verify in conda-forge hdmf-feedstock PR #105 that the failing test cases (`test_basic_read`, `test_get_namespaces`, `test_load_namespaces`) no longer appear once this lands in a 6.0.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)