### PR TITLE
Fix PyNWB action: install via dependency groups

### DIFF
--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -35,8 +35,8 @@ jobs:
           python -m pip list
           git clone https://github.com/NeurodataWithoutBorders/pynwb.git --recurse-submodules
           cd pynwb
-          python -m pip install -r requirements-dev.txt  -r requirements-doc.txt # do not install the pinned install requirements
-          python -m pip install .  # this will install a different version of hdmf from the current one
+          # install PyNWB with the test and docs dependency groups and the gallery extras; this will install a different version of hdmf from the current one
+          python -m pip install --group test --group docs ".[zarr,termset]"
           cd ..
           python -m pip uninstall -y hdmf  # uninstall the other version of hdmf
           python -m pip install .  # reinstall current branch of hdmf


### PR DESCRIPTION
## Motivation

The [Run PyNWB Tests workflow was failing](https://github.com/hdmf-dev/hdmf/actions/runs/28411035896/job/84183834804) with:

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements-dev.txt'
```

PyNWB migrated its dependency management to `pyproject.toml` using PEP 735 dependency groups, removing `requirements-dev.txt` and `requirements-doc.txt`.

## How to test the behavior?

This installs PyNWB using its current convention:

```bash
python -m pip install --group test --group docs ".[zarr,termset]"
```

- `test` group covers the unit/integration tests (`python test.py -v`)
- `docs` group plus the `zarr,termset` extras cover the gallery tests (`python test.py -e -v`)

`--group` requires pip ≥ 25.1; the CI runner uses pip 26.1.2.

This is an minor, internal testing change, so no changelog is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)