### PR TITLE
Harden GitHub Actions: permissions, SHA pins, composite action, zizmor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -3,6 +3,9 @@ Prepare for release of HDMF [version]
 ### Before merging:
 - [ ] Make sure all PRs to be included in this release have been merged to `dev`.
 - [ ] Major and minor releases: Update dependency ranges in `pyproject.toml` as needed.
+- [ ] Update the GitHub Actions used in the workflows to their latest versions. Pin each action to a
+  full commit SHA, except actions that publish immutable releases, which may use a version tag (see
+  `.github/zizmor.yml` for the policy).
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `pyproject.toml` as needed

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -27,8 +27,8 @@ Prepare for release of HDMF [version]
 
 ### After merging:
 1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
-2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
-   [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) with the changelog
+2. After the CI bot creates the new release (wait ~10 min), verify that the release notes on the
+   [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) include the changelog for this version
 3. Check that the readthedocs "stable" build runs and succeeds
 4. Either monitor [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock) for the
    regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within

--- a/.github/actions/setup-python-tox/action.yml
+++ b/.github/actions/setup-python-tox/action.yml
@@ -1,0 +1,24 @@
+name: Set up Python and tox
+description: Set up the requested Python version with pip caching and install tox.
+
+inputs:
+  python-version:
+    description: Python version to pass to actions/setup-python.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: pyproject.toml
+
+    - name: Install tox
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+        python -m pip list

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      # Wait a week after a new action version is published before opening a PR,
+      # so a freshly published (potentially compromised) version is not adopted immediately.
+      default-days: 7

--- a/.github/workflows/check_sphinx_links.yml
+++ b/.github/workflows/check_sphinx_links.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-sphinx-links:
     runs-on: ubuntu-latest
@@ -13,13 +16,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.13'  # TODO: Update to 3.14 when linkml and its deps support 3.14
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,12 +3,17 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -72,7 +72,7 @@ jobs:
           if grep -q '[^[:space:]]' release_notes.md; then
             notes_args=(--notes-file release_notes.md)
           else
-            echo "No CHANGELOG.md section found for ${GITHUB_REF_NAME}; using auto-generated notes."
+            echo "No release notes found in CHANGELOG.md for ${GITHUB_REF_NAME}; using auto-generated notes."
             notes_args=(--generate-notes)
           fi
           # Create the release, or upload the artifacts to it if a re-run finds it already exists,

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -63,21 +63,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Use this version's CHANGELOG.md section as the release notes, falling back to
-          # auto-generated notes if no matching section is found (e.g. a heading/tag mismatch).
+          # auto-generated notes if no matching section with content is found (e.g. a heading/tag mismatch).
           awk -v hdr="## HDMF ${GITHUB_REF_NAME}" '
             index($0, hdr) == 1 { f = 1; next }
             f && /^## / { exit }
             f { print }
           ' CHANGELOG.md > release_notes.md
