### PR TITLE
Show how to inspect HERD after reading in the tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HDMF 6.2.0 (Upcoming)
 
+### Documentation and tutorial enhancements
+- Expanded the "Read HERD" section of the external resources tutorial to show how to inspect a `HERD` after reading it back with `HERD.from_zip`, using `to_dataframe`, the individual interlinked tables, and `get_object_entities`. This addresses confusion about a read `HERD` appearing empty in its default Jupyter display. @rly [#1535](https://github.com/hdmf-dev/hdmf/pull/1535)
+
 ### Changed
 - Added support for hdmf-common schema 1.10.0, which changes ``MeaningsTable.target`` from a link to an object-reference attribute (``dtype`` with ``reftype: object``, ``target_type: VectorData``). Files written with the hdmf-common 1.9.0 ``MeaningsTable`` (a link named "target") are still read correctly via a backwards-compatibility mapping in ``MeaningsTableMap``. There is no change in the read/write API; the change is limited to the representation on disk. @rly [#1525](https://github.com/hdmf-dev/hdmf/pull/1525)
 

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -373,4 +373,35 @@ herd.to_zip(path='./HERD.zip')
 # by providing the path to the file itself.
 
 er_read = HERD.from_zip(path='./HERD.zip')
+
+###############################################################################
+# Inspect the data after reading
+# ------------------------------------------------------
+# In a Jupyter notebook, displaying ``er_read`` renders a summary line with the
+# table sizes followed by the flattened table of references (one row per
+# object/key/entity association). The same information is available
+# programmatically through the accessors below.
+#
+# :py:func:`~hdmf.common.resources.HERD.to_dataframe` gives the flattened view,
+# with one row per (file, object, key, entity) association. This is the most
+# convenient starting point for exploring what was stored.
+er_read.to_dataframe()
+
+###############################################################################
+# The individual interlinked tables are available as well, each as a
+# :py:class:`~pandas.DataFrame`.
+er_read.files.to_dataframe()
+er_read.objects.to_dataframe()
+er_read.entities.to_dataframe()
+er_read.keys.to_dataframe()
+er_read.object_keys.to_dataframe()
+er_read.entity_keys.to_dataframe()
+
+###############################################################################
+# To retrieve the entities annotated on a single object, pass a live container
+# to :py:func:`~hdmf.common.resources.HERD.get_object_entities`. The container's
+# ``object_id`` is matched against the objects stored in the read
+# :py:class:`~hdmf.common.resources.HERD`.
+er_read.get_object_entities(file=file, container=species['Species_Data'])
+
 os.remove('./HERD.zip')


### PR DESCRIPTION
## Motivation

Resolves #1325.

The external resources tutorial's "Read HERD" section only called `HERD.from_zip(...)` and then deleted the zip, showing nothing about how to access the data. Combined with a read `HERD` rendering with empty collapsibles in Jupyter, this left users unsure how to get at the references they had just loaded.

The Jupyter rendering half of the issue was already addressed in #1510 (`HERD.__repr__`/`_repr_html_` now surface a flattened references table). This PR fills the documentation gap.

## Changes

- Expand the "Read HERD" section of `docs/gallery/plot_external_resources.py` into an "Inspect the data after reading" walkthrough that demonstrates:
  - `to_dataframe()` for the flattened, one-row-per-association view,
  - the six interlinked tables via `.to_dataframe()`,
  - `get_object_entities(file=..., container=...)` for single-object lookup.
- Note in the comments what the Jupyter display shows after #1510, so a read `HERD` is no longer perceived as empty.
- Add a CHANGELOG entry.

This mirrors the reading/inspection section added to the pynwb tutorial in NeurodataWithoutBorders/pynwb#2200.

## Verification

- The full tutorial script runs end-to-end (exit 0).
- The new read section returns non-empty data: `to_dataframe()` yields 2 rows and `get_object_entities` yields 2 rows.
- `ruff check` and pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)