### PR TITLE
Fix HERD.from_zip to honor the type map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HDMF 6.0.3 (Upcoming)
 
 ### Fixed
+- Fixed `HERD.from_zip` ignoring the type map. It now constructs the result with `cls` (so subclasses such as `pynwb.resources.HERD` get their own type map) and accepts an optional `type_map` argument. Previously a HERD loaded from a zip archive always used the default type map, so attribute-based `add_ref` on containers of non-default types (e.g. NWB types via pynwb) raised `AttributeError: 'NoneType' object has no attribute 'parent'`. @rly [#1506](https://github.com/hdmf-dev/hdmf/pull/1506)
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 
 ## HDMF 6.0.2 (May 15, 2026)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -1001,12 +1001,14 @@ class HERD(Container):
         return directory
 
     @classmethod
-    @docval({'name': 'path', 'type': str, 'doc': 'The path to the zip file.'})
+    @docval({'name': 'path', 'type': str, 'doc': 'The path to the zip file.'},
+            {'name': 'type_map', 'type': TypeMap, 'default': None,
+             'doc': 'The TypeMap to use for the returned HERD. If None, the default TypeMap is used.'})
     def from_zip(cls, **kwargs):  # noqa: C901
         """
         Method to read in zipped tsv files to populate HERD.
         """
-        zip_file = kwargs['path']
+        zip_file, type_map = popargs('path', 'type_map', kwargs)
         directory = cls.get_zip_directory(zip_file)
 
         with zipfile.ZipFile(zip_file, 'r') as zip:
@@ -1077,12 +1079,13 @@ class HERD(Container):
                 msg = "Key Index out of range in EntityKeyTable. Please check for alterations."
                 raise ValueError(msg)
 
-        er = HERD(
+        er = cls(
             files=files,
             keys=keys,
             entities=entities,
             entity_keys=entity_keys,
             objects=objects,
-            object_keys=object_keys
+            object_keys=object_keys,
+            type_map=type_map,
         )
         return er

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -744,6 +744,40 @@ class TestHERD(TestCase):
 
         self.remove_er_files()
 
+    def test_from_zip_with_type_map(self):
+        er = HERD()
+        data = Data(name="species", data=['Homo sapiens', 'Mus musculus'])
+        er.add_ref(file=HERDManagerContainer(name='file'),
+                   container=data,
+                   key='key1',
+                   entity_id='entity_id1',
+                   entity_uri='entity1')
+        er.to_zip(path='./HERD.zip')
+
+        type_map = get_type_map()
+        er_read = HERD.from_zip(path='./HERD.zip', type_map=type_map)
+        self.assertIs(er_read.type_map, type_map)
+
+        self.remove_er_files()
+
+    def test_from_zip_uses_cls(self):
+        class SubHERD(HERD):
+            pass
+
+        er = SubHERD()
+        data = Data(name="species", data=['Homo sapiens', 'Mus musculus'])
+        er.add_ref(file=HERDManagerContainer(name='file'),
+                   container=data,
+                   key='key1',
+                   entity_id='entity_id1',
+                   entity_uri='entity1')
+        er.to_zip(path='./HERD.zip')
+
+        er_read = SubHERD.from_zip(path='./HERD.zip')
+        self.assertIsInstance(er_read, SubHERD)
+
+        self.remove_er_files()
+
     def test_get_zip_directory(self):
         er = HERD()
         data = Data(name="species", data=['Homo sapiens', 'Mus musculus'])


### PR DESCRIPTION
## Motivation

Fixes #1505.

`HERD.from_zip` hardcoded constructing the base `HERD` class with the default type map and did not accept a `type_map` argument. As a result, a HERD loaded from a zip archive always used the default type map, and attribute-based `add_ref` on containers of non-default types (e.g. NWB types via pynwb's `HERD` subclass) raised `AttributeError: 'NoneType' object has no attribute 'parent'`.

This PR constructs the result with `cls` so subclasses get their own type map, and adds an optional `type_map` argument to `from_zip`.

### Why the `cls` change is load-bearing for PyNWB

PyNWB subclasses `HERD` (`pynwb.resources.HERD`) and overrides `__init__` to inject the pynwb `TypeMap`, so that HERD can resolve NWB types (e.g. `NWBFile`, `Subject`) for attribute-based `add_ref`:

```python
class HERD(hdmf_HERD):
    @docval(*get_docval(hdmf_HERD.__init__), allow_positional=AllowPositional.WARNING)
    def __init__(self, **kwargs):
        kwargs['type_map'] = tm()  # pynwb type map
        super().__init__(**kwargs)
```

Because the old `from_zip` built `er = HERD(...)` (the hdmf class) rather than `cls(...)`, calling `pynwb.resources.HERD.from_zip(...)` bypassed this subclass entirely and returned a plain `hdmf.common.resources.HERD` with the default type map. Switching to `cls(...)` makes `from_zip` polymorphic, so the subclass's `__init__` runs, the pynwb type map is injected, and attribute-based `add_ref` works on a loaded HERD. (The optional `type_map` argument is a secondary path for generic hdmf users with a custom `TypeMap`; pynwb's `__init__` forces its own type map regardless.)

## How to test the behavior?

```python
from hdmf.common import HERD, get_type_map

class SubHERD(HERD):
    pass

# from_zip now returns the subclass and accepts a type_map
er = HERD()
# ... add_ref, then er.to_zip(path="./HERD.zip") ...
loaded = SubHERD.from_zip(path="./HERD.zip")            # instance of SubHERD
loaded = HERD.from_zip(path="./HERD.zip", type_map=get_type_map())  # uses the given type map
```

New unit tests `test_from_zip_with_type_map` and `test_from_zip_uses_cls` cover both paths.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
