### PR TITLE
Fix anonymous typed link to a subtype being dropped on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.0.3 (Upcoming)
+
+### Fixed
+- Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
+
 ## HDMF 6.0.2 (May 15, 2026)
 
 ### Fixed

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1422,9 +1422,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
                     datasets[link_builder.name] = target
                 else:
                     groups[link_builder.name] = target
-                dt = manager.get_builder_dt(target)
-                if dt is not None:
-                    link_dt.setdefault(dt, list()).append(target)
+                self.__index_link_target(link_dt, target, manager)
             # now assign links to their respective specification
             consumed_link_names = set()
             for subspec in spec.links:
@@ -1455,6 +1453,21 @@ class ObjectMapper(metaclass=ExtenderMeta):
             data_spec = builder.matched_spec or spec
             ret[spec] = self.__parse_if_datetime(self.__check_ref_resolver(builder.data), data_spec)
         return ret
+
+    @staticmethod
+    def __index_link_target(link_dt, target, manager):
+        """Index a link target builder under its data type and all of its parent data types.
+
+        Indexing across the full type hierarchy lets an anonymous link spec (matched by
+        ``target_type``) also match targets that are subtypes of ``target_type``, mirroring the
+        behavior used for sub-groups in ``__get_sub_builders``.
+        """
+        dt = manager.get_builder_dt(target)
+        ns = manager.get_builder_ns(target)
+        if dt is None or ns is None:
+            return
+        for parent_dt in manager.namespace_catalog.get_hierarchy(ns, dt):
+            link_dt.setdefault(parent_dt, list()).append(target)
 
     @staticmethod
     def __check_ref_resolver(data):

--- a/tests/unit/build_tests/test_io_map.py
+++ b/tests/unit/build_tests/test_io_map.py
@@ -768,6 +768,86 @@ class TestObjectMapperContainer(ObjectMapperMixin, TestCase):
         self.assertSetEqual(keys, expected)
 
 
+class TestConstructUnnamedLinkSubtype(TestCase):
+    """Regression test for #1481.
+
+    An anonymous (unnamed) typed link should map link targets whose type is the link's ``target_type``
+    or any subtype of it. Previously, subtype targets were dropped on construct because links were
+    matched by exact data type.
+    """
+
+    def setUp(self):
+        self.base_spec = GroupSpec(doc='A base type', data_type_def='LinkBase')
+        self.sub_spec = GroupSpec(doc='A subtype of LinkBase', data_type_def='LinkSub', data_type_inc='LinkBase')
+        self.holder_spec = GroupSpec(
+            doc='Holds anonymous links to LinkBase instances',
+            data_type_def='LinkHolder',
+            links=[LinkSpec(doc='links to LinkBase instances', target_type='LinkBase', quantity='*')],
+        )
+
+        class LinkBase(Container):
+            @property
+            def data_type(self):
+                return 'LinkBase'
+
+        class LinkSub(LinkBase):
+            @property
+            def data_type(self):
+                return 'LinkSub'
+
+        class LinkHolder(Container):
+
+            @docval({'name': 'name', 'type': str, 'doc': 'the name of this LinkHolder'},
+                    {'name': 'links', 'type': ('array_data', 'data'), 'doc': 'linked LinkBases', 'default': None})
+            def __init__(self, **kwargs):
+                name, links = getargs('name', 'links', kwargs)
+                super().__init__(name=name)
+                self.links = links
+
+            @property
+            def data_type(self):
+                return 'LinkHolder'
+
+        class LinkHolderMapper(ObjectMapper):
+            def __init__(self, spec):
+                super().__init__(spec)
+                # map the anonymous link spec to the 'links' constructor argument / field
+                self.map_spec('links', spec.links[0])
+
+        self.type_map = create_test_type_map(
+            [self.base_spec, self.sub_spec, self.holder_spec],
+            {'LinkBase': LinkBase, 'LinkSub': LinkSub, 'LinkHolder': LinkHolder},
+            {'LinkHolder': LinkHolderMapper},
+        )
+        self.manager = BuildManager(self.type_map)
+
+    def _construct_holder_linking(self, target_data_type):
+        base_builder = GroupBuilder(
+            name='my_base',
+            attributes={'data_type': target_data_type, 'namespace': CORE_NAMESPACE, 'object_id': 'base-id'},
+        )
+        holder_builder = GroupBuilder(
+            name='my_holder',
+            links={'my_base': LinkBuilder(builder=base_builder, name='my_base')},
+            attributes={'data_type': 'LinkHolder', 'namespace': CORE_NAMESPACE, 'object_id': 'holder-id'},
+        )
+        return self.manager.construct(holder_builder)
+
+    def test_construct_unnamed_link_exact_type(self):
+        """An anonymous link to an exact-type target is mapped to the field (unchanged behavior)."""
+        holder = self._construct_holder_linking('LinkBase')
+        self.assertIsNotNone(holder.links)
+        self.assertEqual(len(holder.links), 1)
+        self.assertEqual(holder.links[0].data_type, 'LinkBase')
+
+    def test_construct_unnamed_link_subtype(self):
+        """An anonymous link to a subtype target is mapped to the field (was dropped before #1481)."""
+        holder = self._construct_holder_linking('LinkSub')
+        self.assertIsNotNone(holder.links)
+        self.assertEqual(len(holder.links), 1)
+        self.assertEqual(holder.links[0].data_type, 'LinkSub')
+
+
 class TestLinkedContainer(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Motivation

Fixes #1481.

`ObjectMapper.__get_subspec_values` aggregates a group's link targets into `link_dt` keyed by each target's **exact** data type, then matches anonymous (unnamed) link specs with `link_dt.get(subspec.target_type)`. When a link target is a **subtype** of the spec's `target_type`, the exact-key lookup misses it, so the link is never assigned to the spec and the field comes back as `None` on read.

Downstream impact: in `ndx-pose`, `PoseEstimation.devices` is an anonymous `target_type: Device, quantity: '*'` link. Linking a plain `Device` round-trips, but linking any `Device` subtype (e.g. `ndx_franklab_novela.CameraDevice`) yields `devices == None` after read (rly/ndx-pose#48). The link is written correctly; only read-time mapping fails.

## How to fix

Index link targets across their **full type hierarchy** (via `namespace_catalog.get_hierarchy`) instead of only their concrete type, so an anonymous link spec matched by `target_type` also matches subtype targets. This mirrors the subtype-aware matching already used for sub-groups in `__get_sub_builders`. The indexing is extracted into a small `__index_link_target` helper (which also keeps `__get_subspec_values` under the complexity limit).

## Checklist

- [x] Added a construct-level regression test (`TestConstructUnnamedLinkSubtype`) covering both exact-type and subtype anonymous links. Verified it fails on `dev` without the fix and passes with it.
- [x] Full unit suite passes locally (`1792 passed`), `ruff` clean.
- [x] Updated `CHANGELOG.md`.

Opened as a draft pending maintainer input on the approach (and PR-number fixups in the CHANGELOG).