### PR TITLE
Add HERD repr/_repr_html_ surfacing references as a flattened table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HDMF 6.0.3 (Upcoming)
 
+### Enhancements
+- Added a `HERD`-specific `__repr__` and `_repr_html_` that surface the references as a flattened table, so a `HERD` (especially one read back from a file) no longer appears empty in its default display. @rly [#1510](https://github.com/hdmf-dev/hdmf/pull/1510)
+
 ### Fixed
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -970,6 +970,50 @@ class HERD(Container):
         # return the result
         return result_df
 
+    def __flattened_dataframe_or_none(self):
+        """Return the flattened ``to_dataframe()`` view, or None when there are no references.
+
+        ``to_dataframe`` raises when the HERD holds no object-key relationships and may fail if the
+        backing file is closed. The repr methods use this helper so they never raise on display.
+        """
+        if len(self.object_keys) == 0:
+            return None
+        try:
+            return self.to_dataframe()
+        except Exception:
+            return None
+
+    def __summary_line(self):
+        """Return a one-line summary of the table sizes."""
+        return ("%d key(s), %d entity(ies), %d object(s), %d file(s)"
+                % (len(self.keys), len(self.entities), len(self.objects), len(self.files)))
+
+    def __repr__(self):
+        cls = self.__class__
+        template = "%s %s.%s at 0x%d" % (self.name, cls.__module__, cls.__name__, id(self))
+        template += "\n  " + self.__summary_line()
+        df = self.__flattened_dataframe_or_none()
+        if df is not None and len(df) > 0:
+            template += "\n" + repr(df)
+        return template
+
+    def _repr_html_(self):
+        """Generate an HTML representation that surfaces the references as a flattened table."""
+        header_text = self.name if self.name == self.__class__.__name__ else \
+            f"{self.name} ({self.__class__.__name__})"
+        html_repr = self.css_style + self.js_script
+        html_repr += "<div class='container-wrap'>"
+        html_repr += f"<div class='container-header'><div class='xr-obj-type'><h3>{header_text}</h3></div></div>"
+        html_repr += self._closed_file_warning_html()
+        html_repr += f"<p class='container-fields'>{self.__summary_line()}</p>"
+        df = self.__flattened_dataframe_or_none()
+        if df is None or len(df) == 0:
+            html_repr += "<p class='container-fields'>No external resource references.</p>"
+        else:
+            html_repr += df.to_html()
+        html_repr += "</div>"
+        return html_repr
+
     @docval({'name': 'path', 'type': str, 'doc': 'The path to the zip file.'})
     def to_zip(self, **kwargs):
         """

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -131,6 +131,27 @@ class TestHERD(TestCase):
                                           'entities_idx': 'uint32'})
         pd.testing.assert_frame_equal(result_df, expected_df)
 
+    def test_repr_empty(self):
+        er = HERD()
+        # repr and HTML repr must not raise on an empty HERD (to_dataframe raises when empty)
+        self.assertIn('0 key(s)', repr(er))
+        html = er._repr_html_()
+        self.assertIn('No external resource references', html)
+
+    def test_repr_populated(self):
+        er = HERD()
+        er.add_ref(file=HERDManagerContainer(name='file'),
+                   container=Container(name='Container'),
+                   key='Mus musculus',
+                   entity_id='NCBI_TAXON:10090',
+                   entity_uri='http://x')
+        text = repr(er)
+        self.assertIn('1 key(s), 1 entity(ies), 1 object(s), 1 file(s)', text)
+        # the HTML repr surfaces the flattened table content
+        html = er._repr_html_()
+        self.assertIn('NCBI_TAXON:10090', html)
+        self.assertIn('http://x', html)
+
     def test_assert_external_resources_equal(self):
         file = HERDManagerContainer(name='file')
         ref_container_1 = Container(name='Container_1')


### PR DESCRIPTION
## Motivation

Fixes #1508.

`HERD` inherits the generic `Container._repr_html_`, which renders its six child tables as nested collapsibles. For a `HERD` read back from a file these can appear empty at first glance, even though the data is present and accessible via `to_dataframe()` and the individual tables. The PyNWB HERD tutorial (NeurodataWithoutBorders/pynwb#2200) currently has to warn users about this. The underlying need was raised in NeurodataWithoutBorders/nwb-schema#652.

## Solution

Add a `HERD`-specific `__repr__` and `_repr_html_` that show a one-line summary (table sizes) plus the flattened `to_dataframe()` view (one row per object/key/entity association). The display falls back gracefully:
- empty HERD: shows "No external resource references." (`to_dataframe` raises when there are no object-key rows, so the helper guards on that);
- closed backing file or any `to_dataframe` failure: the existing closed-file warning banner is preserved and the table is omitted rather than raising (a repr must never raise).

Display only; no change to stored data or table APIs.

## Screenshot

The `_repr_html_` of a populated `HERD`, rendered as a Jupyter output cell:

![HERD _repr_html_ rendered in a Jupyter output cell](https://raw.githubusercontent.com/hdmf-dev/hdmf/assets/pr-1510-herd-repr/herd_repr.png)

## How to test the behavior

Added `test_repr_empty` and `test_repr_populated` in `tests/unit/common/test_resources.py` (empty HERD reprs do not raise and say "No external resource references"; a populated HERD surfaces the summary line and the entity content in the HTML repr). Full `tests/unit/common/test_resources.py` passes (63 passed, 10 skipped).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
