### PR TITLE
Minor HERD cleanups (dead assignment, files dataframe hoist)

### DIFF
--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -673,7 +673,6 @@ class HERD(Container):
             # for this entity and key combination.
             check_entity_key = True
             if entity_uri is not None:
-                entity_uri = entity.entity_uri
                 msg = 'This entity already exists. Ignoring new entity uri'
                 warn(msg, stacklevel=3)
 
@@ -947,8 +946,9 @@ class HERD(Container):
         result_df.reset_index(inplace=True, drop=True)
         # ADD files
         file_id_col = []
+        files_df = self.files.to_dataframe()
         for idx in result_df['files_idx']:
-            file_id_val = self.files.to_dataframe().iloc[int(idx)]['file_object_id']
+            file_id_val = files_df.iloc[int(idx)]['file_object_id']
             file_id_col.append(file_id_val)
 
         result_df['file_object_id'] = file_id_col


### PR DESCRIPTION
## Motivation

Addresses items 1 and 2 of #1503. Two behavior-preserving cleanups in `src/hdmf/common/resources.py`.

## Changes

1. **`add_ref`**: removed the dead `entity_uri = entity.entity_uri` assignment in the existing-entity branch. In that branch the entity is reused and `_add_entity` is never called, so the reassigned value is never read. The "This entity already exists. Ignoring new entity uri" warning is unchanged.
2. **`to_dataframe`**: build `self.files.to_dataframe()` once before the `file_object_id` loop instead of rebuilding it on every iteration.

## Out of scope

Item 3 of #1503 (the O(n^2) repeated `which()` scans during population) is a non-trivial performance refactor rather than a cleanup, so it is intentionally left out of this PR. **#1503 is left open** to track it.

## How to test the behavior

No behavior change. Existing tests cover both touched paths: `test_to_dataframe` (the dataframe build) and `test_entity_uri_warning` (the existing-entity warning branch). Full `tests/unit/common/test_resources.py` passes (61 passed, 10 skipped).

## Checklist

- [ ] Did you update CHANGELOG.md with your changes? Not applicable: internal cleanups with no user-visible behavior change.
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)