### PR TITLE
Fix HERD entity_keys equality check and file lookup error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
+- Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1498](https://github.com/hdmf-dev/hdmf/issues/1498)
+- Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1499](https://github.com/hdmf-dev/hdmf/issues/1499)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
-- Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1498](https://github.com/hdmf-dev/hdmf/issues/1498)
-- Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1499](https://github.com/hdmf-dev/hdmf/issues/1499)
+- Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
+- Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -202,7 +202,7 @@ class HERD(Container):
     @staticmethod
     def assert_external_resources_equal(left, right, check_dtype=True):
         """
-        Compare that the keys, resources, entities, objects, and object_keys tables match
+        Compare that the keys, files, entities, objects, object_keys, and entity_keys tables match
 
         :param left: HERD object to compare with right
         :param right: HERD object to compare with left
@@ -243,6 +243,12 @@ class HERD(Container):
         try:
             pd.testing.assert_frame_equal(left.object_keys.to_dataframe(),
                                           right.object_keys.to_dataframe(),
+                                          check_dtype=check_dtype)
+        except AssertionError as e:
+            errors.append(e)
+        try:
+            pd.testing.assert_frame_equal(left.entity_keys.to_dataframe(),
+                                          right.entity_keys.to_dataframe(),
                                           check_dtype=check_dtype)
         except AssertionError as e:
             errors.append(e)
@@ -409,16 +415,14 @@ class HERD(Container):
             return file
         else:
             parent = container.parent
-            if parent is not None:
-                while parent is not None:
-                    if isinstance(parent, HERDManager):
-                        file = parent
-                        return file
-                    else:
-                        parent = parent.parent
-            else:
-                msg = 'Could not find file. Add container to the file.'
-                raise ValueError(msg)
+            while parent is not None:
+                if isinstance(parent, HERDManager):
+                    file = parent
+                    return file
+                else:
+                    parent = parent.parent
+            msg = 'Could not find file. Add container to the file.'
+            raise ValueError(msg)
 
     @docval({'name': 'objects', 'type': list,
              'doc': 'List of objects to check for TermSetWrapper within the fields.'})

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -152,16 +152,20 @@ class TestHERD(TestCase):
                                                                           er_right))
 
     def test_invalid_keys_assert_external_resources_equal(self):
+        # use the same file and container so that only the keys table differs
+        file = HERDManagerContainer(name='file')
+        container = Container(name='Container')
+
         er_left = HERD()
-        er_left.add_ref(file=HERDManagerContainer(name='file'),
-                        container=Container(name='Container'),
+        er_left.add_ref(file=file,
+                        container=container,
                         key='key1',
                         entity_id="id11",
                         entity_uri='url11')
 
         er_right = HERD()
-        er_right.add_ref(file=HERDManagerContainer(name='file'),
-                         container=Container(name='Container'),
+        er_right.add_ref(file=file,
+                         container=container,
                          key='invalid',
                          entity_id="id11",
                          entity_uri='url11')
@@ -171,16 +175,19 @@ class TestHERD(TestCase):
                                                               er_right)
 
     def test_invalid_objects_assert_external_resources_equal(self):
+        # use the same file but different containers so that only the objects table differs
+        file = HERDManagerContainer(name='file')
+
         er_left = HERD()
-        er_left.add_ref(file=HERDManagerContainer(name='file'),
-                        container=Container(name='Container'),
+        er_left.add_ref(file=file,
+                        container=Container(name='Container1'),
                         key='key1',
                         entity_id="id11",
                         entity_uri='url11')
 
         er_right = HERD()
-        er_right.add_ref(file=HERDManagerContainer(name='file'),
-                         container=Container(name='Container'),
+        er_right.add_ref(file=file,
+                         container=Container(name='Container2'),
                          key='key1',
                          entity_id="id11",
                          entity_uri='url11')
@@ -190,16 +197,20 @@ class TestHERD(TestCase):
                                                               er_right)
 
     def test_invalid_entity_assert_external_resources_equal(self):
+        # use the same file and container so that only the entities table differs
+        file = HERDManagerContainer(name='file')
+        container = Container(name='Container')
+
         er_left = HERD()
-        er_left.add_ref(file=HERDManagerContainer(name='file'),
-                        container=Container(name='Container'),
+        er_left.add_ref(file=file,
+                        container=container,
                         key='key1',
                         entity_id="invalid",
                         entity_uri='invalid')
 
         er_right = HERD()
-        er_right.add_ref(file=HERDManagerContainer(name='file'),
-                         container=Container(name='Container'),
+        er_right.add_ref(file=file,
+                         container=container,
                          key='key1',
                          entity_id="id11",
                          entity_uri='url11')
@@ -209,20 +220,25 @@ class TestHERD(TestCase):
                                                               er_right)
 
     def test_invalid_object_keys_assert_external_resources_equal(self):
+        # use the same file and container so that only the object_keys table differs
+        file = HERDManagerContainer(name='file')
+        container = Container(name='Container')
+
         er_left = HERD()
-        er_left.add_ref(file=HERDManagerContainer(name='file'),
-                        container=Container(name='Container'),
-                        key='invalid',
+        er_left.add_ref(file=file,
+                        container=container,
+                        key='key1',
                         entity_id="id11",
                         entity_uri='url11')
 
         er_right = HERD()
-        er_right._add_key('key')
-        er_right.add_ref(file=HERDManagerContainer(name='file'),
-                         container=Container(name='Container'),
+        er_right.add_ref(file=file,
+                         container=container,
                          key='key1',
                          entity_id="id11",
                          entity_uri='url11')
+        # add a spurious object-key relationship so that only the object_keys table differs
+        er_right._add_object_key(er_right.objects.row[0], er_right.keys.row[0])
 
         with self.assertRaises(AssertionError):
             HERD.assert_external_resources_equal(er_left,

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -228,6 +228,31 @@ class TestHERD(TestCase):
             HERD.assert_external_resources_equal(er_left,
                                                               er_right)
 
+    def test_invalid_entity_keys_assert_external_resources_equal(self):
+        # use the same file and container so that every table except entity_keys is identical
+        file = HERDManagerContainer(name='file')
+        container = Container(name='Container')
+
+        er_left = HERD()
+        er_left.add_ref(file=file,
+                        container=container,
+                        key='key1',
+                        entity_id="id11",
+                        entity_uri='url11')
+
+        er_right = HERD()
+        er_right.add_ref(file=file,
+                         container=container,
+                         key='key1',
+                         entity_id="id11",
+                         entity_uri='url11')
+        # add a spurious entity-key relationship so that only the entity_keys table differs
+        er_right._add_entity_key(er_right.entities.row[0], er_right.keys.row[0])
+
+        with self.assertRaises(AssertionError):
+            HERD.assert_external_resources_equal(er_left,
+                                                              er_right)
+
     def test_add_ref_search_for_file(self):
         em = HERDManagerContainer()
         er = HERD()
@@ -526,6 +551,16 @@ class TestHERD(TestCase):
 
         with self.assertRaises(ValueError):
             er._get_file_from_container(container)
+
+    def test_get_file_from_container_no_herdmanager_ancestor_error(self):
+        # container has a parent chain but no HERDManager ancestor
+        parent = Container(name='parent')
+        child = Container(name='child')
+        child.parent = parent
+        er = HERD()
+
+        with self.assertRaises(ValueError):
+            er._get_file_from_container(child)
 
     def test_add_ref(self):
         er = HERD()


### PR DESCRIPTION
## Motivation

Fixes #1498 and #1499. Two correctness bugs found while reviewing the `HERD` implementation.

### #1498 — `assert_external_resources_equal` ignored `entity_keys`

`HERD.assert_external_resources_equal` compared the `keys`, `files`, `objects`, `entities`, and `object_keys` tables but omitted `entity_keys` entirely. Two `HERD` objects differing only in their entity↔key relationships compared as equal. Because this helper is used in tests, round-trip and equality tests silently did not validate `entity_keys`.

### #1499 — `_get_file_from_container` returned `None` instead of raising

The `ValueError("Could not find file. Add container to the file.")` only fired when the container had no parent. If the container had a parent chain but none of the ancestors was a `HERDManager`, the loop exhausted and the method returned `None`, so callers hit a confusing `AttributeError: 'NoneType' object has no attribute 'object_id'`. The `raise` now runs whenever no `HERDManager` ancestor is found.

## How to test the behavior

Added two regression tests in `tests/unit/common/test_resources.py`:
- `test_invalid_entity_keys_assert_external_resources_equal` builds two HERDs identical in every table except `entity_keys` (same file and container, with one spurious entity-key row) and asserts they compare unequal.
- `test_get_file_from_container_no_herdmanager_ancestor_error` asserts `ValueError` for a container with ancestors but no `HERDManager`.

Both tests fail on `dev` and pass with this change (verified by stashing the source fix and re-running).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)