### PR TITLE
Add HDMF ↔ LinkML mapping conventions and the base.yaml / CSRMatrix fixtures

### DIFF
--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install package with optional dependencies
         if: ${{ matrix.opt_req }}
         run: |
-          python -m pip install --group test ".[tqdm,sparse,zarr,termset]"
+          python -m pip install --group test ".[tqdm,sparse,zarr,termset,linkml]"
 
       - name: Run tests and generate coverage report
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.0.3 (Upcoming)
+
+### Documentation
+- Added documentation of the conventions for mapping HDMF schema language constructs to LinkML, scoped to the `base.yaml` and `CSRMatrix` types. @rly [#1492](https://github.com/hdmf-dev/hdmf/pull/1492)
+
 ## HDMF 6.0.2 (May 15, 2026)
 
 ### Fixed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,7 @@ If you use HDMF in your research, please use the following citation:
    export
    validation
    spec_language_support
+   linkml_mapping
 
 .. toctree::
    :hidden:

--- a/docs/source/linkml_mapping.rst
+++ b/docs/source/linkml_mapping.rst
@@ -9,6 +9,12 @@ These conventions cover the constructs used by ``base.yaml`` (``Data``, ``Contai
 namespace. This is **not** a complete mapping of HDMFSL; constructs not yet covered are
 listed at the end.
 
+The LinkML files that apply these conventions to that test namespace live in
+``tests/unit/linkml_tests/fixtures/``. They are the reference the reader and writer are
+tested against, and ``tests/unit/linkml_tests/test_fixtures.py`` checks that they load
+under ``linkml-runtime``'s ``SchemaView`` and cover every field of the ``Spec`` objects HDMF
+loads natively from the HDMFSL sources.
+
 Goal and guiding principles
 ---------------------------
 
@@ -21,6 +27,21 @@ HDMF can read LinkML into its ``Spec`` objects (``GroupSpec``, ``DatasetSpec``,
    classes carry (``name``, ``doc``, ``dtype``, ``dims``, ``shape``, ``required``,
    ``quantity``, ``data_type_def`` / ``data_type_inc``, containment) must be recoverable
    from the LinkML.
+
+   ``Spec`` subclasses ``dict`` and inherits ``dict`` equality, so the comparison is over
+   the keys actually present. This puts two requirements on the reader:
+
+   - **Defaults stay absent.** HDMF omits a field left at its default: an
+     ``AttributeSpec`` with ``required`` at its default carries no ``required`` key, and a
+     dataset or subgroup at ``quantity`` ``1`` carries no ``quantity`` key. A reader that
+     writes the default value out explicitly produces a ``Spec`` that does not compare
+     equal.
+   - **Order within a construct list is preserved.** ``attributes``, ``datasets``, and
+     ``groups`` are lists, so their order is part of the comparison. LinkML holds all three
+     kinds in one ``attributes`` block on the class, so the reader partitions the slots by
+     ``spec_type`` and keeps their relative order within each partition. Declaring the
+     slots in HDMFSL order (attributes, then datasets, then groups) makes the LinkML read
+     the same way as the HDMFSL source.
 2. **Annotations carry HDMFSL provenance.** LinkML flattens groups, datasets, and
    attributes into classes and slots; HDMF needs to recover which was which. We record
    that with a small, explicit annotation vocabulary rather than inferring it.
@@ -111,13 +132,18 @@ identifier slot, marked ``identifier: true``, is the one exception and carries n
 How the reader tells a **named, typed** dataset/attribute from a **typed include**
 (``data_type_inc``):
 
-- If the slot ``range`` is a **dtype** (or ``AnyType``) → a named dataset/attribute; the
-  slot name is the HDMFSL ``name``.
-- If the slot ``range`` is a **defined class** → an include of that type
+- If the slot ``range`` is a **dtype**, or the ``AnyType`` class → a named
+  dataset/attribute; the slot name is the HDMFSL ``name``. ``AnyType`` is a class rather
+  than a type (see dtypes), so it is called out here as the one class range that does not
+  mean an include.
+- If the slot ``range`` is any **other defined class** → an include of that type
   (``data_type_inc``). In scope, includes are unnamed, so the slot name is synthesized
   from the included type (snake_case) and is informational only (the writer re-emits the
   entry with ``data_type_inc`` and no ``name``). Named includes are deferred (see Out of
   scope).
+
+The HDMFSL ``doc`` on the entry becomes the slot ``description``, for includes as well as
+for named entries.
 
 A multivalued class-valued slot (an include with ``quantity`` ``*`` or ``+``) uses
 ``inlined_as_list: true``, so its contents serialize as a list of the included objects.
@@ -127,8 +153,9 @@ Naming and identity (the name identifier slot)
 
 LinkML requires an identifier for objects that are inlined as dictionaries, and HDMF
 objects are keyed by name in the file hierarchy. HDMFSL leaves this implicit (objects are
-named where they are used, not via a declared attribute); LinkML makes it explicit. Each
-class gets a ``name`` slot (``identifier: true``, ``range: string``, ``required: true``).
+named where they are used, not via a declared attribute); LinkML makes it explicit. A class
+with no ``is_a`` declares a ``name`` slot (``identifier: true``, ``range: string``,
+``required: true``); classes with an ``is_a`` inherit it.
 
 .. code-block:: yaml
 
@@ -137,51 +164,81 @@ class gets a ``name`` slot (``identifier: true``, ``range: string``, ``required:
          range: string
          required: true
 
+It is declared once at the root of each hierarchy (``Data`` and ``Container`` in the test
+namespace) because LinkML permits at most one identifier per class and inheritance already
+supplies it to every subclass. Every HDMF object therefore has an identifier, and the
+reader only ever sees the slot on the class that declares it.
+
 The reader handles the ``identifier`` slot specially: it represents the object's hierarchy
 name, not a declared attribute, so the reader never builds an ``AttributeSpec`` from it. No
 ``spec_type`` annotation is needed, because ``identifier: true`` already identifies this
-slot (LinkML allows at most one identifier per class, and it is always this slot).
+slot. The slot is required for LinkML inlining of data instances and for
+forward-compatibility with the Pydantic work.
 
-The ``name`` identifier slot is kept on every class. It is required for LinkML inlining of
-data instances and for forward-compatibility with the Pydantic work; the reader does not
-turn it into an ``AttributeSpec``.
+Fixed names and default names on a type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``name`` identifier slot above is the name an *instance* is keyed by. HDMFSL also lets
+a type constrain that name at the schema level, and those constraints map to the identifier
+slot rather than to a separate construct:
+
+- A ``data_type_def`` that also fixes a ``name`` (the name is not free) →
+  ``equals_string: <name>`` on the identifier slot.
+- ``default_name`` (a name used when the caller supplies none) →
+  ``ifabsent: string(<default_name>)`` on the identifier slot.
+
+Neither is used by the types in scope, so both are stated here as the convention and are
+not exercised by the fixtures. A type with neither is unnamed: its instances are named
+where they are used.
 
 dtypes
 ~~~~~~
 
-HDMFSL dtypes map to LinkML ranges via a companion ``hdmf-linkml-types`` schema that
-defines each dtype as its own ``TypeDefinition``, rather than collapsing to LinkML base
-types. Each HDMFSL dtype is a distinct named type, so dtypes are differentiated by
-**name**, not by their underlying ``typeof``: ``float32`` and ``float64`` are separate
-named types even though both build on a LinkML base type, and a slot distinguishes them
-with ``range: float32`` vs ``range: float64``. The reader recovers the exact HDMFSL dtype
-from the range name. This is what keeps precision through the round-trip (``uint`` stays
-``uint``, not a lossy ``integer``); ``typeof`` tracks the closest LinkML base type for
-native LinkML consumers but does not carry the round-trip identity.
+HDMFSL dtypes map to LinkML ranges via a companion ``hdmf-linkml-types`` schema. A slot's
+``range`` is the HDMFSL dtype string verbatim (``range: uint``), and the reader recovers the
+dtype from the range name.
+
+**Every HDMFSL dtype string is its own named type, synonyms included.** HDMFSL treats
+``uint`` and ``uint32``, or ``text`` / ``utf`` / ``utf8`` / ``utf-8``, as synonyms, and a
+``Spec`` stores whichever spelling the schema used. Collapsing synonyms onto a single type
+would rewrite ``dtype: uint`` as ``dtype: uint32`` on the way back and break the ``Spec``
+comparison, so each spelling is a separate ``TypeDefinition``. A synonym's ``typeof`` points
+at the primary dtype, which records the synonym relationship in LinkML itself; a primary
+dtype's ``typeof`` points at a LinkML base type and carries the width and sign constraints.
+Identity for the round trip is always the name, never ``typeof``.
+
+**The dtypes LinkML already provides are reused rather than redefined.** HDMFSL's ``float``,
+``double``, ``date``, and ``datetime`` collide by name with LinkML built-in types whose
+semantics agree (``xsd:float`` is 32 bit, ``xsd:double`` is 64 bit), so ``hdmf-linkml-types``
+imports ``linkml:types`` and leaves those four to it. Redefining them would shadow the
+built-ins for every schema in the import closure.
 
 .. code-block:: yaml
 
    # in hdmf-linkml-types
+   imports:
+     - linkml:types
    types:
-     uint:
+     uint32:
        typeof: integer
        minimum_value: 0
-     int32:
-       typeof: integer
+       maximum_value: 4294967295
+     uint:                      # synonym of uint32; kept distinct so the spelling survives
+       typeof: uint32
      float32:
-       typeof: float
-     float64:
-       typeof: double
+       typeof: float            # float comes from linkml:types
      text:
        typeof: string
-     # ... one per HDMFSL dtype
+     # ... one per HDMFSL dtype string
 
-- A slot's ``range`` is the HDMFSL dtype name (e.g. ``range: uint``).
-- A dataset or attribute with **no dtype** (the ``CSRMatrix`` ``data`` dataset) →
-  ``range: AnyType``, where ``AnyType`` is a class with ``class_uri: linkml:Any``. The
-  reader maps ``range: AnyType`` back to ``dtype = None``.
+A dataset or attribute with **no dtype** (the ``CSRMatrix`` ``data`` dataset) →
+``range: AnyType``, where ``AnyType`` is a class with ``class_uri: linkml:Any`` defined
+alongside the types. The reader maps ``range: AnyType`` back to ``dtype = None``. It is a
+class because LinkML expresses an unconstrained range that way, which is why the slot rules
+above name it as the one class range that is not an include.
 
-Compound and reference dtypes are deferred (see Out of scope).
+The reference dtype ``object`` is deferred along with reference and compound dtypes, so
+``hdmf-linkml-types`` does not define it (see Out of scope).
 
 Arrays (dims / shape)
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,7 +271,9 @@ one ``dimensions`` entry per axis. This applies uniformly to attributes and data
 quantity and required
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- Attribute ``required`` (a boolean in HDMFSL) → slot ``required``.
+- Attribute ``required`` (a boolean in HDMFSL) → slot ``required``, always written out
+  explicitly. HDMFSL defaults an attribute to required while LinkML defaults a slot to
+  optional, so an omitted ``required`` on an attribute slot would flip the meaning.
 - Dataset/subgroup ``quantity`` → slot ``required`` + ``multivalued``:
 
 .. list-table::
@@ -236,9 +295,12 @@ quantity and required
      - true
      - true
 
+A dash means the key is omitted. The four combinations are distinct, so a dataset or
+subgroup slot recovers its ``quantity`` unambiguously.
+
 ``quantity`` (how many of the object) is independent of the array shape (the object's
-dimensions): a single required array dataset is ``required: true``, ``multivalued: false``,
-with an ``array`` expression.
+dimensions): a single required array dataset is ``required: true`` with no ``multivalued``,
+plus an ``array`` expression.
 
 Namespace-level mapping
 -----------------------
@@ -265,100 +327,49 @@ importing ``hdmf-common``) are out of scope; the test namespace is self-containe
 
 LinkML schemas require an ``id`` URI and use ``prefixes`` / ``default_prefix``. A
 placeholder base URI (e.g. ``https://w3id.org/hdmf/...``) is used for now; the final base
-URI convention for HDMF/NWB LinkML schemas will be settled with the LinkML team.
+URI convention for HDMF/NWB LinkML schemas will be settled with the LinkML team. A prefix
+is a CURIE prefix, so a namespace name containing a hyphen is spelled with underscores
+there (``hdmf-common-test`` → ``hdmf_common_test``); the schema ``name`` keeps the HDMFSL
+spelling, and that is what the reader reads the namespace name from.
 
 Worked example
 --------------
 
+These are the LinkML files for the test namespace, as committed under
+``tests/unit/linkml_tests/fixtures/``. They are shown here in full so the conventions above
+can be read against a complete example, and they are the same files the tests load, so the
+example cannot drift from what is validated.
+
+HDMFSL dtypes → hdmf-linkml-types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../tests/unit/linkml_tests/fixtures/hdmf-linkml-types.yaml
+   :language: yaml
+
 base.yaml → base LinkML schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: yaml
-
-   name: base
-   id: https://w3id.org/hdmf/test/base          # placeholder base URI (to be finalized)
-   imports:
-     - hdmf-linkml-types
-   default_prefix: base
-   classes:
-     Data:
-       description: An abstract data type for a dataset.
-       annotations:
-         spec_type: dataset
-       attributes:
-         name:
-           identifier: true
-           range: string
-           required: true
-     Container:
-       description: An abstract data type for a group storing collections of data and metadata. Base type for all data and metadata containers.
-       annotations:
-         spec_type: group
-       attributes:
-         name:
-           identifier: true
-           range: string
-           required: true
-     SimpleMultiContainer:
-       description: A simple Container for holding onto multiple containers.
-       is_a: Container
-       annotations:
-         spec_type: group
-       attributes:
-         name:
-           identifier: true
-           range: string
-           required: true
-         data:                       # datasets: - data_type_inc: Data, quantity: '*'  (unnamed include)
-           range: Data
-           multivalued: true
-           inlined_as_list: true
-           annotations:
-             spec_type: dataset
-         container:                  # groups: - data_type_inc: Container, quantity: '*'  (unnamed include)
-           range: Container
-           multivalued: true
-           inlined_as_list: true
-           annotations:
-             spec_type: group
+.. literalinclude:: ../../tests/unit/linkml_tests/fixtures/base.yaml
+   :language: yaml
 
 sparse.yaml → sparse LinkML schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TBD
+.. literalinclude:: ../../tests/unit/linkml_tests/fixtures/sparse.yaml
+   :language: yaml
 
 Test namespace.yaml → namespace LinkML schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: yaml
-
-   name: hdmf-common-test
-   id: https://w3id.org/hdmf/test                # placeholder base URI (to be finalized)
-   description: Minimal test namespace for the HDMF ↔ LinkML round-trip (base + sparse only).
-   version: 0.1.0
-   imports:
-     - base
-     - sparse
-     - hdmf-linkml-types
-   default_prefix: hdmf-common-test
-   annotations:
-     authors:                        # merged from namespace.yaml author + contact (one-to-one)
-       value:
-       - name: Andrew Tritt
-         email: ajtritt@lbl.gov
-       - name: Oliver Ruebel
-         email: oruebel@lbl.gov
-       - name: Ryan Ly
-         email: rly@lbl.gov
-       - name: Ben Dichter
-         email: bdichter@lbl.gov
+.. literalinclude:: ../../tests/unit/linkml_tests/fixtures/namespace.yaml
+   :language: yaml
 
 Out of scope
 ------------
 
 - Dataset special cases: scalar-with-attributes, list-like datasets, class-range
   references.
-- Compound dtypes; reference dtypes; links.
+- Compound dtypes; reference dtypes, including the ``object`` dtype; links.
 - The ``DynamicTable`` family (``VectorData``, ``VectorIndex``, ``DynamicTableRegion``,
   ragged arrays, inter-table references).
 - Named includes (a ``data_type_inc`` entry that also fixes a ``name``).

--- a/docs/source/linkml_mapping.rst
+++ b/docs/source/linkml_mapping.rst
@@ -1,0 +1,368 @@
+.. _linkml_mapping:
+
+=================================
+HDMF ↔ LinkML mapping conventions
+=================================
+
+These conventions cover the constructs used by ``base.yaml`` (``Data``, ``Container``,
+``SimpleMultiContainer``) and ``sparse.yaml`` (``CSRMatrix``), packaged as a minimal test
+namespace. This is **not** a complete mapping of HDMFSL; constructs not yet covered are
+listed at the end.
+
+Goal and guiding principles
+---------------------------
+
+Define how HDMF Schema Language (HDMFSL) constructs are represented in LinkML, such that
+HDMF can read LinkML into its ``Spec`` objects (``GroupSpec``, ``DatasetSpec``,
+``AttributeSpec``) and write those ``Spec`` objects back to LinkML.
+
+1. **Spec round-trip is the contract.** The ``Spec`` reconstructed from the LinkML must
+   equal the ``Spec`` HDMF loads natively from the HDMFSL. Every field the ``Spec``
+   classes carry (``name``, ``doc``, ``dtype``, ``dims``, ``shape``, ``required``,
+   ``quantity``, ``data_type_def`` / ``data_type_inc``, containment) must be recoverable
+   from the LinkML.
+2. **Annotations carry HDMFSL provenance.** LinkML flattens groups, datasets, and
+   attributes into classes and slots; HDMF needs to recover which was which. We record
+   that with a small, explicit annotation vocabulary rather than inferring it.
+3. **Prefer native LinkML; preserve, don't drop.** Use native LinkML constructs
+   (``is_a``, the arrays metamodel, ``required`` / ``multivalued``) wherever they fit.
+   Anything HDMFSL needs that has no native home is preserved in an annotation. Nothing
+   the reader needs is silently dropped.
+4. **No LinkML features that Spec cannot model.** Constructs with no HDMFSL equivalent are
+   out of scope.
+
+Annotation vocabulary
+---------------------
+
+All annotations are written in LinkML's compact form, e.g. ``spec_type: dataset``, which
+LinkML expands to ``{tag: spec_type, value: dataset}``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Annotation
+     - Applies to
+     - Values
+     - Purpose
+   * - ``spec_type``
+     - class
+     - ``group``, ``dataset``
+     - Which ``Spec`` subclass the ``data_type_def`` builds (``GroupSpec`` vs
+       ``DatasetSpec``).
+   * - ``spec_type``
+     - slot
+     - ``attribute``, ``dataset``, ``group``
+     - Which ``Spec`` construct the slot maps back to. Not used on the identifier slot,
+       which LinkML already marks with ``identifier: true`` (see Naming and identity).
+
+Namespace-level metadata annotations are described in the Namespace section.
+
+File and schema structure
+-------------------------
+
+HDMFSL has two tiers (a ``namespace.yaml`` plus the schema files it lists). LinkML's unit
+is a ``SchemaDefinition`` per file with ``imports``. We mirror the HDMFSL file layout:
+
+- One LinkML schema **per HDMFSL schema file**: ``base.yaml`` → a ``base`` schema,
+  ``sparse.yaml`` → a ``sparse`` schema. Each holds the classes for the ``data_type_def``\ s
+  in that file and imports whatever it references.
+- One **namespace-level** LinkML schema for the test namespace, which imports the per-file
+  schemas. This is what HDMF loads through the namespace/catalog path.
+- One **types** schema (``hdmf-linkml-types``) defining the HDMFSL dtypes as LinkML
+  ``TypeDefinition``\ s (see dtypes), imported by any schema that uses them.
+
+Type-level mappings
+-------------------
+
+data_type_def / data_type_inc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Each ``data_type_def`` → a LinkML ``class`` whose name is the type name.
+- ``data_type_inc`` (when the type extends another) → ``is_a``.
+- A class-level ``spec_type`` annotation records whether the type is a group or a dataset,
+  because HDMF builds a ``GroupSpec`` for a ``data_type_def`` declared under ``groups:``
+  and a ``DatasetSpec`` for one under ``datasets:``, and that cannot be inferred from the
+  LinkML structure alone.
+
+.. code-block:: yaml
+
+   # Container (a group def) and Data (a dataset def), both abstract bases
+   Container:
+     description: An abstract data type for a group storing collections of data and metadata. Base type for all data and metadata containers.
+     annotations:
+       spec_type: group
+   Data:
+     description: An abstract data type for a dataset.
+     annotations:
+       spec_type: dataset
+
+Attributes, datasets, and subgroups → slots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each ``attributes:``, ``datasets:``, or ``groups:`` entry within a type becomes a slot on
+the class, tagged with ``spec_type`` so the reader rebuilds the right construct (the
+identifier slot, marked ``identifier: true``, is the one exception and carries no
+``spec_type``):
+
+- ``spec_type: attribute`` → ``AttributeSpec``
+- ``spec_type: dataset`` → ``DatasetSpec``
+- ``spec_type: group`` → ``GroupSpec`` (subgroup)
+
+How the reader tells a **named, typed** dataset/attribute from a **typed include**
+(``data_type_inc``):
+
+- If the slot ``range`` is a **dtype** (or ``AnyType``) → a named dataset/attribute; the
+  slot name is the HDMFSL ``name``.
+- If the slot ``range`` is a **defined class** → an include of that type
+  (``data_type_inc``). In scope, includes are unnamed, so the slot name is synthesized
+  from the included type (snake_case) and is informational only (the writer re-emits the
+  entry with ``data_type_inc`` and no ``name``). Named includes are deferred (see Out of
+  scope).
+
+A multivalued class-valued slot (an include with ``quantity`` ``*`` or ``+``) uses
+``inlined_as_list: true``, so its contents serialize as a list of the included objects.
+
+Naming and identity (the name identifier slot)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+LinkML requires an identifier for objects that are inlined as dictionaries, and HDMF
+objects are keyed by name in the file hierarchy. HDMFSL leaves this implicit (objects are
+named where they are used, not via a declared attribute); LinkML makes it explicit. Each
+class gets a ``name`` slot (``identifier: true``, ``range: string``, ``required: true``).
+
+.. code-block:: yaml
+
+       name:
+         identifier: true
+         range: string
+         required: true
+
+The reader handles the ``identifier`` slot specially: it represents the object's hierarchy
+name, not a declared attribute, so the reader never builds an ``AttributeSpec`` from it. No
+``spec_type`` annotation is needed, because ``identifier: true`` already identifies this
+slot (LinkML allows at most one identifier per class, and it is always this slot).
+
+The ``name`` identifier slot is kept on every class. It is required for LinkML inlining of
+data instances and for forward-compatibility with the Pydantic work; the reader does not
+turn it into an ``AttributeSpec``.
+
+dtypes
+~~~~~~
+
+HDMFSL dtypes map to LinkML ranges via a companion ``hdmf-linkml-types`` schema that
+defines each dtype as its own ``TypeDefinition``, rather than collapsing to LinkML base
+types. Each HDMFSL dtype is a distinct named type, so dtypes are differentiated by
+**name**, not by their underlying ``typeof``: ``float32`` and ``float64`` are separate
+named types even though both build on a LinkML base type, and a slot distinguishes them
+with ``range: float32`` vs ``range: float64``. The reader recovers the exact HDMFSL dtype
+from the range name. This is what keeps precision through the round-trip (``uint`` stays
+``uint``, not a lossy ``integer``); ``typeof`` tracks the closest LinkML base type for
+native LinkML consumers but does not carry the round-trip identity.
+
+.. code-block:: yaml
+
+   # in hdmf-linkml-types
+   types:
+     uint:
+       typeof: integer
+       minimum_value: 0
+     int32:
+       typeof: integer
+     float32:
+       typeof: float
+     float64:
+       typeof: double
+     text:
+       typeof: string
+     # ... one per HDMFSL dtype
+
+- A slot's ``range`` is the HDMFSL dtype name (e.g. ``range: uint``).
+- A dataset or attribute with **no dtype** (the ``CSRMatrix`` ``data`` dataset) →
+  ``range: AnyType``, where ``AnyType`` is a class with ``class_uri: linkml:Any``. The
+  reader maps ``range: AnyType`` back to ``dtype = None``.
+
+Compound and reference dtypes are deferred (see Out of scope).
+
+Arrays (dims / shape)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A construct's ``dims`` / ``shape`` map to the LinkML arrays metamodel: an ``array`` with
+one ``dimensions`` entry per axis. This applies uniformly to attributes and datasets.
+
+- A ``null`` shape entry → a dimension with an ``alias`` and no cardinality.
+- A fixed integer shape entry → ``exact_cardinality: N``.
+- Multiple allowed shapes → ``any_of`` of ``array`` expressions. (Not exercised by the
+  in-scope types; documented as the convention.)
+- The dimension ``alias`` is the HDMFSL dimension label, used verbatim. LinkML's ``alias``
+  is a free-form optional string (no pattern, identifier, or uniqueness constraint), so
+  labels like ``number of rows, number of columns`` round-trip exactly. The reader
+  reconstructs ``dims`` from the dimensions' aliases in order, and ``shape`` from
+  ``exact_cardinality`` (or ``None`` when absent).
+
+.. code-block:: yaml
+
+         shape:                      # the CSRMatrix shape attribute: dims=["number of rows, number of columns"], shape=[2]
+           range: uint
+           required: true
+           annotations:
+             spec_type: attribute
+           array:
+             dimensions:
+             - alias: number of rows, number of columns
+               exact_cardinality: 2
+
+quantity and required
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Attribute ``required`` (a boolean in HDMFSL) → slot ``required``.
+- Dataset/subgroup ``quantity`` → slot ``required`` + ``multivalued``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``quantity``
+     - ``required``
+     - ``multivalued``
+   * - ``1`` (default)
+     - true
+     - —
+   * - ``?``
+     - —
+     - —
+   * - ``*``
+     - —
+     - true
+   * - ``+``
+     - true
+     - true
+
+``quantity`` (how many of the object) is independent of the array shape (the object's
+dimensions): a single required array dataset is ``required: true``, ``multivalued: false``,
+with an ``array`` expression.
+
+Namespace-level mapping
+-----------------------
+
+An HDMFSL ``namespace.yaml`` declares a namespace (name, version, metadata) and lists its
+schema files. It maps to the namespace-level LinkML schema:
+
+- ``name`` → schema ``name`` and ``id`` (a URI; a placeholder base URI is used for now, to
+  be finalized with the LinkML team).
+- ``version`` → schema ``version``.
+- ``doc`` → schema ``description``.
+- ``full_name`` → schema ``title``.
+- The ``schema:`` list (the ``source:`` files) → ``imports`` of the corresponding
+  per-file LinkML schemas.
+- ``author`` and ``contact`` (positionally one-to-one in HDMFSL) have no native LinkML
+  schema field. LinkML annotation values accept structured data, not just scalars, so the
+  two lists are merged and preserved in a single ``authors`` annotation whose value is a
+  list of ``{name, email}`` objects; this keeps each name bound to its email. The
+  per-entry ``title`` / ``doc`` on each schema source are carried on the imported per-file
+  schema (its ``title`` / ``description``).
+
+Cross-namespace imports (an HDMFSL namespace importing another, e.g. ``hdmf-experimental``
+importing ``hdmf-common``) are out of scope; the test namespace is self-contained.
+
+LinkML schemas require an ``id`` URI and use ``prefixes`` / ``default_prefix``. A
+placeholder base URI (e.g. ``https://w3id.org/hdmf/...``) is used for now; the final base
+URI convention for HDMF/NWB LinkML schemas will be settled with the LinkML team.
+
+Worked example
+--------------
+
+base.yaml → base LinkML schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   name: base
+   id: https://w3id.org/hdmf/test/base          # placeholder base URI (to be finalized)
+   imports:
+     - hdmf-linkml-types
+   default_prefix: base
+   classes:
+     Data:
+       description: An abstract data type for a dataset.
+       annotations:
+         spec_type: dataset
+       attributes:
+         name:
+           identifier: true
+           range: string
+           required: true
+     Container:
+       description: An abstract data type for a group storing collections of data and metadata. Base type for all data and metadata containers.
+       annotations:
+         spec_type: group
+       attributes:
+         name:
+           identifier: true
+           range: string
+           required: true
+     SimpleMultiContainer:
+       description: A simple Container for holding onto multiple containers.
+       is_a: Container
+       annotations:
+         spec_type: group
+       attributes:
+         name:
+           identifier: true
+           range: string
+           required: true
+         data:                       # datasets: - data_type_inc: Data, quantity: '*'  (unnamed include)
+           range: Data
+           multivalued: true
+           inlined_as_list: true
+           annotations:
+             spec_type: dataset
+         container:                  # groups: - data_type_inc: Container, quantity: '*'  (unnamed include)
+           range: Container
+           multivalued: true
+           inlined_as_list: true
+           annotations:
+             spec_type: group
+
+sparse.yaml → sparse LinkML schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TBD
+
+Test namespace.yaml → namespace LinkML schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   name: hdmf-common-test
+   id: https://w3id.org/hdmf/test                # placeholder base URI (to be finalized)
+   description: Minimal test namespace for the HDMF ↔ LinkML round-trip (base + sparse only).
+   version: 0.1.0
+   imports:
+     - base
+     - sparse
+     - hdmf-linkml-types
+   default_prefix: hdmf-common-test
+   annotations:
+     authors:                        # merged from namespace.yaml author + contact (one-to-one)
+       value:
+       - name: Andrew Tritt
+         email: ajtritt@lbl.gov
+       - name: Oliver Ruebel
+         email: oruebel@lbl.gov
+       - name: Ryan Ly
+         email: rly@lbl.gov
+       - name: Ben Dichter
+         email: bdichter@lbl.gov
+
+Out of scope
+------------
+
+- Dataset special cases: scalar-with-attributes, list-like datasets, class-range
+  references.
+- Compound dtypes; reference dtypes; links.
+- The ``DynamicTable`` family (``VectorData``, ``VectorIndex``, ``DynamicTableRegion``,
+  ragged arrays, inter-table references).
+- Named includes (a ``data_type_inc`` entry that also fixes a ``name``).
+- Inheritance roll-down (HDMFSL's recursive merging of parent fields into children).
+- Cross-namespace imports.
+- All LinkML features with no HDMFSL equivalent (enums, ontology URIs, rules,
+  conditional/cross-field validation, mixins, abstract classes).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ zarr = [
     "hdmf-zarr>=0.12.0",
 ]
 sparse = ["scipy>=1.7.2"]
+linkml = ["linkml-runtime>=1.11.1"]
 termset = [
     "linkml-runtime>=1.5.5",
     "schemasheets>=0.4.0rc1",
@@ -54,7 +55,7 @@ termset = [
 ]
 
 # all runtime optional dependencies
-all = ["hdmf[tqdm,zarr,sparse,termset]"]
+all = ["hdmf[tqdm,zarr,sparse,termset,linkml]"]
 
 [dependency-groups]
 # development dependencies

--- a/tests/unit/linkml_tests/fixtures/base.yaml
+++ b/tests/unit/linkml_tests/fixtures/base.yaml
@@ -1,0 +1,58 @@
+id: https://w3id.org/hdmf/test/base
+name: base
+title: Base data types
+description: base data types
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  base: https://w3id.org/hdmf/test/base/
+default_prefix: base
+
+imports:
+  - linkml:types
+  - hdmf-linkml-types
+
+classes:
+
+  Data:
+    description: An abstract data type for a dataset.
+    annotations:
+      spec_type: dataset
+    attributes:
+      name:
+        identifier: true
+        range: string
+        required: true
+
+  Container:
+    description: >-
+      An abstract data type for a group storing collections of data and metadata. Base type
+      for all data and metadata containers.
+    annotations:
+      spec_type: group
+    attributes:
+      name:
+        identifier: true
+        range: string
+        required: true
+
+  SimpleMultiContainer:
+    description: A simple Container for holding onto multiple containers.
+    is_a: Container
+    annotations:
+      spec_type: group
+    attributes:
+      data:
+        description: Data objects held within this SimpleMultiContainer.
+        range: Data
+        multivalued: true
+        inlined_as_list: true
+        annotations:
+          spec_type: dataset
+      container:
+        description: Container objects held within this SimpleMultiContainer.
+        range: Container
+        multivalued: true
+        inlined_as_list: true
+        annotations:
+          spec_type: group

--- a/tests/unit/linkml_tests/fixtures/hdmf-linkml-types.yaml
+++ b/tests/unit/linkml_tests/fixtures/hdmf-linkml-types.yaml
@@ -1,0 +1,126 @@
+id: https://w3id.org/hdmf/test/hdmf-linkml-types
+name: hdmf-linkml-types
+title: HDMF Schema Language dtypes
+description: >-
+  LinkML type definitions for the HDMF Schema Language (HDMFSL) dtypes. Each HDMFSL dtype
+  string is a distinct named type, so a slot's range name is the HDMFSL dtype string
+  verbatim. HDMFSL dtype synonyms (for example uint and uint32, or text and utf8) are
+  separate named types related by typeof, so the exact spelling used in the HDMFSL schema
+  survives the round trip.
+
+  The dtypes float, double, date, and datetime are not redefined here. LinkML's built-in
+  types of those names carry the same semantics (xsd:float is 32 bit, xsd:double is 64
+  bit), so they are used directly.
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  hdmf_types: https://w3id.org/hdmf/test/hdmf-linkml-types/
+default_prefix: hdmf_types
+
+imports:
+  - linkml:types
+
+types:
+
+  # floating point
+  float32:
+    typeof: float
+    description: Single precision floating point. Synonym of the HDMFSL dtype float.
+  float64:
+    typeof: double
+    description: Double precision floating point. Synonym of the HDMFSL dtype double.
+
+  # signed integers
+  int8:
+    typeof: integer
+    description: 8 bit signed integer.
+    minimum_value: -128
+    maximum_value: 127
+  int16:
+    typeof: integer
+    description: 16 bit signed integer.
+    minimum_value: -32768
+    maximum_value: 32767
+  short:
+    typeof: int16
+    description: Synonym of the HDMFSL dtype int16.
+  int32:
+    typeof: integer
+    description: 32 bit signed integer.
+    minimum_value: -2147483648
+    maximum_value: 2147483647
+  int:
+    typeof: int32
+    description: Synonym of the HDMFSL dtype int32.
+  int64:
+    typeof: integer
+    description: 64 bit signed integer.
+    minimum_value: -9223372036854775808
+    maximum_value: 9223372036854775807
+  long:
+    typeof: int64
+    description: Synonym of the HDMFSL dtype int64.
+
+  # unsigned integers
+  uint8:
+    typeof: integer
+    description: 8 bit unsigned integer.
+    minimum_value: 0
+    maximum_value: 255
+  uint16:
+    typeof: integer
+    description: 16 bit unsigned integer.
+    minimum_value: 0
+    maximum_value: 65535
+  uint32:
+    typeof: integer
+    description: 32 bit unsigned integer.
+    minimum_value: 0
+    maximum_value: 4294967295
+  uint:
+    typeof: uint32
+    description: Synonym of the HDMFSL dtype uint32.
+  uint64:
+    typeof: integer
+    description: 64 bit unsigned integer.
+    minimum_value: 0
+    maximum_value: 18446744073709551615
+
+  # text
+  text:
+    typeof: string
+    description: Unicode (UTF-8) text.
+  utf:
+    typeof: text
+    description: Synonym of the HDMFSL dtype text.
+  utf8:
+    typeof: text
+    description: Synonym of the HDMFSL dtype text.
+  utf-8:
+    typeof: text
+    description: Synonym of the HDMFSL dtype text.
+  ascii:
+    typeof: string
+    description: ASCII (byte string) text.
+  bytes:
+    typeof: ascii
+    description: Synonym of the HDMFSL dtype ascii.
+
+  # other scalars
+  bool:
+    typeof: boolean
+    description: Boolean.
+  numeric:
+    typeof: decimal
+    description: Any numeric dtype. The concrete dtype is not constrained.
+  isodatetime:
+    typeof: datetime
+    description: An ISO 8601 date and time.
+
+classes:
+
+  AnyType:
+    class_uri: linkml:Any
+    description: >-
+      The range of a dataset or attribute declared in HDMFSL with no dtype. The reader maps
+      a slot with range AnyType back to a Spec with dtype None.

--- a/tests/unit/linkml_tests/fixtures/namespace.yaml
+++ b/tests/unit/linkml_tests/fixtures/namespace.yaml
@@ -1,0 +1,32 @@
+id: https://w3id.org/hdmf/test
+name: hdmf-common-test
+title: HDMF Common Test
+description: >-
+  Minimal test namespace for the HDMF to LinkML round trip. It declares the same namespace
+  metadata as the hdmf-common namespace but references only base.yaml and sparse.yaml.
+version: 1.10.0
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  hdmf_common_test: https://w3id.org/hdmf/test/
+default_prefix: hdmf_common_test
+
+imports:
+  - linkml:types
+  - hdmf-linkml-types
+  - base
+  - sparse
+
+annotations:
+  # merged from the HDMFSL namespace author and contact lists, which are positionally
+  # one-to-one, so that each name stays bound to its email
+  authors:
+    value:
+      - name: Andrew Tritt
+        email: ajtritt@lbl.gov
+      - name: Oliver Ruebel
+        email: oruebel@lbl.gov
+      - name: Ryan Ly
+        email: rly@lbl.gov
+      - name: Ben Dichter
+        email: bdichter@lbl.gov

--- a/tests/unit/linkml_tests/fixtures/sparse.yaml
+++ b/tests/unit/linkml_tests/fixtures/sparse.yaml
@@ -1,0 +1,63 @@
+id: https://w3id.org/hdmf/test/sparse
+name: sparse
+title: Sparse data types
+description: data types for different types of sparse matrices
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  sparse: https://w3id.org/hdmf/test/sparse/
+default_prefix: sparse
+
+imports:
+  - linkml:types
+  - hdmf-linkml-types
+  - base
+
+classes:
+
+  CSRMatrix:
+    description: >-
+      A compressed sparse row matrix. Data are stored in the standard CSR format, where
+      column indices for row i are stored in indices[indptr[i]:indptr[i+1]] and their
+      corresponding values are stored in data[indptr[i]:indptr[i+1]].
+    is_a: Container
+    annotations:
+      spec_type: group
+    attributes:
+      shape:
+        description: The shape (number of rows, number of columns) of this sparse matrix.
+        range: uint
+        required: true
+        annotations:
+          spec_type: attribute
+        array:
+          dimensions:
+            - alias: number of rows, number of columns
+              exact_cardinality: 2
+      indices:
+        description: The column indices.
+        range: uint
+        required: true
+        annotations:
+          spec_type: dataset
+        array:
+          dimensions:
+            - alias: number of non-zero values
+      indptr:
+        description: The row index pointer.
+        range: uint
+        required: true
+        annotations:
+          spec_type: dataset
+        array:
+          dimensions:
+            - alias: number of rows in the matrix + 1
+      data:
+        description: The non-zero values in the matrix.
+        range: AnyType
+        required: true
+        annotations:
+          spec_type: dataset
+        array:
+          dimensions:
+            - alias: number of non-zero values

--- a/tests/unit/linkml_tests/test_fixtures.py
+++ b/tests/unit/linkml_tests/test_fixtures.py
@@ -1,0 +1,271 @@
+"""Tests for the hand-authored LinkML translation of the minimal hdmf-common test namespace.
+
+The fixtures in ``fixtures/`` are the LinkML translation of ``base.yaml`` and ``sparse.yaml``
+from the hdmf-common schema, following the conventions in ``docs/source/linkml_mapping.rst``.
+They are the reference the LinkML reader and writer are tested against, so these tests check
+that they are valid LinkML and that they carry every field of the HDMF ``Spec`` objects that
+HDMF loads natively from the equivalent HDMFSL schema.
+"""
+
+import os
+
+import pytest
+
+from hdmf.common import get_type_map
+from hdmf.spec import AttributeSpec, DatasetSpec, DtypeHelper, GroupSpec
+from hdmf.testing import TestCase
+
+try:
+    from linkml_runtime.utils.schemaview import SchemaView
+
+    REQUIREMENTS_INSTALLED = True
+except ImportError:
+    REQUIREMENTS_INSTALLED = False
+
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
+
+# the HDMFSL schema files the test namespace covers, and the data_type_defs in each
+TEST_NAMESPACE_TYPES = {
+    "base": ["Data", "Container", "SimpleMultiContainer"],
+    "sparse": ["CSRMatrix"],
+}
+
+# HDMFSL dtypes deferred with references and compound dtypes, so not defined in
+# hdmf-linkml-types
+DEFERRED_DTYPES = {"object"}
+
+# LinkML built-in types reused as-is for the HDMFSL dtypes of the same name
+BUILTIN_DTYPES = {"float", "double", "date", "datetime"}
+
+SPEC_TYPE_FOR_CLASS = {GroupSpec: "group", DatasetSpec: "dataset"}
+
+
+def fixture_path(name):
+    return os.path.join(FIXTURE_DIR, name + ".yaml")
+
+
+def annotation(element, tag):
+    """Return the value of an annotation on a LinkML element, or None if it is absent."""
+    ann = element.annotations.get(tag)
+    return None if ann is None else ann.value
+
+
+def native_specs():
+    """Return the Spec objects HDMF loads natively from the hdmf-common schema, by type name."""
+    catalog = get_type_map().namespace_catalog
+    names = [name for names in TEST_NAMESPACE_TYPES.values() for name in names]
+    return {name: catalog.get_spec("hdmf-common", name) for name in names}
+
+
+@pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
+class TestFixturesAreValidLinkML(TestCase):
+    """The fixtures are valid LinkML and resolve through the namespace-level schema."""
+
+    def test_each_schema_loads(self):
+        """Every fixture file loads under SchemaView on its own."""
+        for name in ["hdmf-linkml-types", "base", "sparse", "namespace"]:
+            with self.subTest(schema=name):
+                view = SchemaView(fixture_path(name))
+                self.assertIsNotNone(view.schema.id)
+                self.assertIsNotNone(view.schema.name)
+
+    def test_namespace_import_closure(self):
+        """The namespace schema imports the per-file schemas and resolves their classes."""
+        view = SchemaView(fixture_path("namespace"))
+        self.assertEqual(view.schema.name, "hdmf-common-test")
+        self.assertEqual(view.schema.version, "1.10.0")
+        for name in ["hdmf-linkml-types", "base", "sparse"]:
+            self.assertIn(name, view.schema.imports)
+        expected = {name for names in TEST_NAMESPACE_TYPES.values() for name in names}
+        self.assertTrue(expected.issubset(set(view.all_classes(imports=True))))
+
+    def test_every_range_resolves(self):
+        """Every slot range names a type or class that the import closure defines.
+
+        SchemaView does not report a range that names nothing, so it is checked here.
+        """
+        view = SchemaView(fixture_path("namespace"))
+        defined = set(view.all_types(imports=True)) | set(view.all_classes(imports=True))
+        for class_name, class_def in view.all_classes(imports=True).items():
+            for slot_name, slot in class_def.attributes.items():
+                with self.subTest(cls=class_name, slot=slot_name):
+                    self.assertIn(slot.range, defined)
+
+    def test_namespace_authors_annotation(self):
+        """The namespace author and contact lists are preserved as structured annotation values."""
+        view = SchemaView(fixture_path("namespace"))
+        authors = annotation(view.schema, "authors")
+        self.assertEqual(
+            authors,
+            [
+                {"name": "Andrew Tritt", "email": "ajtritt@lbl.gov"},
+                {"name": "Oliver Ruebel", "email": "oruebel@lbl.gov"},
+                {"name": "Ryan Ly", "email": "rly@lbl.gov"},
+                {"name": "Ben Dichter", "email": "bdichter@lbl.gov"},
+            ],
+        )
+
+
+@pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
+class TestDtypeCoverage(TestCase):
+    """hdmf-linkml-types covers the HDMFSL dtypes, keeping each synonym a distinct named type."""
+
+    def test_covers_every_hdmfsl_dtype(self):
+        """Every valid HDMFSL dtype string, including synonyms, resolves to a LinkML type."""
+        view = SchemaView(fixture_path("hdmf-linkml-types"))
+        available = set(view.all_types(imports=True))
+        expected = set(DtypeHelper.valid_primary_dtypes) - DEFERRED_DTYPES
+        self.assertEqual(expected - available, set())
+
+    def test_defines_only_the_dtypes_linkml_lacks(self):
+        """The dtypes LinkML already provides are reused rather than shadowed."""
+        view = SchemaView(fixture_path("hdmf-linkml-types"))
+        defined_here = set(view.schema.types)
+        expected = set(DtypeHelper.valid_primary_dtypes) - DEFERRED_DTYPES - BUILTIN_DTYPES
+        self.assertEqual(defined_here, expected)
+
+    def test_synonyms_are_distinct_types(self):
+        """Synonyms are separate named types, so the HDMFSL spelling survives the round trip."""
+        view = SchemaView(fixture_path("hdmf-linkml-types"))
+        for synonym, primary in [("uint", "uint32"), ("short", "int16"), ("long", "int64"),
+                                 ("int", "int32"), ("utf8", "text"), ("bytes", "ascii")]:
+            with self.subTest(dtype=synonym):
+                self.assertEqual(view.get_type(synonym).typeof, primary)
+
+    def test_any_type_is_defined(self):
+        """The no-dtype case has a range to point at."""
+        view = SchemaView(fixture_path("hdmf-linkml-types"))
+        self.assertEqual(view.get_class("AnyType").class_uri, "linkml:Any")
+
+
+@pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
+class TestFixturesCoverTheHDMFSLSchema(TestCase):
+    """Every field of the natively loaded Spec objects is represented in the fixtures.
+
+    These checks walk the Spec objects HDMF loads from the hdmf-common schema rather than a
+    hand-copied expectation, so a change to base.yaml or sparse.yaml that the fixtures do not
+    follow shows up as a failure here.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(fixture_path("namespace"))
+        cls.specs = native_specs()
+
+    @staticmethod
+    def sub_datasets(spec):
+        """Return the datasets entries of a spec. Only a GroupSpec can contain datasets."""
+        return spec.datasets if isinstance(spec, GroupSpec) else []
+
+    def get_slot(self, class_name, slot_name):
+        slot = self.view.get_class(class_name).attributes.get(slot_name)
+        self.assertIsNotNone(slot, msg="%s has no slot %s" % (class_name, slot_name))
+        return slot
+
+    def assert_array_matches(self, slot, spec, context):
+        """The slot's array expression carries the spec's dims and shape."""
+        if spec.dims is None:
+            self.assertIsNone(slot.array, msg=context)
+            return
+        self.assertIsNotNone(slot.array, msg="%s has no array expression" % context)
+        dimensions = slot.array.dimensions
+        self.assertEqual([d.alias for d in dimensions], list(spec.dims), msg=context)
+        self.assertEqual([d.exact_cardinality for d in dimensions], list(spec.shape), msg=context)
+
+    def assert_named_slot_matches(self, class_name, spec, spec_type):
+        """A named attribute or dataset maps to a slot whose range is its dtype."""
+        context = "%s.%s" % (class_name, spec.name)
+        slot = self.get_slot(class_name, spec.name)
+        self.assertEqual(slot.description, spec.doc, msg=context)
+        self.assertEqual(annotation(slot, "spec_type"), spec_type, msg=context)
+        self.assertEqual(slot.range, spec.dtype if spec.dtype is not None else "AnyType", msg=context)
+        self.assert_array_matches(slot, spec, context)
+
+    def assert_include_slot_matches(self, class_name, spec, spec_type):
+        """An unnamed data_type_inc maps to a slot whose range is the included type."""
+        context = "%s include of %s" % (class_name, spec.data_type_inc)
+        matches = [s for s in self.view.get_class(class_name).attributes.values()
+                   if s.range == spec.data_type_inc]
+        self.assertEqual(len(matches), 1, msg="%s: expected exactly one slot" % context)
+        slot = matches[0]
+        self.assertEqual(slot.description, spec.doc, msg=context)
+        self.assertEqual(annotation(slot, "spec_type"), spec_type, msg=context)
+        # quantity '*' is zero or more, so the slot is multivalued and not required
+        self.assertEqual(spec.quantity, "*", msg=context)
+        self.assertTrue(slot.multivalued, msg=context)
+        self.assertFalse(slot.required, msg=context)
+        self.assertTrue(slot.inlined_as_list, msg=context)
+
+    def test_every_type_def_has_a_class(self):
+        """Each data_type_def is a class carrying its doc, is_a, and spec_type."""
+        for name, spec in self.specs.items():
+            with self.subTest(type=name):
+                class_def = self.view.get_class(name)
+                self.assertIsNotNone(class_def)
+                self.assertEqual(class_def.description, spec.doc)
+                self.assertEqual(class_def.is_a, spec.data_type_inc)
+                self.assertEqual(annotation(class_def, "spec_type"), SPEC_TYPE_FOR_CLASS[type(spec)])
+
+    def test_root_classes_have_a_name_identifier(self):
+        """The classes with no is_a declare the name identifier slot the subclasses inherit."""
+        for name in ["Data", "Container"]:
+            with self.subTest(type=name):
+                slot = self.get_slot(name, "name")
+                self.assertTrue(slot.identifier)
+                self.assertEqual(slot.range, "string")
+                self.assertIsNone(annotation(slot, "spec_type"))
+        for name in ["SimpleMultiContainer", "CSRMatrix"]:
+            with self.subTest(type=name):
+                self.assertNotIn("name", self.view.get_class(name).attributes)
+
+    def test_every_attribute_has_a_slot(self):
+        """Each attributes entry is a slot tagged spec_type: attribute."""
+        for name, spec in self.specs.items():
+            for attribute in spec.attributes:
+                with self.subTest(type=name, attribute=attribute.name):
+                    self.assertIsInstance(attribute, AttributeSpec)
+                    self.assert_named_slot_matches(name, attribute, "attribute")
+                    slot = self.get_slot(name, attribute.name)
+                    self.assertEqual(bool(slot.required), attribute.required)
+
+    def test_every_dataset_has_a_slot(self):
+        """Each datasets entry is a slot tagged spec_type: dataset."""
+        for name, spec in self.specs.items():
+            for dataset in self.sub_datasets(spec):
+                with self.subTest(type=name, dataset=dataset.name or dataset.data_type_inc):
+                    if dataset.name is not None:
+                        self.assert_named_slot_matches(name, dataset, "dataset")
+                    else:
+                        self.assert_include_slot_matches(name, dataset, "dataset")
+
+    def test_every_group_has_a_slot(self):
+        """Each groups entry is a slot tagged spec_type: group."""
+        for name, spec in self.specs.items():
+            if not isinstance(spec, GroupSpec):
+                continue
+            for group in spec.groups:
+                with self.subTest(type=name, group=group.name or group.data_type_inc):
+                    self.assertIsNone(group.name, msg="named includes are out of scope")
+                    self.assert_include_slot_matches(name, group, "group")
+
+    def test_no_extra_slots(self):
+        """The fixtures add nothing beyond the name identifier and the spec's own constructs.
+
+        A slot the HDMFSL schema does not account for would become a Spec construct that the
+        native load does not produce, so the reader's Spec would not compare equal.
+        """
+        for name, spec in self.specs.items():
+            named = {c.name for c in list(spec.attributes) + list(self.sub_datasets(spec))
+                     if c.name is not None}
+            includes = {c.data_type_inc for c in
+                        list(self.sub_datasets(spec)) + list(spec.groups if isinstance(spec, GroupSpec) else [])
+                        if c.name is None}
+            for slot_name, slot in self.view.get_class(name).attributes.items():
+                with self.subTest(type=name, slot=slot_name):
+                    if slot.identifier:
+                        # the object's hierarchy name, not a declared attribute
+                        self.assertIsNone(spec.data_type_inc)
+                    elif slot.range in self.view.all_classes() and slot.range != "AnyType":
+                        self.assertIn(slot.range, includes)
+                    else:
+                        self.assertIn(slot_name, named)

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ extras =
     optional:  sparse
     optional:  zarr
     optional:  termset
+    optional:  linkml
 dependency_groups =
     # which dependency group(s) to use (default: none)
     pytest:    test


### PR DESCRIPTION
**Fixes #1487**
**Fixes #1488**

## Motivation

This adds the initial **HDMF ↔ LinkML mapping conventions** document together with the hand-authored LinkML translation of a minimal test namespace that applies them, the first two deliverables of the "Read and write LinkML schema for HDMF (CSRMatrix / base.yaml)" epic (#1486). Before any reader or writer is built, we need an agreed, written contract for how HDMF Schema Language (HDMFSL) constructs map to LinkML, and fixtures that prove the contract is real.

The two were originally separate issues. They are combined here because a conventions document that nothing has ever parsed is not a verifiable deliverable, and because running the conventions through `linkml-runtime` changed several of them. Fixing the doc before it merges is cheaper than amending it right after.

The scope is the constructs used by `base.yaml` (`Data`, `Container`, `SimpleMultiContainer`) and `sparse.yaml` (`CSRMatrix`), packaged as a minimal test namespace. What is out of scope is listed explicitly so the doc is not mistaken for a complete mapping.

## What is here

- `docs/source/linkml_mapping.rst`, added to the "Resources" toctree.
- LinkML fixtures in `tests/unit/linkml_tests/fixtures/`: `namespace.yaml`, `base.yaml`, `sparse.yaml`, and the companion `hdmf-linkml-types.yaml` defining the HDMFSL dtypes.
- A new `linkml` optional dependency group (`linkml-runtime`), wired into `all`, `tox.ini`, and the coverage workflow. The core install is unaffected and the tests skip when it is absent.
- `tests/unit/linkml_tests/test_fixtures.py`: the fixtures load under `SchemaView`, every range resolves, the dtype schema covers `DtypeHelper.valid_primary_dtypes`, and every field of the `Spec` objects HDMF loads natively from hdmf-common is present in the LinkML.

The coverage tests walk the natively loaded `Spec` objects rather than a hand-copied expectation, so a change to `base.yaml` or `sparse.yaml` that the fixtures do not follow fails here. The worked examples in the doc are `literalinclude`s of the fixture files, so the documented example cannot drift from what is tested.

## Conventions that changed once they were run through linkml-runtime

- The `name` identifier slot is declared once at each hierarchy root (`Data`, `Container`) and inherited via `is_a`. LinkML permits at most one identifier per class, so redeclaring it on every subclass was redundant.
- Every HDMFSL dtype string is its own named type, **synonyms included**. `Spec` stores whichever spelling the schema used, so collapsing `uint` onto `uint32` would rewrite the dtype on the way back and break the comparison. A synonym's `typeof` points at its primary, which records the synonym relationship in LinkML itself.
- `float`, `double`, `date`, and `datetime` are reused from `linkml:types` rather than redefined. They collide by name with LinkML built-ins whose semantics agree (`xsd:float` is 32 bit, `xsd:double` is 64 bit), and redefining them would shadow the built-ins for every schema in the import closure.
- `required` is always written explicitly on an attribute slot. HDMFSL defaults an attribute to required while LinkML defaults a slot to optional, so an omitted `required` would flip the meaning.
- `Spec` subclasses `dict` and inherits `dict` equality, so the comparison is over the keys actually present. The doc now states the two consequences for the reader: defaults stay absent (no `quantity: 1`, no explicit default `required`), and order within `attributes` / `datasets` / `groups` is preserved.
- Includes carry the HDMFSL `doc` as the slot `description`. The original example dropped it.
- Fixed `name` and `default_name` on a type map to `equals_string` and `ifabsent` on the identifier slot. Issue #1487 asked for these; neither is exercised by the types in scope, so both are stated as the convention.
- `AnyType` is called out as the one class range that does not mean a `data_type_inc`.

## How to test the behavior

```
pytest tests/unit/linkml_tests/
cd docs && sphinx-build -b html -W source _build/html
```

Verified: 14 tests pass (40 subtests), the full unit suite passes (1979 passed), the tests skip cleanly when `linkml-runtime` is not installed, ruff and codespell are clean, and the docs build with `-W` and 0 warnings.

## Checklist

- [x] Did you update `CHANGELOG.md`?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed the Contributing Guide?
- [x] Does the PR use "Fix #XXX" notation?
