### PR TITLE
Validate quantity in GroupSpec and DatasetSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
+- Fix #531 Disallow or explicitly allow spec quantity to be specified with a numeric string @jwbear [#1521]
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
-- Fix #531 Disallow or explicitly allow spec quantity to be specified with a numeric string @jwbear [#1521]
+- Fix #531 Validate quantity specified with an integor or numeric string @jwbear [#1521]
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
-- Fix #531 Validate quantity specified with an integor or numeric string @jwbear [#1521]
+- Fix #531 Validate quantity specified with an integor or numeric string @jwbear [#1521] (https://github.com/hdmf-dev/hdmf/pull/1521)
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
-- Fix #531 Validate quantity specified with an integor or numeric string @jwbear [#1521] (https://github.com/hdmf-dev/hdmf/pull/1521)
+- Fixed #531 Validate quantity specified with an integer or numeric string @jwbear [#1521](https://github.com/hdmf-dev/hdmf/pull/1521)
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
-- Fixed #531 Validate quantity specified with an integer or numeric string @jwbear [#1521](https://github.com/hdmf-dev/hdmf/pull/1521)
+- Fixed issue #531 where invalid values were accepted for `GroupSpec.quantity` and `DatasetSpec.quantity`. Now only positive integers, string representations of positive integers, and '?', '*', and '+' are allowed. @jwbear [#1521](https://github.com/hdmf-dev/hdmf/pull/1521)
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -529,7 +529,6 @@ class BaseStorageSpec(Spec):
         :returns: A validated quantity string.
         :rtype: str
 
