### PR TITLE
Fix HERD.get_object_entities failing on a HERD read from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
-- Fixed `HERD.get_object_entities` (and other `_check_object_field(create=False)` paths) failing on a `HERD` read from a file. The `HERD` table row index columns (e.g. `files_idx`) are declared with schema dtype `uint`, so they come back as numpy unsigned integers, which the row column specs (typed `int`) rejected. The index column specs now also accept numpy integers, and `get_object_entities` coerces read-back entity rows (numpy structured-array `numpy.void`) to tuples so they expand into columns. @rly [#1496](https://github.com/hdmf-dev/hdmf/issues/1496)
+- Fixed `HERD.get_object_entities` (and other `_check_object_field(create=False)` paths) failing on a `HERD` read from a file. The `HERD` table row index columns (e.g. `files_idx`) are declared with schema dtype `uint`, so they come back as numpy unsigned integers, which the row column specs (typed `int`) rejected. The index column specs now also accept numpy integers, and `get_object_entities` coerces read-back entity rows (numpy structured-array `numpy.void`) to tuples so they expand into columns. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
-- Fixed `HERD.get_object_entities` (and other `_check_object_field(create=False)` paths) failing on a `HERD` read from a file. The `HERD` table row index columns (e.g. `files_idx`) are declared with schema dtype `uint`, so they come back as numpy unsigned integers, which the row column specs (typed `int`) rejected. The index column specs now also accept numpy integers, and `get_object_entities` coerces read-back entity rows (numpy structured-array `numpy.void`) to tuples so they expand into columns. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)
+- Fixed `HERD.get_object_entities` failing on a `HERD` read from a file, where index columns come back as numpy unsigned integers. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
+- Fixed `HERD.get_object_entities` (and other `_check_object_field(create=False)` paths) failing on a `HERD` read from a file. The `HERD` table row index columns (e.g. `files_idx`) are declared with schema dtype `uint`, so they come back as numpy unsigned integers, which the row column specs (typed `int`) rejected. The index column specs now also accept numpy integers, and `get_object_entities` coerces read-back entity rows (numpy structured-array `numpy.void`) to tuples so they expand into columns. @rly [#1496](https://github.com/hdmf-dev/hdmf/issues/1496)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -88,7 +88,7 @@ class ObjectTable(Table):
     __defaultname__ = 'objects'
 
     __columns__ = (
-        {'name': 'files_idx', 'type': int,
+        {'name': 'files_idx', 'type': (int, np.integer),
          'doc': 'The row idx for the file_object_id in FileTable containing the object.'},
         {'name': 'object_id', 'type': str,
          'doc': 'The object ID for the Container/Data.'},
@@ -119,9 +119,9 @@ class ObjectKeyTable(Table):
     __defaultname__ = 'object_keys'
 
     __columns__ = (
-        {'name': 'objects_idx', 'type': (int, Object),
+        {'name': 'objects_idx', 'type': (int, np.integer, Object),
          'doc': 'The index into the objects table for the Object that uses the Key.'},
-        {'name': 'keys_idx', 'type': (int, Key),
+        {'name': 'keys_idx', 'type': (int, np.integer, Key),
          'doc': 'The index into the keys table that is used to make an external resource reference.'}
     )
 
@@ -134,9 +134,9 @@ class EntityKeyTable(Table):
     __defaultname__ = 'entity_keys'
 
     __columns__ = (
-        {'name': 'entities_idx', 'type': (int, Entity),
+        {'name': 'entities_idx', 'type': (int, np.integer, Entity),
          'doc': 'The index into the EntityTable for the Entity that associated with the Key.'},
-        {'name': 'keys_idx', 'type': (int, Key),
+        {'name': 'keys_idx', 'type': (int, np.integer, Key),
          'doc': 'The index into the KeyTable that is used to make an external resource reference.'}
     )
 
@@ -289,7 +289,7 @@ class HERD(Container):
 
     @docval({'name': 'container', 'type': (str, AbstractContainer),
              'doc': 'The Container/Data object to add or the object id of the Container/Data object to add.'},
-            {'name': 'files_idx', 'type': int,
+            {'name': 'files_idx', 'type': (int, np.integer),
              'doc': 'The file_object_id row idx.'},
             {'name': 'object_type', 'type': str, 'default': None,
              'doc': ('The type of the object. This is also the parent in relative_path. If omitted, '
@@ -317,8 +317,8 @@ class HERD(Container):
         obj = Object(files_idx, container, object_type, relative_path, field, table=self.objects)
         return obj
 
-    @docval({'name': 'obj', 'type': (int, Object), 'doc': 'The Object that uses the Key.'},
-            {'name': 'key', 'type': (int, Key), 'doc': 'The Key that the Object uses.'})
+    @docval({'name': 'obj', 'type': (int, np.integer, Object), 'doc': 'The Object that uses the Key.'},
+            {'name': 'key', 'type': (int, np.integer, Key), 'doc': 'The Key that the Object uses.'})
     def _add_object_key(self, **kwargs):
         """
         Specify that an object (i.e. container and relative_path) uses a key to reference
@@ -327,8 +327,8 @@ class HERD(Container):
         obj, key = popargs('obj', 'key', kwargs)
         return ObjectKey(obj, key, table=self.object_keys)
 
-    @docval({'name': 'entity', 'type': (int, Entity), 'doc': 'The Entity associated with the Key.'},
-            {'name': 'key', 'type': (int, Key), 'doc': 'The Key that the connected to the Entity.'})
+    @docval({'name': 'entity', 'type': (int, np.integer, Entity), 'doc': 'The Entity associated with the Key.'},
+            {'name': 'key', 'type': (int, np.integer, Key), 'doc': 'The Key that the connected to the Entity.'})
     def _add_entity_key(self, **kwargs):
         """
         Add entity-key relationship to the EntityKeyTable.
@@ -893,7 +893,9 @@ class HERD(Container):
             entity_key_row_idx = self.entity_keys.which(keys_idx=key_idx)
             for row_idx in entity_key_row_idx:
                 entity_idx = self.entity_keys['entities_idx', row_idx]
-                entities.append(self.entities.__getitem__(entity_idx))
+                # coerce the row to a tuple so a read-back numpy structured-array row
+                # (numpy.void) expands into columns the same as an in-memory list row
+                entities.append(tuple(self.entities[entity_idx]))
         df = pd.DataFrame(entities, columns=['entity_id', 'entity_uri'])
         return df
 

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -1,8 +1,9 @@
 import pandas as pd
 import unittest
-from hdmf.common import DynamicTable, VectorData, get_type_map
+from hdmf.common import DynamicTable, VectorData, get_type_map, get_manager
 from hdmf.common import CORE_NAMESPACE as HDMF_COMMON_NAMESPACE
 from hdmf import TermSet, TermSetWrapper
+from hdmf.backends.hdf5 import HDF5IO
 from hdmf.common.resources import HERD, Key
 from hdmf import Data, Container, HERDManager
 from hdmf.testing import TestCase, remove_test_file
@@ -632,6 +633,42 @@ class TestHERD(TestCase):
              'entity_uri': {0: 'entity1'}}
         expected_df = pd.DataFrame.from_dict(expected_df_data)
 
+        pd.testing.assert_frame_equal(df, expected_df)
+
+    def test_get_obj_entities_hdf5_roundtrip(self):
+        """Regression test for #1496: idx columns are read back as numpy unsigned ints.
+
+        After an HDF5 round-trip the objects table's ``files_idx`` (schema dtype ``uint``)
+        comes back as a numpy ``uint``. Building an ``Object`` row from it, as
+        ``get_object_entities`` does via ``_check_object_field(create=False)``, must accept
+        the numpy integer rather than rejecting it as not a Python ``int``.
+        """
+        er = HERD()
+        data = Data(name="species", data=['Homo sapiens'])
+        file = HERDManagerContainer(name='file')
+        er.add_ref(file=file,
+                   container=data,
+                   key='Homo sapiens',
+                   entity_id='NCBI_TAXON:9606',
+                   entity_uri='http://x')
+
+        path = 'test_HERD_hdf5_roundtrip.h5'
+        try:
+            with HDF5IO(path, manager=get_manager(), mode='w') as io:
+                io.write(er)
+            with HDF5IO(path, manager=get_manager(), mode='r') as io:
+                read_er = io.read()
+                # files_idx is read back as a numpy unsigned int (schema dtype is uint)
+                self.assertIsInstance(read_er.objects['files_idx', 0], np.unsignedinteger)
+                # the same file and container (matched by object_id) resolve the persisted rows
+                df = read_er.get_object_entities(file=file, container=data)
+        finally:
+            remove_test_file(path)
+
+        expected_df = pd.DataFrame.from_dict(
+            {'entity_id': {0: 'NCBI_TAXON:9606'},
+             'entity_uri': {0: 'http://x'}}
+        )
         pd.testing.assert_frame_equal(df, expected_df)
 
     def test_get_obj_entities_file_none_container(self):


### PR DESCRIPTION
## Motivation

Fixes #1496.

`HERD.get_object_entities()` (and any code path through `HERD._check_object_field(..., create=False)`) raised a `TypeError` when the `HERD` was read back from a file, while the same call worked on an in-memory `HERD`:

```
TypeError: Row.__build_row_class.<locals>.__init__: incorrect type for 'files_idx' (got 'uint32', expected 'int')
```

### Root cause

The `HERD` table row index columns (`files_idx`, `objects_idx`, `keys_idx`, `entities_idx`) are declared with schema dtype `uint`, so they come back as numpy unsigned integers after an HDF5 round-trip. docval's `int` check accepts Python `int` and signed numpy ints, but deliberately excludes unsigned numpy ints, so constructing an `Object` row from a persisted `files_idx` failed.

A second bug was masked by the first: `get_object_entities` failed at the `files_idx` lookup before ever reaching the entities loop. Once the type check passes, the loop hit `self.entities[idx]` returning a numpy structured-array row (`numpy.void`), which `pd.DataFrame` cannot expand into two columns.

## How to test the behavior

Added `test_get_obj_entities_hdf5_roundtrip` in `tests/unit/common/test_resources.py`, which writes a `HERD` via `HDF5IO`, reads it back, asserts `files_idx` returns as `np.unsignedinteger`, and checks `get_object_entities` returns the expected frame. The existing `H5RoundTripMixin` would not catch this since it only does container equality and never calls `get_object_entities`.

## Changes

- Accept numpy integers in the index column specs (`(int, np.integer)`) and the internal `_add_object` / `_add_object_key` / `_add_entity_key` docvals.
- Coerce read-back entity rows to tuples in `get_object_entities` so a `numpy.void` row expands into columns like an in-memory list row.

The schema dtype is left as `uint` (correct for non-negative indices); the fix narrows the gap between the API row specs and what the schema produces on read.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)