### PR TITLE
Return None from get_meanings_for_column when column has no MeaningsTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - Added support for hdmf-common schema 1.10.0, which changes ``MeaningsTable.target`` from a link to an object-reference attribute (``dtype`` with ``reftype: object``, ``target_type: VectorData``). Files written with the hdmf-common 1.9.0 ``MeaningsTable`` (a link named "target") are still read correctly via a backwards-compatibility mapping in ``MeaningsTableMap``. There is no change in the read/write API; the change is limited to the representation on disk. @rly [#1525](https://github.com/hdmf-dev/hdmf/pull/1525)
-- ``DynamicTable.get_meanings_for_column`` (and the ``AlignedDynamicTable`` override) now returns ``None`` when the named column exists but has no ``MeaningsTable``, and raises ``KeyError`` only when the column itself does not exist. @rly [#1537](https://github.com/hdmf-dev/hdmf/issues/1537)
+- ``DynamicTable.get_meanings_for_column`` (and the ``AlignedDynamicTable`` override) now returns ``None`` when the named column exists but has no ``MeaningsTable``, and raises ``KeyError`` only when the column itself does not exist. @rly [#1538](https://github.com/hdmf-dev/hdmf/pull/1538)
 
 ### Fixed
 - Fixed reading the resolved values of an `EnumData` column from an HDF5 file (e.g. `column[:]`). @rly [#1534](https://github.com/hdmf-dev/hdmf/pull/1534)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Added support for hdmf-common schema 1.10.0, which changes ``MeaningsTable.target`` from a link to an object-reference attribute (``dtype`` with ``reftype: object``, ``target_type: VectorData``). Files written with the hdmf-common 1.9.0 ``MeaningsTable`` (a link named "target") are still read correctly via a backwards-compatibility mapping in ``MeaningsTableMap``. There is no change in the read/write API; the change is limited to the representation on disk. @rly [#1525](https://github.com/hdmf-dev/hdmf/pull/1525)
+- ``DynamicTable.get_meanings_for_column`` (and the ``AlignedDynamicTable`` override) now returns ``None`` when the named column exists but has no ``MeaningsTable``, and raises ``KeyError`` only when the column itself does not exist. @rly [#1537](https://github.com/hdmf-dev/hdmf/issues/1537)
 
 ### Fixed
 - Fixed reading the resolved values of an `EnumData` column from an HDF5 file (e.g. `column[:]`). @rly [#1534](https://github.com/hdmf-dev/hdmf/pull/1534)

--- a/src/hdmf/common/alignedtable.py
+++ b/src/hdmf/common/alignedtable.py
@@ -422,16 +422,17 @@ class AlignedDynamicTable(DynamicTable):
              'doc': 'The name of the column to get the MeaningsTable for.'},
             {'name': 'category', 'type': str,
              'doc': 'The category the column belongs to.', 'default': None},
-            returns='the MeaningsTable for the given column', rtype='MeaningsTable')
+            returns="the MeaningsTable for the given column, or None if the column has no MeaningsTable",
+            rtype='MeaningsTable')
     def get_meanings_for_column(self, **kwargs):
-        """Get a MeaningsTable for a column in this DynamicTable."""
+        """Get the MeaningsTable for a column in this AlignedDynamicTable.
+
+        Return None if the column exists but has no MeaningsTable. Raise KeyError if the column
+        does not exist in the specified table.
+        """
         col_name, category = getargs('col_name', 'category', kwargs)
         if category is not None:
             category_table = self.get_category(category)
-            meanings_table_name = f"{col_name}_meanings"
-            if meanings_table_name not in category_table.meanings_tables:
-                raise KeyError(f"No MeaningsTable found for column '{col_name}' in category '{category}' "
-                               f"of AlignedDynamicTable '{self.name}'")
-            return category_table.meanings_tables[meanings_table_name]
+            return category_table.get_meanings_for_column(col_name=col_name)
         else:
             return super().get_meanings_for_column(col_name=col_name)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -610,14 +610,18 @@ class DynamicTable(Container):
 
     @docval({'name': 'col_name', 'type': str,
              'doc': 'The name of the column to get the MeaningsTable for.'},
-            returns='the MeaningsTable for the given column', rtype='MeaningsTable')
+            returns="the MeaningsTable for the given column, or None if the column has no MeaningsTable",
+            rtype='MeaningsTable')
     def get_meanings_for_column(self, **kwargs):
-        """Get a MeaningsTable for a column in this DynamicTable."""
+        """Get the MeaningsTable for a column in this DynamicTable.
+
+        Return None if the column exists but has no MeaningsTable. Raise KeyError if the column
+        does not exist in this DynamicTable.
+        """
         col_name = getargs('col_name', kwargs)
-        meanings_table_name = f"{col_name}_meanings"
-        if meanings_table_name not in self.__meanings_tables:
-            raise KeyError(f"No MeaningsTable found for column '{col_name}' in DynamicTable '{self.name}'")
-        return self.__meanings_tables[meanings_table_name]
+        if col_name not in self:
+            raise KeyError(f"Column '{col_name}' not found in DynamicTable '{self.name}'")
+        return self.__meanings_tables.get(f"{col_name}_meanings")
 
     def __set_table_attr(self, col):
         if hasattr(self, col.name) and col.name not in self.__uninit_cols:

--- a/tests/unit/common/test_alignedtable.py
+++ b/tests/unit/common/test_alignedtable.py
@@ -635,8 +635,8 @@ class TestAlignedDynamicTableContainer(TestCase):
         retrieved = adt.get_meanings_for_column('response_type', category='responses')
         self.assertEqual(retrieved, mt)
 
-    def test_get_meanings_for_column_category_not_found(self):
-        """Test error when no MeaningsTable exists for a column in a category."""
+    def test_get_meanings_for_column_category_no_meanings(self):
+        """Test that None is returned when a valid category column has no MeaningsTable."""
         # Create category table without a MeaningsTable
         category_col = VectorData(name='response_type', description='response type', data=['x', 'y', 'z'])
         category_table = DynamicTable(
@@ -652,18 +652,43 @@ class TestAlignedDynamicTableContainer(TestCase):
             columns=[main_col],
             category_tables=[category_table])
 
-        # Test error when no MeaningsTable exists
-        with self.assertRaisesRegex(KeyError, "No MeaningsTable found for column 'response_type'"):
-            adt.get_meanings_for_column('response_type', category='responses')
+        self.assertIsNone(adt.get_meanings_for_column('response_type', category='responses'))
 
-    def test_get_meanings_for_column_main_not_found(self):
-        """Test error when no MeaningsTable exists for a column in the main table."""
+    def test_get_meanings_for_column_category_invalid_column(self):
+        """Test error when the column does not exist in the category table."""
+        category_col = VectorData(name='response_type', description='response type', data=['x', 'y', 'z'])
+        category_table = DynamicTable(
+            name='responses',
+            description='response category',
+            columns=[category_col])
+
+        main_col = VectorData(name='trial_id', description='trial id', data=[1, 2, 3])
+        adt = AlignedDynamicTable(
+            name='test_aligned_table',
+            description='Test aligned container',
+            columns=[main_col],
+            category_tables=[category_table])
+
+        with self.assertRaisesRegex(KeyError, "Column 'nonexistent' not found"):
+            adt.get_meanings_for_column('nonexistent', category='responses')
+
+    def test_get_meanings_for_column_main_no_meanings(self):
+        """Test that None is returned when a valid main-table column has no MeaningsTable."""
         main_col = VectorData(name='stimulus_type', description='stimulus type', data=['a', 'b', 'c'])
         adt = AlignedDynamicTable(
             name='test_aligned_table',
             description='Test aligned container',
             columns=[main_col])
 
-        # Test error when no MeaningsTable exists
-        with self.assertRaisesRegex(KeyError, "No MeaningsTable found for column 'stimulus_type'"):
-            adt.get_meanings_for_column('stimulus_type')
+        self.assertIsNone(adt.get_meanings_for_column('stimulus_type'))
+
+    def test_get_meanings_for_column_main_invalid_column(self):
+        """Test error when the column does not exist in the main table."""
+        main_col = VectorData(name='stimulus_type', description='stimulus type', data=['a', 'b', 'c'])
+        adt = AlignedDynamicTable(
+            name='test_aligned_table',
+            description='Test aligned container',
+            columns=[main_col])
+
+        with self.assertRaisesRegex(KeyError, "Column 'nonexistent' not found"):
+            adt.get_meanings_for_column('nonexistent')

--- a/tests/unit/common/test_table.py
+++ b/tests/unit/common/test_table.py
@@ -3426,10 +3426,14 @@ class TestDynamicTableMeaningsTables(TestCase):
         retrieved = self.table.get_meanings_for_column('stimulus_type')
         self.assertEqual(retrieved, mt)
 
-    def test_get_meanings_for_column_not_found(self):
-        """Test error when no MeaningsTable exists for a column."""
+    def test_get_meanings_for_column_no_meanings(self):
+        """Test that None is returned when a valid column has no MeaningsTable."""
+        self.assertIsNone(self.table.get_meanings_for_column('stimulus_type'))
+
+    def test_get_meanings_for_column_invalid_column(self):
+        """Test error when the column does not exist."""
         with self.assertRaises(KeyError):
-            self.table.get_meanings_for_column('stimulus_type')
+            self.table.get_meanings_for_column('nonexistent')
 
     def test_get_meanings_table_not_found(self):
         """Test error when MeaningsTable not found."""


### PR DESCRIPTION
## Motivation

Fixes #1537.

`DynamicTable.get_meanings_for_column` raised `KeyError` whenever a column had no `MeaningsTable`, without distinguishing a valid column that simply lacks meanings from an invalid column name. The key names a **column** (not a `MeaningsTable`), so a valid column with no `MeaningsTable` is a normal, expected state.

## Changes

- `DynamicTable.get_meanings_for_column` returns `None` when the named column exists but has no `MeaningsTable`, and raises `KeyError` only when the column does not exist in the table.
- The `AlignedDynamicTable` override delegates the category branch to the category table's `get_meanings_for_column` so it inherits the same semantics.
- Updated docstrings and `returns` docval docs.
- Updated/added unit tests in `test_table.py` and `test_alignedtable.py` covering both valid-column-no-meanings (`None`) and invalid-column (`KeyError`) cases for the main table and category tables.
- CHANGELOG entry under 6.2.0.

`VectorData.get_meanings` (which caught `KeyError` from this method) is unaffected.

## Checklist

- [x] Tests pass locally (`test_table.py` + `test_alignedtable.py`)
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)