### PR TITLE
Fix DatasetBuilder rejecting numpy scalar types with numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.0.2 (Unreleased)
+
+### Fixed
+- Added `numpy.generic` to the `scalar_data` docval macro so that numpy scalar types (e.g. `numpy.uint64`) are accepted as scalar data values. This fixes a compatibility issue with numpy 2.0, which removed `__iter__` from numpy scalars and caused them to be rejected by `DatasetBuilder`. @rly [#1474](https://github.com/hdmf-dev/hdmf/pull/1474)
+
 ## HDMF 6.0.1 (May 5, 2026)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 6.0.2 (Unreleased)
 
 ### Fixed
-- Added `numpy.generic` to the `scalar_data` docval macro so that numpy scalar types (e.g. `numpy.uint64`) are accepted as scalar data values. This fixes a compatibility issue with numpy 2.0, which removed `__iter__` from numpy scalars and caused them to be rejected by `DatasetBuilder`. @rly [#1474](https://github.com/hdmf-dev/hdmf/pull/1474)
+- Added `numpy.generic` to the `scalar_data` docval macro so that numpy scalar types (e.g. `numpy.uint64`) are accepted as scalar data values. This fixes a compatibility issue with numpy 2.0, which removed `__iter__` from numpy scalars and caused them to be rejected by `DatasetBuilder`. @rly [#1476](https://github.com/hdmf-dev/hdmf/pull/1476)
 
 ## HDMF 6.0.1 (May 5, 2026)
 

--- a/src/hdmf/utils.py
+++ b/src/hdmf/utils.py
@@ -13,7 +13,7 @@ import numpy as np
 
 __macros = {
     'array_data': [np.ndarray, list, tuple, h5py.Dataset],
-    'scalar_data': [str, int, float, bytes, bool, datetime.datetime, datetime.date],
+    'scalar_data': [str, int, float, bytes, bool, datetime.datetime, datetime.date, np.generic],
     'data': []
 }
 

--- a/tests/unit/build_tests/test_builder.py
+++ b/tests/unit/build_tests/test_builder.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
 from hdmf.testing import TestCase
 
@@ -379,6 +381,14 @@ class TestDatasetBuilder(TestCase):
         msg = 'Cannot overwrite parent.'
         with self.assertRaisesWith(AttributeError, msg):
             db1.parent = gb1
+
+    def test_constructor_numpy_scalar_data(self):
+        """DatasetBuilder must accept numpy scalar types as data (numpy 2.x removed __iter__ from scalars)."""
+        for dtype in (np.uint8, np.uint16, np.uint32, np.uint64, np.int32, np.int64, np.float32, np.float64, np.bool_):
+            with self.subTest(dtype=dtype):
+                val = dtype(5)
+                db = DatasetBuilder(name='db', data=val)
+                self.assertIs(db.data, val)
 
     def test_repr(self):
         gb1 = GroupBuilder('gb1')

--- a/tests/unit/utils_test/test_docval.py
+++ b/tests/unit/utils_test/test_docval.py
@@ -1086,7 +1086,7 @@ class TestMacro(TestCase):
 
         self.assertTupleEqual(
             get_docval_macro('scalar_data'),
-            (str, int, float, bytes, bool, datetime.datetime, datetime.date),
+            (str, int, float, bytes, bool, datetime.datetime, datetime.date, np.generic),
         )
 
         @docval_macro('scalar_data')
@@ -1095,7 +1095,7 @@ class TestMacro(TestCase):
 
         self.assertTupleEqual(
             get_docval_macro('scalar_data'),
-            (str, int, float, bytes, bool, datetime.datetime, datetime.date, Dummy1),
+            (str, int, float, bytes, bool, datetime.datetime, datetime.date, np.generic, Dummy1),
         )
 
         @docval_macro('dummy')


### PR DESCRIPTION
## Summary

- Adds `numpy.generic` to the `scalar_data` docval macro so that numpy scalar types (e.g. `numpy.uint64`) are accepted as scalar dataset data values.
- Fixes compatibility with numpy 2.0, which removed `__iter__` from scalars, causing them to be silently rejected by `DatasetBuilder`.

Fixes #1475. See also NeurodataWithoutBorders/pynwb#2193.

## Test plan

- [x] New regression test in `TestDatasetBuilder.test_constructor_numpy_scalar_data` covers all common numpy scalar dtypes.
- [x] Updated `TestMacro.test_macro` to assert `numpy.generic` is in `scalar_data`.
- [x] Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)