-        :raises ValueError: If quantity is not in FLAGS or is not >= 1.
         :raises TypeError: If quantity is not an integer.
         """
         invalid_name = (

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -480,10 +480,35 @@ class BaseStorageSpec(Spec):
             else:
                 self['default_name'] = default_name
         self.__attributes = dict()
-        if quantity in (ONE_OR_MANY, ZERO_OR_MANY):
-            if name is not None:
-                raise ValueError("Cannot give specific name to something that can "
-                                 "exist multiple times: name='%s', quantity='%s'" % (name, quantity))
+
+        def validate_quantity(qty):
+            invalid_name = (f"Cannot give specific name to something that can "
+                            f"exist multiple times: name='{name}', quantity='{qty}'")
+            invalid_int = f"Invalid quantity '{qty}': must be greater than or equal to 1 or in '{FLAGS}'"
+            # Check FLAGS
+            if isinstance(qty, str) and ((qty in FLAGS.values()) or (qty in FLAGS)):
+                if qty in (ONE_OR_MANY, ZERO_OR_MANY):
+                    if name is not None:
+                        raise ValueError(invalid_name)
+                return qty
+
+            # Convert numeric strings
+            if isinstance(qty, str):
+                try:
+                    qty = int(qty)
+                except (TypeError, ValueError):
+                    raise ValueError(invalid_int)
+
+            # Validate integers
+            if isinstance(qty, int):
+                if qty < 1:
+                    raise ValueError(invalid_int)
+                return qty
+
+            raise ValueError(invalid_int)
+
+        # Validate Quantity
+        quantity = validate_quantity(quantity)
         if quantity != DEF_QUANTITY:
             self['quantity'] = quantity
         if not linkable:

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -526,10 +526,10 @@ class BaseStorageSpec(Spec):
         :param qty: Quantity string or number.
         :type qty: str | int
 
-        :returns: A validated quantity string.
-        :rtype: str
+        :returns: The validated quantity.
+        :rtype: str | int
 
-        :raises TypeError: If quantity is not an integer.
+        :raises ValueError: If quantity is invalid or is incompatible with the name.
         """
         invalid_name = (
             f"Cannot give specific name to something that can exist multiple times: name='{name}', quantity='{qty}'"

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -548,8 +548,8 @@ class BaseStorageSpec(Spec):
         if isinstance(qty, str):
             try:
                 qty = int(qty)
-            except (ValueError):
-                raise ValueError(invalid_int)
+            except ValueError:
+                raise ValueError(invalid_int) from None
 
         # Validate integers
         if isinstance(qty, int):

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -481,36 +481,14 @@ class BaseStorageSpec(Spec):
                 self['default_name'] = default_name
         self.__attributes = dict()
 
-        def validate_quantity(qty):
-            invalid_name = (f"Cannot give specific name to something that can "
-                            f"exist multiple times: name='{name}', quantity='{qty}'")
-            invalid_int = f"Invalid quantity '{qty}': must be greater than or equal to 1 or in '{FLAGS}'"
-            # Check FLAGS
-            if isinstance(qty, str) and ((qty in FLAGS.values()) or (qty in FLAGS)):
-                if qty in (ONE_OR_MANY, ZERO_OR_MANY):
-                    if name is not None:
-                        raise ValueError(invalid_name)
-                return qty
-
-            # Convert numeric strings
-            if isinstance(qty, str):
-                try:
-                    qty = int(qty)
-                except (TypeError, ValueError):
-                    raise ValueError(invalid_int)
-
-            # Validate integers
-            if isinstance(qty, int):
-                if qty < 1:
-                    raise ValueError(invalid_int)
-                return qty
-
-            raise ValueError(invalid_int)
-
         # Validate Quantity
-        quantity = validate_quantity(quantity)
+        quantity = self.__validate_quantity(name, quantity)
+
+        # Prevent overwrite of DEF_Quantity
         if quantity != DEF_QUANTITY:
-            self['quantity'] = quantity
+            self["quantity"] = quantity
+
+
         if not linkable:
             self['linkable'] = False
 
@@ -537,6 +515,49 @@ class BaseStorageSpec(Spec):
         self.__data_type_inc_resolved = None
         self.__inc_spec_resolved = False
         self.__resolved = False
+
+    @staticmethod
+    def __validate_quantity(name, qty):
+        """
+        Ensure quantity is integer >= 1 or in FLAGS and is a valid name, quantity combination.
+
+        Args:
+            name: name string.
+            qty: quantity string or number.
+
+        Returns:
+            A validated quantity string.
+
+        Raises:
+            ValueError: If quantity is not in FLAGS or is not >=1.
+            TypeError: If quantity is not an integer.
+        """
+        invalid_name = (
+            f"Cannot give specific name to something that can exist multiple times: name='{name}', quantity='{qty}'"
+        )
+        valid_flags = ", ".join(FLAGS.values())
+        invalid_int = f"Invalid quantity '{qty}': must be greater than or equal to 1 or in '[{valid_flags}]'"
+        # Check FLAGS
+        if isinstance(qty, str) and ((qty in FLAGS.values()) or (qty in FLAGS)):
+            if qty in (ONE_OR_MANY, ZERO_OR_MANY):
+                if name is not None:
+                    raise ValueError(invalid_name)
+            return qty
+
+        # Convert numeric strings
+        if isinstance(qty, str):
+            try:
+                qty = int(qty)
+            except (TypeError, ValueError):
+                raise ValueError(invalid_int)
+
+        # Validate integers
+        if isinstance(qty, int):
+            if qty < 1:
+                raise ValueError(invalid_int)
+            return qty
+
+        raise ValueError(invalid_int)
 
     @property
     def default_name(self):

--- a/src/hdmf/spec/spec.py
+++ b/src/hdmf/spec/spec.py
@@ -519,18 +519,18 @@ class BaseStorageSpec(Spec):
     @staticmethod
     def __validate_quantity(name, qty):
         """
-        Ensure quantity is integer >= 1 or in FLAGS and is a valid name, quantity combination.
+        Ensure quantity is an integer >= 1 or in FLAGS and is a valid name/quantity combination.
 
-        Args:
-            name: name string.
-            qty: quantity string or number.
+        :param name: Name string.
+        :type name: str
+        :param qty: Quantity string or number.
+        :type qty: str | int
 
-        Returns:
-            A validated quantity string.
+        :returns: A validated quantity string.
+        :rtype: str
 
-        Raises:
-            ValueError: If quantity is not in FLAGS or is not >=1.
-            TypeError: If quantity is not an integer.
+        :raises ValueError: If quantity is not in FLAGS or is not >= 1.
+        :raises TypeError: If quantity is not an integer.
         """
         invalid_name = (
             f"Cannot give specific name to something that can exist multiple times: name='{name}', quantity='{qty}'"
@@ -548,7 +548,7 @@ class BaseStorageSpec(Spec):
         if isinstance(qty, str):
             try:
                 qty = int(qty)
-            except (TypeError, ValueError):
+            except (ValueError):
                 raise ValueError(invalid_int)
 
         # Validate integers

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -302,6 +302,36 @@ class TestNotAllowedConfig(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             GroupSpec(doc='A test group', name='MyGroup', quantity='*')
 
+    def test_quantity_with_string_float(self):
+        msg = ("Invalid quantity '3.5': must be greater than or equal to 1 or in '[?, *, +]'")
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc='A test group', name='MyGroup', quantity='3.5')
+            
+    def test_quantity_with_string_zero(self):
+        msg = ("Invalid quantity '0': must be greater than or equal to 1 or in '[?, *, +]'")
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc='A test group', name='MyGroup', quantity='0')
+            
+    def test_quantity_with_zero(self):
+        msg = ("Invalid quantity '0': must be greater than or equal to 1 or in '[?, *, +]'")
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc='A test group', name='MyGroup', quantity=0)
+            
+    def test_quantity_with_negative(self):
+        msg = ("Invalid quantity '-1': must be greater than or equal to 1 or in '[?, *, +]'")
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc='A test group', name='MyGroup', quantity=-1)
+
+    def test_quantity_with_string_negative(self):
+        msg = "Invalid quantity '-1': must be greater than or equal to 1 or in '[?, *, +]'"
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc="A test group", name="MyGroup", quantity='-1')
+
+    def test_quantity_with_string_notflags(self):
+        msg = "Invalid quantity 'foo': must be greater than or equal to 1 or in '[?, *, +]'"
+        with self.assertRaisesWith(ValueError, msg):
+            GroupSpec(doc="A test group", name="MyGroup", quantity='foo')
+
     def test_same_data_type_def_inc(self):
         msg = ("data_type_inc and data_type_def cannot be the same: MyType. Ignoring data_type_inc.")
         with self.assertWarnsWith(UserWarning, msg):

