### PR TITLE
Use PyPI trusted publishing and gh CLI for releases

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -16,13 +16,13 @@ jobs:
       contents: write  # create the GitHub release
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.14'
 
@@ -53,7 +53,7 @@ jobs:
         # Publishes to PyPI via OIDC trusted publishing. The hdmf project on PyPI must have a trusted
         # publisher configured for the hdmf-dev/hdmf repository, the deploy_release.yml workflow, and the
         # pypi environment.
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           skip-existing: true
 

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout repo with submodules
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
@@ -61,7 +62,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" dist/* \
-            --repo hdmf-dev/hdmf \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
+          # Use this version's CHANGELOG.md section as the release notes, falling back to
+          # auto-generated notes if no matching section is found (e.g. a heading/tag mismatch).
+          awk -v hdr="## HDMF ${GITHUB_REF_NAME}" '
+            index($0, hdr) == 1 { f = 1; next }
+            f && /^## / { exit }
+            f { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ -s release_notes.md ]; then
+            gh release create "${GITHUB_REF_NAME}" dist/* \
+              --repo hdmf-dev/hdmf \
+              --title "${GITHUB_REF_NAME}" \
+              --notes-file release_notes.md
+          else
+            echo "No CHANGELOG.md section found for ${GITHUB_REF_NAME}; using auto-generated notes."
+            gh release create "${GITHUB_REF_NAME}" dist/* \
+              --repo hdmf-dev/hdmf \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -8,6 +8,12 @@ jobs:
   deploy-release:
     name: Deploy release from tag
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hdmf
+    permissions:
+      id-token: write  # mint the OIDC token for PyPI trusted publishing
+      contents: write  # create the GitHub release
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v7
@@ -44,15 +50,18 @@ jobs:
           tox -e wheelinstall --installpkg dist/*.tar.gz
 
       - name: Upload wheel and source distributions to PyPI
-        run: |
-          python -m pip install twine
-          ls -1 dist
-          # twine upload --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_TEST_PYPI_PASSWORD }} --skip-existing dist/*
-          twine upload -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
+        # Publishes to PyPI via OIDC trusted publishing. The hdmf project on PyPI must have a trusted
+        # publisher configured for the hdmf-dev/hdmf repository, the deploy_release.yml workflow, and the
+        # pypi environment.
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          skip-existing: true
 
       - name: Publish wheel and source distributions as a GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          python -m pip install "githubrelease>=1.5.9"
-          githubrelease --github-token ${{ secrets.BOT_GITHUB_TOKEN }} release hdmf-dev/hdmf \
-            create ${{ github.ref_name }} --name ${{ github.ref_name }} \
-            --publish dist/*
+          gh release create "${{ github.ref_name }}" dist/* \
+            --repo hdmf-dev/hdmf \
+            --title "${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
## Motivation

Modernize the release publishing path in `deploy_release.yml` (suggestions 1 + 4 from the DevOps infra review):

1. **PyPI trusted publishing (OIDC).** The PyPI upload used `twine upload -u <user> -p <password>` with a long-lived password stored as a secret and passed on the command line (visible in the process list). It now uses `pypa/gh-action-pypi-publish` with OIDC trusted publishing: short-lived, no stored credentials. The job declares `id-token: write` and runs in a dedicated `pypi` environment.
4. **Drop stale release tooling.** The GitHub release was created with `githubrelease` (a lightly maintained third-party CLI installed at release time). It now uses the `gh` CLI that ships on the runner, authenticated with the built-in `GITHUB_TOKEN` (`contents: write`) instead of `BOT_GITHUB_TOKEN`, and the release body is generated from the changelog (see Notes).

## ⚠️ Required one-time setup before the next release

**edit: Done**

PyPI trusted publishing will not work until a trusted publisher is configured **on PyPI** (this cannot be done from the repo):

- PyPI → `hdmf` project → Settings → Publishing → Add a new GitHub publisher:
  - Owner: `hdmf-dev`, Repository: `hdmf`
  - Workflow: `deploy_release.yml`
  - Environment: `pypi`

After this, the `BOT_PYPI_USER` / `BOT_PYPI_PASSWORD` secrets can be removed.

## Notes / things to confirm

- The GitHub release is now authored by `github-actions[bot]` rather than the bot PAT account. No workflow triggers on `release:` events, so losing the PAT's ability to trigger downstream workflows is not a concern here.
- The GitHub release notes are built automatically from this version's `CHANGELOG.md` section (the block under `## HDMF <tag>`), so the post-release "paste the changelog into the release" step is no longer needed. It falls back to `--generate-notes` if no matching section is found.
- The `deploy-dev` pre-release job in `run_tests.yml` still uses `scikit-ci-addons`; its rolling pre-release logic is more involved and is left for a separate change.

## How to test the behavior?
```
Cannot be fully exercised without a tag push + the PyPI trusted publisher configured.
Verified: YAML parses; the publish/release steps are standard, documented usages of
pypa/gh-action-pypi-publish and the gh CLI.
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes? (CI-only change; no user-facing entry)
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our Contributing Guide?
- [ ] Does the PR use "Fix #XXX" notation? (no associated issue)
