### PR TITLE
Require AbstractContainer for HERD container args; drop dead object_id string option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `HERD.add_ref` no longer warns when an `entity_uri` is provided for an already-existing `entity_id` and the URI matches the stored one. The entity tables are normalized, so re-passing the same `entity_uri` (common when annotating many objects or files with the same entity) is harmless; a warning is now emitted only when a *different* `entity_uri` is provided, in which case the existing URI is kept. @bendichter [#1513](https://github.com/hdmf-dev/hdmf/pull/1513)
 
 ### Fixed
-- Removed the never-functional `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
+- Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD.get_object_entities` failing on a `HERD` read from a file, where index columns come back as numpy unsigned integers. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `HERD.add_ref` no longer warns when an `entity_uri` is provided for an already-existing `entity_id` and the URI matches the stored one. The entity tables are normalized, so re-passing the same `entity_uri` (common when annotating many objects or files with the same entity) is harmless; a warning is now emitted only when a *different* `entity_uri` is provided, in which case the existing URI is kept. @bendichter [#1513](https://github.com/hdmf-dev/hdmf/pull/1513)
 
 ### Fixed
+- Removed the never-functional `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.assert_external_resources_equal` not comparing the `entity_keys` table, so HERDs differing only in entity-key relationships compared as equal. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD._get_file_from_container` returning `None` instead of raising `ValueError` when a container has ancestors but none is a `HERDManager`. @rly [#1500](https://github.com/hdmf-dev/hdmf/pull/1500)
 - Fixed `HERD.get_object_entities` failing on a `HERD` read from a file, where index columns come back as numpy unsigned integers. @rly [#1497](https://github.com/hdmf-dev/hdmf/pull/1497)

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -344,8 +344,7 @@ class HERD(Container):
 
     @docval({'name': 'file',  'type': HERDManager, 'doc': 'The file associated with the container.'},
             {'name': 'container', 'type': AbstractContainer,
-             'doc': ('The Container/Data object that uses the key or '
-                     'the object id for the Container/Data object that uses the key.')},
+             'doc': 'The Container/Data object that uses the key.'},
             {'name': 'relative_path', 'type': str,
              'doc': ('The relative_path of the attribute of the object that uses ',
                      'an external resource reference key. Use an empty string if not applicable.'),
@@ -356,8 +355,6 @@ class HERD(Container):
     def _check_object_field(self, **kwargs):
         """
         Check if a container, relative path, and field have been added.
-
-        The container can be either an object_id string or an AbstractContainer.
 
         If the container, relative_path, and field have not been added, add them
         and return the corresponding Object. Otherwise, just return the Object.
@@ -482,9 +479,8 @@ class HERD(Container):
 
     @docval({'name': 'file',  'type': HERDManager, 'doc': 'The file associated with the container.',
              'default': None},
-            {'name': 'container', 'type': (str, AbstractContainer), 'default': None,
-             'doc': ('The Container/Data object that uses the key or '
-                     'the object_id for the Container/Data object that uses the key.')},
+            {'name': 'container', 'type': AbstractContainer, 'default': None,
+             'doc': 'The Container/Data object that uses the key.'},
             {'name': 'attribute', 'type': str,
              'doc': 'The attribute of the container for the external reference.', 'default': None},
             {'name': 'field', 'type': str, 'default': '',
@@ -595,9 +591,8 @@ class HERD(Container):
         return object_field
 
 
-    @docval({'name': 'container', 'type': (str, AbstractContainer), 'default': None,
-             'doc': ('The Container/Data object that uses the key or '
-                     'the object_id for the Container/Data object that uses the key.')},
+    @docval({'name': 'container', 'type': AbstractContainer, 'default': None,
+             'doc': 'The Container/Data object that uses the key.'},
             {'name': 'attribute', 'type': str,
              'doc': 'The attribute of the container for the external reference.', 'default': None},
             {'name': 'field', 'type': str, 'default': '',
@@ -785,9 +780,8 @@ class HERD(Container):
     @docval({'name': 'key_name', 'type': str, 'doc': 'The name of the Key to get.'},
             {'name': 'file', 'type': HERDManager, 'doc': 'The file associated with the container.',
              'default': None},
-            {'name': 'container', 'type': (str, AbstractContainer), 'default': None,
-             'doc': ('The Container/Data object that uses the key or '
-                     'the object id for the Container/Data object that uses the key.')},
+            {'name': 'container', 'type': AbstractContainer, 'default': None,
+             'doc': 'The Container/Data object that uses the key.'},
             {'name': 'relative_path', 'type': str,
              'doc': ('The relative_path of the attribute of the object that uses ',
                      'an external resource reference key. Use an empty string if not applicable.'),
@@ -873,7 +867,7 @@ class HERD(Container):
 
     @docval({'name': 'file',  'type': HERDManager, 'doc': 'The file.',
              'default': None},
-            {'name': 'container', 'type': (str, AbstractContainer),
+            {'name': 'container', 'type': AbstractContainer,
              'doc': 'The Container/data object that is linked to resources/entities.'},
             {'name': 'attribute', 'type': str,
              'doc': 'The attribute of the container for the external reference.', 'default': None},


### PR DESCRIPTION
## Motivation

Spun out of the review of #1512. The `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities` is typed `(str, AbstractContainer)` and documented as accepting "the object_id for the Container/Data object", but a string container has never worked: every path funnels through `HERD._check_object_field`, whose docval requires an `AbstractContainer` and which dereferences `container.object_id`. Passing a string therefore raised a confusing error from deep in the call stack (e.g. `AttributeError: 'str' object has no attribute 'parent'` or an inner-method type error) rather than a clear message at the public boundary.

Empirically, on `dev`, every combination of a string `container` fails:

| Call | Result |
|------|--------|
| `add_ref(file=f, container="obj-id", ...)` | `TypeError` from `_check_object_field` |
| `add_ref(container="obj-id", ...)` (no file) | `AttributeError: 'str' object has no attribute 'parent'` |
| `get_key(file=f, container="obj-id", ...)` | `TypeError` from `_check_object_field` |
| `get_object_entities(file=f, container="obj-id", ...)` | `TypeError` from `_check_object_field` |

## Changes

- Narrowed the `container` type on `add_ref`, `add_ref_termset`, `get_key`, and `get_object_entities` from `(str, AbstractContainer)` to `AbstractContainer`, and dropped the inaccurate "or the object_id" wording from their docs.
- Removed the contradictory docstring/doc line in `_check_object_field` claiming a container "can be either an object_id string or an AbstractContainer" (its docval already required `AbstractContainer`).

A string `container` is now rejected with a clear, argument-named docval error, e.g.:

```
TypeError: HERD.add_ref: incorrect type for 'container' (got 'str', expected 'AbstractContainer')
```

The low-level private `_add_object` (which genuinely handles a string object_id) and `_get_file_from_container` are unchanged.

## Note

This narrows accepted types but is not a breaking change in practice: a string `container` always raised, so no working call is affected.

## Verification

- `tests/unit/common/test_resources.py` and `tests/unit/test_io_hdf5_h5tools.py::TestHERDIO`: pass
- `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)