### PR TITLE
HERD.add_ref: default key to a scalar attribute's value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HDMF 6.0.3 (Upcoming)
 
+### Enhancements
+- `HERD.add_ref` now defaults `key` to the value of a scalar string `attribute` when `key` is not provided, removing the redundant argument in the common case. @rly [#1511](https://github.com/hdmf-dev/hdmf/pull/1511)
+
 ### Fixed
 - Fixed reading an anonymous (unnamed) typed link whose target is a subtype of the link's `target_type`. During construct, links were matched to their spec by exact data type, so a subtype target (e.g. a `Device` subtype linked through `ndx-pose`'s `PoseEstimation.devices`) was dropped and the field came back as `None`. Links are now indexed across their full type hierarchy, matching the behavior already used for sub-groups. @rly [#1482](https://github.com/hdmf-dev/hdmf/pull/1482)
 

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -599,7 +599,9 @@ class HERD(Container):
             {'name': 'field', 'type': str, 'default': '',
              'doc': ('The field of the compound data type using an external resource.')},
             {'name': 'key', 'type': (str, Key), 'default': None,
-             'doc': 'The name of the key or the Key object from the KeyTable for the key to add a resource for.'},
+             'doc': ('The name of the key or the Key object from the KeyTable for the key to add a resource for. '
+                     'If not provided and ``attribute`` names a scalar string attribute, the value of that '
+                     'attribute is used as the key.')},
             {'name': 'entity_id', 'type': str, 'doc': 'The identifier for the entity at the resource.'},
             {'name': 'entity_uri', 'type': str, 'doc': 'The URI for the identifier at the resource.', 'default': None},
             {'name': 'file',  'type': HERDManager, 'doc': 'The file associated with the container.',
@@ -625,6 +627,21 @@ class HERD(Container):
         entity_id = kwargs['entity_id']
         entity_uri = kwargs['entity_uri']
         file = kwargs['file']
+
+        ##########################################
+        # Default the key from a scalar attribute
+        ##########################################
+        if key is None and attribute is not None:
+            if not isinstance(container, AbstractContainer):
+                msg = ("Cannot default 'key' from attribute '%s' because 'container' is not a "
+                       "Container/Data object. Provide 'key' explicitly." % attribute)
+                raise ValueError(msg)
+            attribute_value = getattr(container, attribute)
+            if not isinstance(attribute_value, str):
+                msg = ("Cannot default 'key' from attribute '%s' because its value is not a single "
+                       "string. Provide 'key' explicitly." % attribute)
+                raise ValueError(msg)
+            key = attribute_value
 
         ##################
         # Set File if None

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -539,6 +539,48 @@ class TestHERD(TestCase):
         self.assertEqual(er.entities.data, [('entity_id1', 'entity1')])
         self.assertEqual(er.objects.data, [(0, data.object_id, 'Data', '', '')])
 
+    def test_add_ref_default_key_from_scalar_attribute(self):
+        # key defaults to the value of a scalar string attribute when not provided
+        table = DynamicTable(name='table', description='a table description')
+        file = HERDManagerContainer(name='file')
+
+        er = HERD()
+        er.add_ref(file=file,
+                   container=table,
+                   attribute='description',
+                   entity_id='entity_id1',
+                   entity_uri='entity1')
+        self.assertEqual(er.keys.data, [('a table description',)])
+        self.assertEqual(er.objects.data, [(0, table.object_id, 'DynamicTable', 'description', '')])
+
+    def test_add_ref_explicit_key_overrides_attribute_value(self):
+        table = DynamicTable(name='table', description='a table description')
+        file = HERDManagerContainer(name='file')
+
+        er = HERD()
+        er.add_ref(file=file,
+                   container=table,
+                   attribute='description',
+                   key='explicit',
+                   entity_id='entity_id1',
+                   entity_uri='entity1')
+        self.assertEqual(er.keys.data, [('explicit',)])
+
+    def test_add_ref_default_key_non_scalar_attribute_error(self):
+        # a column (non-scalar) attribute cannot supply a key; require it explicitly
+        table = DynamicTable(name='table', description='a table description')
+        table.add_column(name='col1', description='column')
+        table.add_row(id=0, col1='data')
+        file = HERDManagerContainer(name='file')
+
+        er = HERD()
+        with self.assertRaises(ValueError):
+            er.add_ref(file=file,
+                       container=table,
+                       attribute='col1',
+                       entity_id='entity_id1',
+                       entity_uri='entity1')
+
     def test_get_object_type(self):
         er = HERD()
         file = HERDManagerContainer(name='file')


### PR DESCRIPTION
## Motivation

Fixes #1509.

In `HERD.add_ref`, the `key` argument almost always duplicates the value being annotated:

```python
add_ref(container=subject, attribute="strain", key="C57BL/6J", entity_id=..., entity_uri=...)
```

When `attribute` names a scalar string attribute, the `key` is just the value at that attribute, so requiring it is redundant. This was raised in the usability discussion at NeurodataWithoutBorders/nwb-schema#652.

## Solution

When `add_ref` is called with an `attribute` but no `key`, default `key` to `getattr(container, attribute)` if that value is a string:

```python
add_ref(container=subject, attribute="strain", entity_id="RRID:IMSR_JAX:000664",
        entity_uri="https://www.jax.org/strain/000664")
```

Scope and safety:
- Only applies when the resolved attribute value is a string. A column/array attribute (e.g. a `DynamicTable` column) or a non-`Container` container raises a clear `ValueError` asking for an explicit `key`, rather than guessing.
- Explicit `key` still takes precedence (backward compatible).
- Behavior when no `attribute` is given is unchanged (`key` still required).

## How to test the behavior

Added tests in `tests/unit/common/test_resources.py`:
- `test_add_ref_default_key_from_scalar_attribute` (key derived from `DynamicTable.description`),
- `test_add_ref_explicit_key_overrides_attribute_value`,
- `test_add_ref_default_key_non_scalar_attribute_error` (column attribute raises).

Full `tests/unit/common/test_resources.py` passes (64 passed, 10 skipped).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This will be checked during CI.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/hdmf-dev/hdmf/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)