### PR TITLE
Prepare for release of HDMF 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HDMF Changelog
 
-## HDMF 6.2.0 (Upcoming)
+## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements
 - Expanded the "Read HERD" section of the external resources tutorial to show how to inspect a `HERD` after reading it back with `HERD.from_zip`, using `to_dataframe`, the individual interlinked tables, and `get_object_entities`. This addresses confusion about a read `HERD` appearing empty in its default Jupyter display. @rly [#1535](https://github.com/hdmf-dev/hdmf/pull/1535)
@@ -13,6 +13,7 @@
 - `DynamicTable.add_row` now warns at most once per column that the column has become ragged, on the row that makes it ragged, instead of on that row and every row after it. @h-mayorquin [#1561](https://github.com/hdmf-dev/hdmf/pull/1561)
 
 ### Fixed
+- Fixed issue #531 where invalid values were accepted for `GroupSpec.quantity` and `DatasetSpec.quantity`. Now only positive integers, string representations of positive integers, and '?', '*', and '+' are allowed. @jwbear [#1521](https://github.com/hdmf-dev/hdmf/pull/1521)
 - Fixed `DynamicTable.add_row` being quadratic in the number of rows when `check_ragged` is on, which is the default. Filling 16,000 rows into a one-column table drops from 22 s to 0.3 s. @h-mayorquin [#1561](https://github.com/hdmf-dev/hdmf/pull/1561)
 - Fixed a deadlock when exporting a Zarr file to HDF5 with `HDF5IO.export`. A zarr array is now read into memory before the HDF5 write (in `__list_fill__`/`__scalar_fill__`), so the read does not run while h5py's global lock is held. @rly [#1547](https://github.com/hdmf-dev/hdmf/pull/1547)
 - Fixed `IndexError` when selecting an empty region from an in-memory `DynamicTableRegion` (e.g. `table["region"][i]` for a ragged region row that references no target rows, or an empty slice), both when the target table's columns hold their data as numpy arrays and when the target table has ragged columns. @h-mayorquin [#1549](https://github.com/hdmf-dev/hdmf/pull/1549)
@@ -44,7 +45,6 @@
 - Hardened the GitHub Actions CI: added least-privilege `permissions` blocks, pinned actions to commit SHAs (or immutable release tags), deduplicated the test setup into a composite action, passed untrusted inputs through environment variables, and added a zizmor security audit of the workflows. @rly [#1518](https://github.com/hdmf-dev/hdmf/pull/1518)
 
 ### Fixed
-- Fixed issue #531 where invalid values were accepted for `GroupSpec.quantity` and `DatasetSpec.quantity`. Now only positive integers, string representations of positive integers, and '?', '*', and '+' are allowed. @jwbear [#1521](https://github.com/hdmf-dev/hdmf/pull/1521)
 - Fixed iterative HDF5 writes (e.g. from a `DataChunkIterator`) storing data as `float32` when no explicit dtype was set on the builder. The data's own dtype is now used, so e.g. integer data is stored as integers rather than silently downcast, and an `H5pyDeprecationWarning` is no longer emitted. @rly [#1519](https://github.com/hdmf-dev/hdmf/pull/1519)
 - Removed the broken `str` (object_id) option from the `container` argument of `HERD.add_ref`, `HERD.add_ref_termset`, `HERD.get_key`, and `HERD.get_object_entities`; these methods now require an `AbstractContainer` and reject a string with a clear type error. @rly [#1514](https://github.com/hdmf-dev/hdmf/pull/1514)
 - Fixed `HERD.get_object_entities(attribute=...)` not finding references added with `HERD.add_ref(attribute=...)`, which raised `KeyError`/`TypeError` for non-DataType attributes. Both methods now resolve the attribute the same way. @rly [#1504](https://github.com/hdmf-dev/hdmf/pull/1504)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,6 +83,7 @@ intersphinx_mapping = {
 linkcheck_ignore = [
     "https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key",
     "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request",
+    "https://nwb-users.slack.com",
 ]
 
 nitpicky = True

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3783,6 +3783,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
         io.write_dataset(f, DatasetBuilder(name='test_dataset', data=zarr_data, attributes={}))
         dset = f['test_dataset']
@@ -3797,6 +3798,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
         io.write_dataset(f, DatasetBuilder(name='test_dataset', data=zarr_data, attributes={}))
         dset = f['test_dataset']
@@ -3812,6 +3814,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3841,6 +3844,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3870,6 +3874,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr_data = zarr.open(self.zarr_path, shape=(2,), dtype=object, object_codec=numcodecs.VLenUTF8())
         zarr_data[:] = base_data
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3899,6 +3904,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr_data = zarr.open(self.zarr_path, shape=(2,), dtype=object, object_codec=numcodecs.VLenBytes())
         zarr_data[:] = base_data
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3932,6 +3938,7 @@ class TestWriteHDF5withZarrInput(TestCase):
                      shuffle=True,
                      fletcher32=True)
         io = HDF5IO(self.path, mode='a')
+        self.addCleanup(io.close)
         f = io._file
         io.write_dataset(f, DatasetBuilder('test_dataset', a, attributes={}))
         dset = f['test_dataset']

--- a/tests/unit/test_io_hdf5_h5tools.py
+++ b/tests/unit/test_io_hdf5_h5tools.py
@@ -3737,8 +3737,11 @@ class TestWriteHDF5withZarrInput(TestCase):
         self.path = get_temp_filepath()
         self.path = get_temp_filepath()
         self.zarr_path = tempfile.mkdtemp()
+        self.io = None
 
     def tearDown(self):
+        if self.io is not None:
+            self.io.close()
         if os.path.exists(self.path):
             os.remove(self.path)
         if os.path.exists(self.zarr_path):
@@ -3783,7 +3786,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
         io.write_dataset(f, DatasetBuilder(name='test_dataset', data=zarr_data, attributes={}))
         dset = f['test_dataset']
@@ -3798,7 +3801,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
         io.write_dataset(f, DatasetBuilder(name='test_dataset', data=zarr_data, attributes={}))
         dset = f['test_dataset']
@@ -3814,7 +3817,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3844,7 +3847,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr.save(self.zarr_path, base_data)
         zarr_data = zarr.open(self.zarr_path, 'r')
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3874,7 +3877,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr_data = zarr.open(self.zarr_path, shape=(2,), dtype=object, object_codec=numcodecs.VLenUTF8())
         zarr_data[:] = base_data
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3904,7 +3907,7 @@ class TestWriteHDF5withZarrInput(TestCase):
         zarr_data = zarr.open(self.zarr_path, shape=(2,), dtype=object, object_codec=numcodecs.VLenBytes())
         zarr_data[:] = base_data
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
 
         io.write_dataset(f, DatasetBuilder('test_dataset1', zarr_data))  # no dtype specified
@@ -3938,7 +3941,7 @@ class TestWriteHDF5withZarrInput(TestCase):
                      shuffle=True,
                      fletcher32=True)
         io = HDF5IO(self.path, mode='a')
-        self.addCleanup(io.close)
+        self.io = io
         f = io._file
         io.write_dataset(f, DatasetBuilder('test_dataset', a, attributes={}))
         dset = f['test_dataset']


### PR DESCRIPTION
### Before merging:
- [x] Make sure all PRs to be included in this release have been merged to `dev`.
- [x] Major and minor releases: Update dependency ranges in `pyproject.toml` as needed.
- [x] Update the GitHub Actions used in the workflows to their latest versions. Pin each action to a full commit SHA, except actions that publish immutable releases, which may use a version tag (see `.github/zizmor.yml` for the policy).
- [x] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`, and any other locations as needed
- [x] Update `pyproject.toml` as needed
- [x] Update `README.rst` as needed
- [x] Update `src/hdmf/common/hdmf-common-schema` submodule as needed. Check the version number and commit SHA manually. Make sure we are using the latest release and not the latest commit on the `main` branch.
- [x] Update changelog (set release date) in `CHANGELOG.md` and any other docs as needed
- [x] Run tests locally including gallery tests, and inspect all warnings and outputs (`pytest && python test_gallery.py`). Try to remove all warnings.
- [x] Run PyNWB tests locally including gallery and validation tests, and inspect all warnings and outputs (`cd pynwb; git checkout dev; git pull; python test.py -v > out.txt 2>&1`)
- [x] Run HDMF-Zarr tests locally including gallery and validation tests, and inspect all warnings and outputs (`cd hdmf-zarr; git checkout dev; git pull; pytest && python test_gallery.py`)
- [x] Test docs locally and inspect all warnings and outputs `cd docs; make clean && make html`
- [x] After pushing this branch to GitHub, manually trigger the "Run all tests" GitHub Actions workflow on this branch by going to https://github.com/hdmf-dev/hdmf/actions/workflows/run_all_tests.yml, selecting "Run workflow" on the right, selecting this branch, and clicking "Run workflow". Make sure all tests pass.
- [x] Check that the readthedocs build for this PR succeeds (see the PR check)

### After merging:
1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
2. After the CI bot creates the new release (wait ~10 min), verify that the release notes on the [GitHub releases page](https://github.com/hdmf-dev/hdmf/releases) include the changelog for this version
3. Check that the readthedocs "stable" build runs and succeeds
4. Either monitor [conda-forge/hdmf-feedstock](https://github.com/conda-forge/hdmf-feedstock) for the regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within 24 hours of release, or manually create a PR updating `recipe/meta.yaml` with the latest version number and SHA256 retrieved from PyPI > HDMF > Download Files > View hashes for the `.tar.gz` file. Re-render and update the dependencies as needed.

### Notes on this release

Changes in this PR beyond setting the release date:

- Pointed the `hdmf-common-schema` submodule at the `1.10.0` release tag (`e7f84f0`). It was on `4508b8f`, one commit past `1.9.0`, which is the `MeaningsTable.target` change already described in the changelog.
- Moved the changelog entry for #1521 from the 6.1.0 section into 6.2.0. That PR merged on 2026-07-06, after the 6.1.0 tag on 2026-06-25, and the entry is not in the changelog as of the `6.1.0` tag.
- Added `https://nwb-users.slack.com` to `linkcheck_ignore` in `docs/source/conf.py`, which was failing the "Check Sphinx links" workflow.
- Closed the `HDF5IO` opened by the `TestWriteHDF5withZarrInput` tests. Since #1547 changed `HDMFIO.__del__` to warn rather than close, those tests emitted a `ResourceWarning` under `-W always`.

Local test results:

- hdmf: 1965 passed, 20 skipped, 1 xfailed, 919 subtests passed. Gallery: 7 tests OK. Remaining warnings under `-W always` are the intentional `EnumData is experimental` warning and third-party deprecations from `linkml-runtime` and `sssom`.
- hdmf-zarr (dev, `5e633ff`): 547 passed, 11 skipped, 1080 subtests passed. Gallery: 5 tests OK. Warnings are hdmf-zarr's own and `zarr`'s `NestedDirectoryStore` deprecation.
- Sphinx `make clean && make html`: build succeeded, no warnings. `sphinx-build -W -b linkcheck`: build succeeded, no broken links.
- PyNWB (dev, `6285dd8`): 763 tests, 7 failures and 1 error, all in `integration.hdf5.test_misc` for `TestUnitsCustomWaveformUnitIO` and `TestUnitsWaveformTimeBeforePeakIO`. These reproduce identically against the released hdmf 6.1.0, so they are a pre-existing issue on pynwb `dev` from NeurodataWithoutBorders/pynwb#2237, not a regression in this release.

CI notes:

- All PR checks pass, including `check-sphinx-links` (confirming the `linkcheck_ignore` addition), `run-pynwb-tests`, `run-hdmf-zarr-tests`, and the readthedocs build.
- "Run all tests" ([32220709636](https://github.com/hdmf-dev/hdmf/actions/runs/32220709636)): 36 of 37 jobs pass. The remaining job, `windows-python3.14-ros3`, hangs in "Run ros3 tests" until the 6-hour limit. That is pre-existing on `dev`: the nightly runs on 2026-08-17 and 2026-08-18 were both cancelled after hanging on the same job, while `linux-python3.14-ros3` and `macos-python3.14-ros3` finish in under two minutes. Worth a separate issue.
- Two earlier attempts at "Run all tests" failed in the `python3.14-upgraded-optional` jobs while installing `lxml`. `lxml` 6.1.2 was published to PyPI at 04:58:23 UTC and the jobs resolved it at 04:58:45, before the cp314 wheels finished uploading, so pip fell back to the sdist and the build failed. Unrelated to this release; the rerun after the wheels landed is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
