### PR TITLE
Fix rank-3 maxshape when writing a reference column targeting a DynamicTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## HDMF 6.1.1 (Upcoming)
 
 ### Fixed
-- Fixed writing a 1D dataset of object references whose targets are `DynamicTable`s (or other sized, indexable containers). Because such a container is `len()`/index-able, the reference column's shape was inferred by recursing into the referenced tables, producing a spurious higher-rank `maxshape` that did not match the 1D reference dataset the backend writes and raised `ValueError: 'maxshape' must have same rank as dataset shape`. The shape of a reference (or compound) dataset is now taken from the reference array itself. @pauladkisson [#1533](https://github.com/hdmf-dev/hdmf/pull/1533)
+- Fixed writing a 1D dataset of object references whose targets are `DynamicTable`s (or other sized, indexable containers). The shape of a reference (or compound) dataset is now taken from the reference array itself. @pauladkisson [#1533](https://github.com/hdmf-dev/hdmf/pull/1533)
+
 
 ## HDMF 6.1.0 (June 25, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.1.1 (Upcoming)
+
+### Fixed
+- Fixed writing a 1D dataset of object references whose targets are `DynamicTable`s (or other sized, indexable containers). Because such a container is `len()`/index-able, the reference column's shape was inferred by recursing into the referenced tables, producing a spurious higher-rank `maxshape` that did not match the 1D reference dataset the backend writes and raised `ValueError: 'maxshape' must have same rank as dataset shape`. The shape of a reference (or compound) dataset is now taken from the reference array itself. @pauladkisson [#1533](https://github.com/hdmf-dev/hdmf/pull/1533)
+
 ## HDMF 6.1.0 (June 25, 2026)
 
 ### Enhancements

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -1007,7 +1007,13 @@ class ObjectMapper(metaclass=ExtenderMeta):
         if spec_shape is None:
             return None, None
         else:
-            if isinstance(spec.dtype, list):
+            if isinstance(spec.dtype, (list, RefSpec)) or self.__is_reftype(data):
+                # A compound (list) or reference dataset is written 1D with one element per entry, so
+                # treat it as 1D of length len(data). This covers references declared in the spec
+                # (RefSpec) as well as an untyped column whose data are references. Using
+                # get_data_shape here would recurse into reference targets (e.g. a DynamicTable,
+                # which is len()/index-able) and report a spurious higher-rank shape, yielding a
+                # maxshape whose rank does not match the 1D dataset the backend actually writes.
                 data_shape = (_get_length(data),)
             else:
                 data_shape = get_data_shape(data)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -988,7 +988,12 @@ class ObjectMapper(metaclass=ExtenderMeta):
         spec
             The DatasetSpec or AttributeSpec providing ``shape``, ``dims``, and ``dtype`` to
             match against. When ``spec.dtype`` is a list (compound dtype), the data is treated
-            as 1D with length equal to ``len(data)`` for the purpose of shape matching.
+       spec
+           The DatasetSpec or AttributeSpec providing ``shape``, ``dims``, and ``dtype`` to
+           match against. When ``spec.dtype`` is a list (compound dtype), or a``RefSpec``, or
+           when ``data`` holds references, the data is treated as 1D with length equal to
+           ``len(data)`` for the purpose of shape matching, since the backend writes such
+           datasets 1D with one element per entry.
 
         Returns
         -------

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -987,13 +987,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
             any array-like object supported by :func:`get_data_shape`.
         spec
             The DatasetSpec or AttributeSpec providing ``shape``, ``dims``, and ``dtype`` to
-            match against. When ``spec.dtype`` is a list (compound dtype), the data is treated
-       spec
-           The DatasetSpec or AttributeSpec providing ``shape``, ``dims``, and ``dtype`` to
-           match against. When ``spec.dtype`` is a list (compound dtype), or a``RefSpec``, or
-           when ``data`` holds references, the data is treated as 1D with length equal to
-           ``len(data)`` for the purpose of shape matching, since the backend writes such
-           datasets 1D with one element per entry.
+            match against. When ``spec.dtype`` is a list (compound dtype), or a ``RefSpec``, or
+            when ``data`` holds references, the data is treated as 1D with length equal to
+            ``len(data)`` for the purpose of shape matching, since the backend writes such
+            datasets 1D with one element per entry.
 
         Returns
         -------

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -4348,6 +4348,48 @@ class TestDefaultExpandableWithReferences(H5RoundTripMixin, TestCase):
             self.assertEqual(f[ref_ds[1]].name, '/group2')
 
 
+class TestDefaultExpandableWithTableReferences(H5RoundTripMixin, TestCase):
+    """Test that a VectorData column of references to DynamicTables is written 1D and expandable.
+
+    A DynamicTable is ``len()``/index-able, so inferring the reference column's shape by recursing
+    into the referenced tables reports a spurious higher-rank shape, producing a maxshape whose rank
+    does not match the 1D reference dataset the backend writes. Regression test: the shape must be
+    taken from the reference array (1D), not the referenced tables.
+    """
+
+    def setUpContainer(self):
+        target1 = DynamicTable(name='target1', description='a referenced table')
+        target1.add_column(name='x', description='a column')
+        target1.add_row(x=1.0)
+        target2 = DynamicTable(name='target2', description='another referenced table')
+        target2.add_column(name='x', description='a column')
+        target2.add_row(x=2.0)
+
+        table = DynamicTable(name='table0', description='an example table')
+        table.add_column(name='ref', description='a reference column to whole tables')
+        table.add_row(ref=target1)
+        table.add_row(ref=target2)
+
+        multi = SimpleMultiContainer(name='multi')
+        multi.add_container(target1)
+        multi.add_container(target2)
+        multi.add_container(table)
+        return multi
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+
+        with h5py.File(self.filename, 'r') as f:
+            ref_ds = f['table0/ref']
+            self.assertEqual(ref_ds.maxshape, (None,))
+            self.assertIsNotNone(ref_ds.chunks)
+            self.assertTrue(h5py.check_ref_dtype(ref_ds.dtype))
+            # Stored refs resolve to the expected target tables.
+            self.assertIsInstance(ref_ds[0], h5py.Reference)
+            self.assertEqual(f[ref_ds[0]].name, '/target1')
+            self.assertEqual(f[ref_ds[1]].name, '/target2')
+
+
 class TestDefaultExpandableExplicitOverride(H5RoundTripMixin, TestCase):
     """Test that explicit H5DataIO settings are not overridden by the default expandable behavior."""
 


### PR DESCRIPTION
Fixes #1532.

## What changed

`ObjectMapper.__get_spec_info` now treats a reference dataset like a compound dataset when computing its shape — it takes the length of the reference array (1D) instead of calling `get_data_shape`, which recurses into `DynamicTable` reference targets (they are `len()`/index-able) and reports a spurious higher-rank shape. That rank was matched against `VectorData`'s multi-dimensional allowed shapes and used as the `maxshape`, so the write raised `ValueError: 'maxshape' must have same rank as dataset shape` even though the backend writes the reference array 1D.

The check covers both references declared via `RefSpec` and untyped columns whose data are references.

## Testing

Added `TestDefaultExpandableWithTableReferences` (roundtrip + export) — a `VectorData` reference column whose targets are `DynamicTable`s; it fails before the change and passes after. The existing build / common / HDF5 suites pass (1146 passed, 0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)