-          if [ -s release_notes.md ]; then
-            gh release create "${GITHUB_REF_NAME}" dist/* \
-              --repo hdmf-dev/hdmf \
-              --title "${GITHUB_REF_NAME}" \
-              --notes-file release_notes.md
+          if grep -q '[^[:space:]]' release_notes.md; then
+            notes_args=(--notes-file release_notes.md)
           else
             echo "No CHANGELOG.md section found for ${GITHUB_REF_NAME}; using auto-generated notes."
+            notes_args=(--generate-notes)
+          fi
+          # Create the release, or upload the artifacts to it if a re-run finds it already exists,
+          # so the step can be re-run safely.
+          if gh release view "${GITHUB_REF_NAME}" --repo hdmf-dev/hdmf > /dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" dist/* --repo hdmf-dev/hdmf --clobber
+          else
             gh release create "${GITHUB_REF_NAME}" dist/* \
               --repo hdmf-dev/hdmf \
               --title "${GITHUB_REF_NAME}" \
-              --generate-notes
+              "${notes_args[@]}"
           fi

--- a/.github/workflows/project_action.yml
+++ b/.github/workflows/project_action.yml
@@ -17,7 +17,8 @@ jobs:
         id: generate_token
         # The token is used to add issues to the org-level project boards, which the default GITHUB_TOKEN
         # cannot reach; its scope is bounded by the GitHub App's own installed permissions.
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0  # zizmor: ignore[github-app]
+        # immutable release (see .github/zizmor.yml for the policy exception)
+        uses: actions/create-github-app-token@v3.2.0  # zizmor: ignore[github-app]
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}

--- a/.github/workflows/project_action.yml
+++ b/.github/workflows/project_action.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to project
@@ -12,7 +15,9 @@ jobs:
     steps:
       - name: GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@v3
+        # The token is used to add issues to the org-level project boards, which the default GITHUB_TOKEN
+        # cannot reach; its scope is bounded by the GitHub App's own installed permissions.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0  # zizmor: ignore[github-app]
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
@@ -20,7 +25,7 @@ jobs:
       - name: Add to Developer Board
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-        uses: actions/add-to-project@v2.0.0
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/hdmf-dev/projects/7
           github-token: ${{ env.TOKEN }}
@@ -28,7 +33,7 @@ jobs:
       - name: Add to Community Board
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-        uses: actions/add-to-project@v2.0.0
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/hdmf-dev/projects/8
           github-token: ${{ env.TOKEN }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,6 +13,5 @@ jobs:
         with:
           persist-credentials: false
       - name: Run ruff
-        # astral-sh/ruff-action publishes immutable releases, so it is pinned to a version tag
-        # (allowed by the unpinned-uses policy in .github/zizmor.yml).
+        # immutable release (see .github/zizmor.yml for the policy exception)
         uses: astral-sh/ruff-action@v4.0.0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,11 +1,16 @@
 name: Ruff
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run ruff
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,4 +13,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Run ruff
-        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
+        # astral-sh/ruff-action publishes immutable releases, so it is pinned to a version tag
+        # (allowed by the unpinned-uses policy in .github/zizmor.yml).
+        uses: astral-sh/ruff-action@v4.0.0

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -7,6 +7,9 @@ on:
       - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-all-tests:
     # the only differences between this job and "run_tests.yml" is the "strategy.matrix.include" and the upload
@@ -54,21 +57,16 @@ jobs:
           - { name: macos-python3.13-prerelease-optional   , test-tox-env: pytest-py313-prerelease-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and tox
+        uses: ./.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          python -m pip list
 
       - name: Run tox tests
         run: |
@@ -112,21 +110,16 @@ jobs:
           - { name: macos-gallery-python3.13-prerelease-optional   , test-tox-env: gallery-py313-prerelease-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and tox
+        uses: ./.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          python -m pip list
 
       - name: Run tox tests
         run: |
@@ -150,13 +143,14 @@ jobs:
           - { name: macos-python3.14-ros3   , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           auto-update-conda: true
           activate-environment: ros3

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -70,7 +70,8 @@ jobs:
           pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        # immutable release (see .github/zizmor.yml for the policy exception)
+        uses: codecov/codecov-action@v7.0.0
         with:
           fail_ci_if_error: true
           files: ./coverage.xml
@@ -125,7 +126,8 @@ jobs:
           python -m pytest --cov --cov-report=xml --cov-report=term tests/unit/test_io_hdf5_streaming.py
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        # immutable release (see .github/zizmor.yml for the policy exception)
+        uses: codecov/codecov-action@v7.0.0
         with:
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-coverage:
     name: ${{ matrix.os }}, opt reqs ${{ matrix.opt_req }}
@@ -34,13 +37,14 @@ jobs:
       PYTHON: '3.13'  # TODO: Update to 3.14 when linkml and its deps support 3.14
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: ${{ env.PYTHON }}
 
@@ -66,7 +70,7 @@ jobs:
           pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           fail_ci_if_error: true
           files: ./coverage.xml
@@ -89,13 +93,14 @@ jobs:
           - { name: linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           auto-update-conda: true
           activate-environment: ros3
@@ -120,7 +125,7 @@ jobs:
           python -m pytest --cov --cov-report=xml --cov-report=term tests/unit/test_io_hdf5_streaming.py
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           fail_ci_if_error: true
           files: ./coverage.xml

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-hdmf-zarr-tests:
     runs-on: ubuntu-latest
@@ -13,13 +16,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.14'
 

--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -142,9 +142,9 @@ jobs:
         run: |
           cd extension_repo
 
-          # Test basic import functionality
-          extension_import_name=$(echo "$EXTENSION_NAME" | sed 's/-/_/g')
-          python -c "import ${extension_import_name}; print('Successfully imported ${extension_import_name}')"
+          # Test basic import functionality. Read the name from the environment and pass it to
+          # importlib as a string so it cannot be interpreted as Python code.
+          python -c "import importlib, os; name = os.environ['EXTENSION_NAME'].replace('-', '_'); importlib.import_module(name); print('Successfully imported', name)"
 
           # Install test dependencies in case they were not already installed
           python -m pip install pytest pytest-cov

--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -48,6 +48,9 @@ on:
     - cron: '0 6 * * *'  # once per day at 1 AM ET, offset from other daily workflows
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-extension-matrix:
     runs-on: ubuntu-latest
@@ -55,10 +58,12 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.11'
 
@@ -91,13 +96,14 @@ jobs:
       fail-fast: false  # Continue testing other extensions even if one fails
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.11'  # Use 3.11 for better compatibility with extensions
 
@@ -105,15 +111,18 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install NWB extension from PyPI with current branch of HDMF - ${{ matrix.extension.name }}
+        env:
+          EXTENSION_NAME: ${{ matrix.extension.name }}
+          EXTENSION_REPO: ${{ matrix.extension.repository }}
         run: |
-          echo "Repository: ${{ matrix.extension.repository }}"
+          echo "Repository: $EXTENSION_REPO"
 
           # Clone the extension repository
-          git clone --depth 1 ${{ matrix.extension.repository }} extension_repo
+          git clone --depth 1 "$EXTENSION_REPO" extension_repo
           cd extension_repo
 
           # Try to install the extension
-          echo "Installing extension ${{ matrix.extension.name }}..."
+          echo "Installing extension $EXTENSION_NAME..."
           python -m pip install -r requirements-dev.txt || true  # Continue even if this fails
           python -m pip install -r requirements.txt || true  # Continue even if this fails
           python -m pip install ".[test]"
@@ -128,11 +137,13 @@ jobs:
           python -m pip check
 
       - name: Run tests for NWB extension - ${{ matrix.extension.name }}
+        env:
+          EXTENSION_NAME: ${{ matrix.extension.name }}
         run: |
           cd extension_repo
 
           # Test basic import functionality
-          extension_import_name=$(echo "${{ matrix.extension.name }}" | sed 's/-/_/g')
+          extension_import_name=$(echo "$EXTENSION_NAME" | sed 's/-/_/g')
           python -c "import ${extension_import_name}; print('Successfully imported ${extension_import_name}')"
 
           # Install test dependencies in case they were not already installed
@@ -148,4 +159,4 @@ jobs:
             python -m unittest discover -s . -p "*test*.py" -v
           fi
 
-          echo "Completed testing ${{ matrix.extension.name }}"
+          echo "Completed testing $EXTENSION_NAME"

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-pynwb-tests:
     runs-on: ubuntu-latest
@@ -13,13 +16,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.14'
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,6 +8,9 @@ on:
       - 'latest-tmp'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: ${{ matrix.name }}
@@ -35,21 +38,16 @@ jobs:
           - { name: macos-python3.13-upgraded-optional   , test-tox-env: pytest-py313-upgraded-optional , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and tox
+        uses: ./.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          python -m pip list
 
       - name: Run tox tests
         run: |
@@ -70,7 +68,7 @@ jobs:
 
       - name: Upload distribution as a workspace artifact
         if: ${{ matrix.upload-wheels }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: distributions
           path: dist
@@ -95,21 +93,16 @@ jobs:
           - { name: windows-gallery-python3.13-upgraded-optional , test-tox-env: gallery-py313-upgraded-optional , python-ver: "3.13", os: windows-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and tox
+        uses: ./.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          python -m pip list
 
       - name: Run tox tests
         run: |
@@ -125,18 +118,19 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.14'
 
       - name: Download wheel and source distributions from artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: distributions
           path: dist
@@ -169,13 +163,14 @@ jobs:
           - { name: linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5  # v4.0.1
         with:
           auto-update-conda: true
           activate-environment: ros3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: Zizmor GitHub Actions security audit
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches:
+      - dev
+    paths:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.14'
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}  # lets zizmor run its online audits against the GitHub API
+        run: |
+          python -m pip install zizmor==1.26.1
+          zizmor --persona regular .github/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,9 +4,11 @@ rules:
   unpinned-uses:
     config:
       # Every action must be pinned to a full commit SHA so the referenced code cannot change
-      # under a moving tag. astral-sh/ruff-action publishes GitHub immutable releases, whose tags
-      # cannot be reassigned, so it is allowed to be pinned to a version tag (ref-pin). This
-      # exception can be dropped once zizmor recognizes immutable releases (zizmorcore/zizmor#766).
+      # under a moving tag. The actions below publish GitHub immutable releases, whose tags cannot
+      # be reassigned, so they are allowed to be pinned to a version tag (ref-pin). These exceptions
+      # can be dropped once zizmor recognizes immutable releases (zizmorcore/zizmor#766).
       policies:
         astral-sh/ruff-action: ref-pin
+        codecov/codecov-action: ref-pin
+        actions/create-github-app-token: ref-pin
         "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,8 @@ rules:
     config:
       # Every action must be pinned to a full commit SHA so the referenced code cannot change
       # under a moving tag. astral-sh/ruff-action publishes GitHub immutable releases, whose tags
-      # cannot be reassigned, so it is allowed to be pinned to a version tag (ref-pin).
+      # cannot be reassigned, so it is allowed to be pinned to a version tag (ref-pin). This
+      # exception can be dropped once zizmor recognizes immutable releases (zizmorcore/zizmor#766).
       policies:
         astral-sh/ruff-action: ref-pin
         "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# Configuration for zizmor (https://docs.zizmor.sh), the GitHub Actions security auditor.
+
+rules:
+  unpinned-uses:
+    config:
+      # Every action must be pinned to a full commit SHA so the referenced code cannot change
+      # under a moving tag. astral-sh/ruff-action publishes GitHub immutable releases, whose tags
+      # cannot be reassigned, so it is allowed to be pinned to a version tag (ref-pin).
+      policies:
+        astral-sh/ruff-action: ref-pin
+        "*": hash-pin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Refactored `HERD` internals. The object lookup now identifies an object by its file together with its object_id, relative_path, and field, so a shared object_id across files (e.g. a copied, modified file) resolves to the correct object instead of colliding. @rly [#1515](https://github.com/hdmf-dev/hdmf/pull/1515)
 
 ### Internal improvements
-- Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned all actions to commit SHAs, deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
+- Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Changed
 - Refactored `HERD` internals. The object lookup now identifies an object by its file together with its object_id, relative_path, and field, so a shared object_id across files (e.g. a copied, modified file) resolves to the correct object instead of colliding. @rly [#1515](https://github.com/hdmf-dev/hdmf/pull/1515)
 
+### Internal improvements
+- Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned all actions to commit SHAs, deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
+
 ### Fixed
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)


### PR DESCRIPTION
## Motivation

GitHub Actions security and maintainability hardening.

### What changed
- **Least-privilege permissions:** every workflow now declares a top-level `permissions: contents: read`. No job needs more (release/board jobs use their own OIDC / app / PAT tokens).
- **SHA-pinned actions:** every `uses:` is pinned to a full commit SHA with a version comment. Dependabot (already enabled for `github-actions`) understands SHA pins and will keep them current. See also the rationale for this change in https://github.com/hdmf-dev/hdmf/pull/1517#discussion_r3476513911
- **ruff-action v3 → v4.0.0:** v4 ships immutable releases (no floating `v4` tag), so it is pinned to the version tag `v4.0.0`. `.github/zizmor.yml` allows a `ref-pin` for this one action while requiring a hash-pin for every other action.
- **Composite action + caching:** `.github/actions/setup-python-tox` sets up Python with pip caching and installs tox; `run_tests.yml` and `run_all_tests.yml` use it instead of duplicating the setup/install steps across four jobs.
- **`persist-credentials: false`** on all checkouts (none push using the checkout credential).
- **Template-injection fix:** `run_nwb_extension_tests.yml` passed untrusted extension-catalog values (`matrix.extension.*`, sourced from an external catalog) straight into `run:` shell. They now go through `env:` and are referenced as shell variables. This is a real command-injection vector, surfaced by zizmor.
- **Dependabot cooldown:** 7-day cooldown before adopting a newly published action version.
- **zizmor:** a new `zizmor.yml` workflow audits the Actions config on any `.github/**` change, with a `ref-pin` exception for the immutable `ruff-action@v4.0.0` that can be dropped once zizmor recognizes immutable releases (https://github.com/zizmorcore/zizmor/issues/766).

### Relationship to #1517
`dev` (now containing the merged #1517) has been merged into this branch, so `deploy_release.yml` is present here in its hardened form and the whole tree is audited as a unit. This PR also addresses the Copilot review feedback on #1517's release step:
- treat a CHANGELOG section containing only whitespace as empty, falling back to auto-generated notes;
- make the GitHub release step idempotent, uploading artifacts to an existing release on a re-run instead of failing, and pin its checkout with `persist-credentials: false`.

### zizmor status
`zizmor --persona regular` (with `.github/zizmor.yml`) reports **zero findings across all workflows**, with only one justified inline `github-app` ignore in `project_action.yml` (which mints an org-scoped App token by design).

## How to test the behavior?
```
Verified locally:
- every workflow + the composite action + dependabot.yml + .github/zizmor.yml parse as YAML
- zizmor 1.26.1 (offline and online) reports no findings across .github/
- the release-notes shell block passes `bash -n`; a whitespace-only changelog section
  correctly falls back to auto-generated notes
The workflow logic (composite, caching, pins) is exercised when CI runs on this PR.
```

## Checklist
- [x] Did you update `CHANGELOG.md`?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our Contributing Guide?
- [ ] Does the PR use "Fix #XXX" notation? (no associated issue)