--- a/tests/unit/spec_tests/test_group_spec.py
+++ b/tests/unit/spec_tests/test_group_spec.py
@@ -306,17 +306,17 @@ class TestNotAllowedConfig(TestCase):
         msg = ("Invalid quantity '3.5': must be greater than or equal to 1 or in '[?, *, +]'")
         with self.assertRaisesWith(ValueError, msg):
             GroupSpec(doc='A test group', name='MyGroup', quantity='3.5')
-            
+
     def test_quantity_with_string_zero(self):
         msg = ("Invalid quantity '0': must be greater than or equal to 1 or in '[?, *, +]'")
         with self.assertRaisesWith(ValueError, msg):
             GroupSpec(doc='A test group', name='MyGroup', quantity='0')
-            
+
     def test_quantity_with_zero(self):
         msg = ("Invalid quantity '0': must be greater than or equal to 1 or in '[?, *, +]'")
         with self.assertRaisesWith(ValueError, msg):
             GroupSpec(doc='A test group', name='MyGroup', quantity=0)
-            
+
     def test_quantity_with_negative(self):
         msg = ("Invalid quantity '-1': must be greater than or equal to 1 or in '[?, *, +]'")
         with self.assertRaisesWith(ValueError, msg):


### PR DESCRIPTION
ISSUE #531

## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

Fix #531

## How to test the behavior?
```
Show how to reproduce the new behavior (can be a bug fix or a new feature)
```
Test FLAGS not in dictionary, integers, strings, and integers entered as strings eg "2"
## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
