### PR TITLE
Fix HERD.get_object_entities(attribute=...) to mirror add_ref(attribute=...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
+- Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)
+- Fixed `HERD.get_key` failing with an `AttributeError` instead of a clear error when called with a container that has not been added to the object table. It now raises `ValueError("Object not in Object Table.")`. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)
 - Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD.get_object_entities` failing on a `HERD` read from a file, where index columns come back as numpy unsigned integers. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -352,15 +352,20 @@ class HERD(Container):
              'default': ''},
             {'name': 'field', 'type': str, 'default': '',
              'doc': ('The field of the compound data type using an external resource.')},
-            {'name': 'create', 'type': bool, 'default': True})
+            {'name': 'create', 'type': bool, 'default': False,
+             'doc': ('If the object is missing, create and return a dict that add_ref can use to add it to the '
+                     'tables. The created dict misses the idx key since the entry does not yet exist in HERD.')})
     def _check_object_field(self, **kwargs):
         """
         Check if a container, relative path, and field have been added.
 
-        The container can be either an object_id string or an AbstractContainer.
+        The following cases may occur:
+          1. If a single, corresponding object is found, then return that object from ``self.objects.row``.
+          2. If the container, relative_path, and field have not been added yet and ``create`` is True, then
+             return a new dict that add_ref can use to create the object. The returned dict misses the idx key
+             since the object has not been created yet.
 
-        If the container, relative_path, and field have not been added, add them
-        and return the corresponding Object. Otherwise, just return the Object.
+        :raises ValueError: If the object is missing and ``create`` is False, or if multiple matching objects exist.
         """
         file = kwargs['file']
         container = kwargs['container']
@@ -547,7 +552,24 @@ class HERD(Container):
         if len(missing_terms)>0:
             return {"missing_terms": missing_terms}
 
-    def _validate_object(self, container, attribute, field, file, create=True):
+    def _validate_object(self, container, attribute, field, file, create=False):
+        """
+        Resolve the object that an external reference is attached to and return it via ``_check_object_field``.
+
+        The ``attribute`` is resolved to the container and relative_path that identify the referenced object:
+          - ``attribute`` is None: the reference is on the container itself (relative_path '').
+          - ``attribute`` names a DataType (an AbstractContainer): the reference is on that sub-container.
+          - ``attribute`` names a non-DataType attribute (e.g. ``DynamicTable.description``): the reference is on the
+            nearest container ancestor of the attribute spec, with the relative_path computed from the spec path.
+
+        :param container: The Container/Data object that the reference is attached to.
+        :param attribute: The name of the attribute on the container, or None for the container itself.
+        :param field: The field of a compound data type using an external resource, or '' if not applicable.
+        :param file: The HERDManager file associated with the container.
+        :param create: Passed to ``_check_object_field``. If True and the object is missing, return a dict that
+                       add_ref can use to add it; if False, a missing object raises a ValueError.
+        :returns: The matching object from ``self.objects.row``, or (when ``create`` is True) a dict for add_ref.
+        """
         if attribute is None:  # Trivial Case
             relative_path = ''
             object_field = self._check_object_field(file=file,
@@ -698,7 +720,7 @@ class HERD(Container):
                        % (entity_uri, entity.entity_uri, entity_id))
                 warn(msg, stacklevel=3)
 
-        object_field = self._validate_object(container, attribute, field, file)
+        object_field = self._validate_object(container, attribute, field, file, create=True)
 
         #######################################
         # Validate Parameters and Populate HERD
@@ -898,16 +920,14 @@ class HERD(Container):
             object_field = self._check_object_field(file=file,
                                                     container=container,
                                                     relative_path=relative_path,
-                                                    field=field,
-                                                    create=False)
+                                                    field=field)
         else:
             # resolve the attribute the same way add_ref does so that a reference added with an
             # attribute can be retrieved with the same attribute
             object_field = self._validate_object(container=container,
                                                  attribute=attribute,
                                                  field=field,
-                                                 file=file,
-                                                 create=False)
+                                                 file=file)
         # Find all keys associated with the object
         for row_idx in self.object_keys.which(objects_idx=object_field.idx):
             keys.append(self.object_keys['keys_idx', row_idx])

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -544,13 +544,14 @@ class HERD(Container):
         if len(missing_terms)>0:
             return {"missing_terms": missing_terms}
 
-    def _validate_object(self, container, attribute, field, file):
+    def _validate_object(self, container, attribute, field, file, create=True):
         if attribute is None:  # Trivial Case
             relative_path = ''
             object_field = self._check_object_field(file=file,
                                                     container=container,
                                                     relative_path=relative_path,
-                                                    field=field)
+                                                    field=field,
+                                                    create=create)
         else:  # DataType Attribute Case
             attribute_object = getattr(container, attribute)  # returns attribute object
             if isinstance(attribute_object, AbstractContainer):
@@ -558,7 +559,8 @@ class HERD(Container):
                 object_field = self._check_object_field(file=file,
                                                         container=attribute_object,
                                                         relative_path=relative_path,
-                                                        field=field)
+                                                        field=field,
+                                                        create=create)
             else:  # Non-DataType Attribute Case:
                 obj_mapper = self.type_map.get_map(container)
                 spec = obj_mapper.get_attr_spec(attr_name=attribute)
@@ -575,7 +577,8 @@ class HERD(Container):
                         object_field = self._check_object_field(file=file,
                                                                 container=parent,
                                                                 relative_path=relative_path,
-                                                                field=field)
+                                                                field=field,
+                                                                create=create)
                     else:
                         msg = 'Container not the nearest data_type'
                         raise ValueError(msg)
@@ -587,7 +590,8 @@ class HERD(Container):
                     object_field = self._check_object_field(file=file,
                                                             container=parent,
                                                             relative_path=relative_path,
-                                                            field=field)
+                                                            field=field,
+                                                            create=create)
         return object_field
 
 
@@ -880,11 +884,13 @@ class HERD(Container):
                                                     field=field,
                                                     create=False)
         else:
-            object_field = self._check_object_field(file=file,
-                                                    container=container[attribute],
-                                                    relative_path=relative_path,
-                                                    field=field,
-                                                    create=False)
+            # resolve the attribute the same way add_ref does so that a reference added with an
+            # attribute can be retrieved with the same attribute
+            object_field = self._validate_object(container=container,
+                                                 attribute=attribute,
+                                                 field=field,
+                                                 file=file,
+                                                 create=False)
         # Find all keys associated with the object
         for row_idx in self.object_keys.which(objects_idx=object_field.idx):
             keys.append(self.object_keys['keys_idx', row_idx])

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -1437,7 +1437,8 @@ class TestHERD(TestCase):
         _dict = er._check_object_field(file=file,
                                container=data,
                                relative_path='',
-                               field='')
+                               field='',
+                               create=True)
         expected = {'file_object_id': file.object_id,
                     'files_idx': None,
                     'container': data,
@@ -1734,6 +1735,17 @@ class TestHERDGetKey(TestCase):
         msg = "No key found with that container."
         with self.assertRaisesWith(ValueError, msg):
             _ = self.er.get_key(key_name='key2', container=container1, file=file)
+
+    def test_get_key_container_not_in_table(self):
+        # a container that has never been added must raise a clear error rather than failing
+        # while resolving the (non-existent) object's idx
+        file = HERDManagerContainer()
+        container1 = Container(name='Container')
+        container1.parent = file
+
+        msg = "Object not in Object Table."
+        with self.assertRaisesWith(ValueError, msg):
+            _ = self.er.get_key(key_name='key1', container=container1, file=file)
 
 
 class TestHERDNamespace(TestCase):

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -729,6 +729,33 @@ class TestHERD(TestCase):
 
         pd.testing.assert_frame_equal(df, expected_df)
 
+    def test_get_obj_entities_non_datatype_attribute(self):
+        # a reference added with a non-DataType attribute (stored with a computed relative_path)
+        # must be retrievable with the same attribute
+        table = DynamicTable(name='table', description='table')
+        table.add_column(name='col1', description="column")
+        table.add_row(id=0, col1='data')
+
+        file = HERDManagerContainer(name='file')
+
+        er = HERD()
+        er.add_ref(file=file,
+                   container=table,
+                   attribute='description',
+                   key='key1',
+                   entity_id='entity_0',
+                   entity_uri='entity_0_uri')
+        df = er.get_object_entities(file=file,
+                                    container=table,
+                                    attribute='description')
+
+        expected_df_data = \
+            {'entity_id': {0: 'entity_0'},
+             'entity_uri': {0: 'entity_0_uri'}}
+        expected_df = pd.DataFrame.from_dict(expected_df_data)
+
+        pd.testing.assert_frame_equal(df, expected_df)
+
     def test_to_and_from_zip(self):
         er = HERD()
         data = Data(name="species", data=['Homo sapiens', 'Mus musculus'])


### PR DESCRIPTION
## Motivation

Fixes #1501.

`HERD.add_ref(container=..., attribute=...)` and `HERD.get_object_entities(container=..., attribute=...)` resolved the `attribute` argument differently, so a reference added with an `attribute` could not be read back with the same `attribute`:

- `add_ref` routes through `_validate_object`, which for a non-DataType attribute (e.g. `DynamicTable.description`) stores the parent container under a computed `relative_path`.
- `get_object_entities` instead did `container[attribute]` with the default `relative_path=''`, which raises `KeyError` (or `TypeError` for containers without `__getitem__`) for non-DataType attributes.

## Solution

`_validate_object` now takes a `create` flag and threads it to its `_check_object_field` calls. `get_object_entities` reuses `_validate_object(..., create=False)` for the attribute case, so both methods resolve the attribute identically.

The `attribute=None` path in `get_object_entities` is unchanged, so directly passing `relative_path` still works.

## How to test the behavior

Added `test_get_obj_entities_non_datatype_attribute`: adds a ref with `attribute='description'` and retrieves it with the same attribute. It fails on `dev` (`KeyError: 'description'`) and passes with this change. The existing `test_get_obj_entities_attribute` (DataType-attribute / column case) continues to pass.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)