### PR TITLE
Add support for aliases in TermSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # HDMF Changelog
 
+## HDMF 6.3.0 (Upcomping)
+
+### Enhancements
+- Added support for aliases in TermSet. Aliases can be used to look up terms in a TermSet using alternative names. @oruebel [#1565](https://github.com/hdmf-dev/hdmf/pull/1565)
+- Added `TermSet.suggest_term` to suggest a close matching term for a given term and `TermSet.get_primary_term` to look up the corresponding primary term for an alias. @oruebel [#1565](https://github.com/hdmf-dev/hdmf/pull/1565)
+- Added `TypeMap.get_configured_termsets` and `AbstractContainer.get_configured_termsets` convenience methods to simplify retrieving configured TermSet's for a particular types and container instance. @oruebel [#1565](https://github.com/hdmf-dev/hdmf/pull/1565)
+
+### Documentation and tutorial enhancements
+- Updated the TermSet and External Resources tutorials to describe the use of aliases. @oruebel [#1565](https://github.com/hdmf-dev/hdmf/pull/1565)
+
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/docs/gallery/example_term_set.yaml
+++ b/docs/gallery/example_term_set.yaml
@@ -1,8 +1,8 @@
-id: termset/species_example
-name: Species
-version: 0.0.1
+id: termset/nwb_subject_species_starter
+name: NWBSubjectSpeciesStarter
+version: 0.1.0
 prefixes:
-  NCBITaxon: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
 imports:
   - linkml:types
 default_range: string
@@ -11,14 +11,122 @@ enums:
   Species:
     permissible_values:
       Homo sapiens:
-        description: the species is human
+        description: Human.
         meaning: NCBITaxon:9606
+        aliases:
+          - human
       Mus musculus:
-        description: the species is a house mouse
+        description: House mouse.
         meaning: NCBITaxon:10090
-      Ursus arctos horribilis:
-        description: the species is a grizzly bear
-        meaning: NCBITaxon:116960
-      Myrmecophaga tridactyla:
-        description: the species is an anteater
-        meaning: NCBITaxon:71006
+        aliases:
+          - mouse
+          - house mouse
+      Rattus norvegicus:
+        description: Brown rat.
+        meaning: NCBITaxon:10116
+        aliases:
+          - rat
+          - norway rat
+      Macaca mulatta:
+        description: Rhesus macaque.
+        meaning: NCBITaxon:9544
+        aliases:
+          - macaque
+          - rhesus macaque
+          - rhesus monkey
+      Drosophila melanogaster:
+        description: Fruit fly.
+        meaning: NCBITaxon:7227
+        aliases:
+          - fruit fly
+          - fly
+      Danio rerio:
+        description: Zebrafish.
+        meaning: NCBITaxon:7955
+        aliases:
+          - zebrafish
+      Macaca nemestrina:
+        description: Pig-tailed macaque.
+        meaning: NCBITaxon:9545
+        aliases:
+          - pig-tailed macaque
+      Cricetulus griseus:
+        description: Chinese hamster.
+        meaning: NCBITaxon:10029
+        aliases:
+          - chinese hamster
+      Canis lupus familiaris:
+        description: Domestic dog.
+        meaning: NCBITaxon:9615
+        aliases:
+          - dog
+      Ooceraea biroi:
+        description: Clonal raider ant.
+        meaning: NCBITaxon:2015173
+        aliases:
+          - clonal raider ant
+      Caenorhabditis elegans:
+        description: Nematode worm.
+        meaning: NCBITaxon:6239
+        aliases:
+          - worm
+          - c. elegans
+      Oryctolagus cuniculus:
+        description: Rabbit.
+        meaning: NCBITaxon:9986
+        aliases:
+          - rabbit
+      Bos taurus:
+        description: Cattle.
+        meaning: NCBITaxon:9913
+        aliases:
+          - cattle
+      unidentified:
+        description: Unspecified or unidentified organism label.
+        meaning: NCBITaxon:32644
+      Callithrix jacchus:
+        description: Common marmoset.
+        meaning: NCBITaxon:9483
+        aliases:
+          - marmoset
+          - common marmoset
+      Macaca fascicularis:
+        description: Cynomolgus macaque.
+        meaning: NCBITaxon:9541
+        aliases:
+          - cynomolgus macaque
+          - crab-eating macaque
+      Meriones unguiculatus:
+        description: Mongolian gerbil.
+        meaning: NCBITaxon:10047
+        aliases:
+          - mongolian gerbil
+      Microtus ochrogaster:
+        description: Prairie vole.
+        meaning: NCBITaxon:79684
+        aliases:
+          - prairie vole
+      Procambarus clarkii:
+        description: Red swamp crayfish.
+        meaning: NCBITaxon:6728
+        aliases:
+          - red swamp crayfish
+      Saimiri boliviensis:
+        description: Bolivian squirrel monkey.
+        meaning: NCBITaxon:27679
+        aliases:
+          - bolivian squirrel monkey
+      Sus scrofa domesticus:
+        description: Domestic pig.
+        meaning: NCBITaxon:9825
+        aliases:
+          - domestic pig
+          - pig
+      Taeniopygia guttata:
+        description: Zebra finch.
+        meaning: NCBITaxon:59729
+        aliases:
+          - zebra finch
+      Drosophila persimilis:
+        description: Drosophila persimilis.
+        meaning: NCBITaxon:7234

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -197,7 +197,7 @@ herd.add_ref(
 col1 = VectorData(
     name='Species_Data',
     description='species from NCBI and Ensemble',
-    data=['Homo sapiens', 'Ursus arctos horribilis'],
+    data=['Homo sapiens', 'Drosophila melanogaster'],
 )
 
 # Create a DynamicTable with this column and set the table parent to the file object created earlier
@@ -207,7 +207,7 @@ species.parent = file
 herd.add_ref(
     container=species,
     attribute='Species_Data',
-    key='Ursus arctos horribilis',
+    key='Drosophila melanogaster',
     entity_id='NCBITaxon:116960',
     entity_uri='https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id'
 )
@@ -246,7 +246,7 @@ genotype_key_object = herd.get_key(key_name='Rorb')
 # to provide the unique (file, container, relative_path, field, key) combination.
 species_key_object = herd.get_key(file=file,
                                 container=species['Species_Data'],
-                                key_name='Ursus arctos horribilis')
+                                key_name='Drosophila melanogaster')
 
 # If the file is not provided, :py:func:`~hdmf.common.resources.HERD.get_key` also will check the
 # :py:class:`~hdmf.common.resources.Object` for a :py:class:`~hdmf.common.resources.File` along the
@@ -335,7 +335,7 @@ terms = TermSet(term_schema_path=yaml_file)
 
 herd.add_ref_termset(container=species,
                    attribute='Species_Data',
-                   key='Ursus arctos horribilis',
+                   key='Drosophila melanogaster',
                    termset=terms)
 
 ###############################################################################
@@ -356,6 +356,51 @@ terms = TermSet(term_schema_path=yaml_file)
 herd.add_ref_termset(container=species,
                    attribute='Species_Data',
                    termset=terms)
+
+
+###############################################################################
+# Finding Configured Termsets and Resolving Aliases
+# ------------------------------------------------------
+# A common workflow in an HDMF ecosystem involves configuring datasets or attributes 
+# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
+# method on a container class or instance lets you inspect which attributes are bound to a TermSet.
+# This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
+#
+# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD` 
+# takes advantage of these aliases under the hood. If your data uses an alias (e.g., "human" instead of "Homo sapiens"),
+# :py:func:`~hdmf.common.resources.HERD.add_ref_termset` uses
+# :py:meth:`~hdmf.term_set.TermSet.__getitem__` which automatically resolves the alias to its canonical term and
+# URI, ensuring consistent mapping across your files.
+#
+# The following code automatically adds the configured termsets for the 'species' container to HERD.
+# In this tutorial, our 'species' container has not been globally configured with termsets, so we expect an empty dict.
+
+configured_termsets = species.get_configured_termsets()
+for attribute_name, ts in configured_termsets.items():
+    herd.add_ref_termset(container=species, attribute=attribute_name, termset=ts)
+
+
+###############################################################################
+# Finding Configured Termsets and Resolving Aliases
+# ------------------------------------------------------
+# A common workflow in an HDMF ecosystem involves configuring datasets or attributes 
+# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
+# method on a container class or instance lets you inspect which attributes are bound to a TermSet.
+# This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
+# We will use this to find the termsets for our data.
+#
+# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD` 
+# takes advantage of these aliases under the hood. If your data uses an alias (e.g., "human" instead of "Homo sapiens"),
+# :py:func:`~hdmf.common.resources.HERD.add_ref_termset` uses
+# :py:meth:`~hdmf.term_set.TermSet.__getitem__` which automatically resolves the alias to its canonical term and
+# URI, ensuring consistent mapping across your files.
+#
+# NOTE: The following is just an example of what using get_configured_termsets would look like.
+# In this tutorial, our 'species' container has not been globally configured with termsets, so we expect an empty dict.
+
+configured_termsets = species.get_configured_termsets()
+for attribute_name, ts in configured_termsets.items():
+    herd.add_ref_termset(container=species, attribute=attribute_name, termset=ts)
 
 ###############################################################################
 # Write HERD

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -361,12 +361,12 @@ herd.add_ref_termset(container=species,
 ###############################################################################
 # Finding Configured Termsets and Resolving Aliases
 # ------------------------------------------------------
-# A common workflow in an HDMF ecosystem involves configuring datasets or attributes 
+# A common workflow in an HDMF ecosystem involves configuring datasets or attributes
 # to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
 # method on a container class or instance lets you inspect which attributes are bound to a TermSet.
 # This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
 #
-# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD` 
+# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD`
 # takes advantage of these aliases under the hood. If your data uses an alias (e.g., "human" instead of "Homo sapiens"),
 # :py:func:`~hdmf.common.resources.HERD.add_ref_termset` uses
 # :py:meth:`~hdmf.term_set.TermSet.__getitem__` which automatically resolves the alias to its canonical term and
@@ -383,13 +383,13 @@ for attribute_name, ts in configured_termsets.items():
 ###############################################################################
 # Finding Configured Termsets and Resolving Aliases
 # ------------------------------------------------------
-# A common workflow in an HDMF ecosystem involves configuring datasets or attributes 
+# A common workflow in an HDMF ecosystem involves configuring datasets or attributes
 # to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
 # method on a container class or instance lets you inspect which attributes are bound to a TermSet.
 # This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
 # We will use this to find the termsets for our data.
 #
-# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD` 
+# Additionally, :py:class:`~hdmf.term_set.TermSet` entries may have aliases. :py:class:`~hdmf.common.resources.HERD`
 # takes advantage of these aliases under the hood. If your data uses an alias (e.g., "human" instead of "Homo sapiens"),
 # :py:func:`~hdmf.common.resources.HERD.add_ref_termset` uses
 # :py:meth:`~hdmf.term_set.TermSet.__getitem__` which automatically resolves the alias to its canonical term and

--- a/docs/gallery/plot_external_resources.py
+++ b/docs/gallery/plot_external_resources.py
@@ -362,7 +362,7 @@ herd.add_ref_termset(container=species,
 # Finding Configured Termsets and Resolving Aliases
 # ------------------------------------------------------
 # A common workflow in an HDMF ecosystem involves configuring datasets or attributes
-# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
+# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.AbstractContainer.get_configured_termsets`
 # method on a container class or instance lets you inspect which attributes are bound to a TermSet.
 # This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
 #
@@ -384,7 +384,7 @@ for attribute_name, ts in configured_termsets.items():
 # Finding Configured Termsets and Resolving Aliases
 # ------------------------------------------------------
 # A common workflow in an HDMF ecosystem involves configuring datasets or attributes
-# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.Container.get_configured_termsets`
+# to use specific TermSets globally. Using the :py:meth:`~hdmf.container.AbstractContainer.get_configured_termsets`
 # method on a container class or instance lets you inspect which attributes are bound to a TermSet.
 # This makes it easy to automatically wire up :py:class:`~hdmf.common.resources.HERD` with the configured termsets.
 # We will use this to find the termsets for our data.

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -134,7 +134,7 @@ print(f"Term: {term_info.id} matched 'human' with status {status}")
 print(f"Aliases for 'Homo sapiens': {terms['Homo sapiens'].aliases}")
 
 # In HDMF containers, you can inspect which fields are configured with TermSets
-# using the :py:meth:`~hdmf.container.Container.get_configured_termsets` method.
+# using the :py:meth:`~hdmf.container.AbstractContainer.get_configured_termsets` method.
 # For example, if ``VectorData`` had an attribute configured with a TermSet:
 # termsets = VectorData.get_configured_termsets()
 
@@ -154,7 +154,7 @@ perm_values_dict = terms.view.all_enums()[enumeration].permissible_values
 print(f"Aliases for 'Homo sapiens': {perm_values_dict['Homo sapiens'].aliases}")
 
 # In HDMF containers, you can inspect which fields are configured with TermSets
-# using the :py:meth:`~hdmf.container.Container.get_configured_termsets` method.
+# using the :py:meth:`~hdmf.container.AbstractContainer.get_configured_termsets` method.
 # For example, if ``VectorData`` had an attribute configured with a TermSet:
 # termsets = VectorData.get_configured_termsets()
 

--- a/docs/gallery/plot_term_set.py
+++ b/docs/gallery/plot_term_set.py
@@ -121,6 +121,45 @@ print(terms.view_set)
 terms['Homo sapiens']
 
 ######################################################
+# Using Aliases and get_configured_termsets
+# ----------------------------------------------------
+# :py:class:`~hdmf.term_set.TermSet` allows terms to define `aliases`. These aliases provide alternative strings
+# that map to the same exact term. You can test this using the :py:meth:`~hdmf.term_set.TermSet.suggest_term` method,
+# which returns the canonical term information, a machine-readable status, and a human-readable reason.
+term_info, status, reason = terms.suggest_term(term="human")
+print(f"Term: {term_info.id} matched 'human' with status {status}")
+
+# You can also retrieve the aliases for a given term directly from the TermSet lookup.
+# `TermSet.__getitem__` returns a `Term_Info` namedtuple which contains `id`, `description`, `meaning`, and `aliases`.
+print(f"Aliases for 'Homo sapiens': {terms['Homo sapiens'].aliases}")
+
+# In HDMF containers, you can inspect which fields are configured with TermSets
+# using the :py:meth:`~hdmf.container.Container.get_configured_termsets` method.
+# For example, if ``VectorData`` had an attribute configured with a TermSet:
+# termsets = VectorData.get_configured_termsets()
+
+
+######################################################
+# Using Aliases and get_configured_termsets
+# ----------------------------------------------------
+# :py:class:`~hdmf.term_set.TermSet` allows terms to define `aliases`. These aliases provide alternative strings
+# that map to the same exact term. You can test this using the :py:meth:`~hdmf.term_set.TermSet.suggest_term` method,
+# which returns the canonical term information, a machine-readable status, and a human-readable reason.
+term_info, status, reason = terms.suggest_term(term="human")
+print(f"Term: {term_info.id} matched 'human' with status {status}")
+
+# You can also retrieve the aliases for a given term directly from the permissible values dict.
+enumeration = list(terms.view.all_enums())[0]
+perm_values_dict = terms.view.all_enums()[enumeration].permissible_values
+print(f"Aliases for 'Homo sapiens': {perm_values_dict['Homo sapiens'].aliases}")
+
+# In HDMF containers, you can inspect which fields are configured with TermSets
+# using the :py:meth:`~hdmf.container.Container.get_configured_termsets` method.
+# For example, if ``VectorData`` had an attribute configured with a TermSet:
+# termsets = VectorData.get_configured_termsets()
+
+
+######################################################
 # Validate Data with TermSetWrapper
 # ----------------------------------------------------
 # :py:class:`~hdmf.term_set.TermSetWrapper` can be wrapped around data.
@@ -168,8 +207,8 @@ data = VectorData(
     data=TermSetWrapper(value=['Homo sapiens'], termset=terms)
     )
 
-data.append('Ursus arctos horribilis')
-data.extend(['Mus musculus', 'Myrmecophaga tridactyla'])
+data.append('Drosophila melanogaster')
+data.extend(['Mus musculus', 'Rattus norvegicus'])
 
 ######################################################
 # Validate Data in a DynamicTable
@@ -208,4 +247,4 @@ species.add_row(Species_1='Mus musculus', Species_2='Mus musculus')
 # method as if you were making a new instance of :py:class:`~hdmf.common.table.VectorData`.
 species.add_column(name='Species_3',
                    description='...',
-                   data=TermSetWrapper(value=['Ursus arctos horribilis', 'Mus musculus'], termset=terms),)
+                   data=TermSetWrapper(value=['Drosophila melanogaster', 'Mus musculus'], termset=terms),)

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -875,9 +875,11 @@ class TypeMap:
             container_cls = container_cls.__class__
 
         configurator = self.type_config
+        empty_return_val = None if attribute is not None else dict()
+
         if not configurator.paths:
-            msg = "No TermSet configuration has been loaded onto this TypeMap."
-            raise ValueError(msg)
+            # No TermSet configuration has been loaded onto this TypeMap.
+            return empty_return_val
 
         namespace, data_type = self.get_container_cls_dt(container_cls)
         if namespace is None:
@@ -886,13 +888,13 @@ class TypeMap:
 
         termset_config = configurator.config
         if namespace not in termset_config['namespaces']:
-            msg = "No TermSet configuration found for namespace '%s'." % namespace
-            raise ValueError(msg)
+            # No TermSet configuration found for this namespace.
+            return empty_return_val
 
         config_namespace = termset_config['namespaces'][namespace]
         if data_type not in config_namespace['data_types']:
-            msg = "No TermSet configuration found for data_type '%s' in namespace '%s'." % (data_type, namespace)
-            raise ValueError(msg)
+            # No TermSet configuration found for this data_type in the namespace.
+            return empty_return_val
 
         config_data_type = config_namespace['data_types'][data_type]
         # NOTE: the config always has exactly one loaded path at a time (see TypeConfigurator);
@@ -906,8 +908,8 @@ class TypeMap:
         if attribute is not None:
             config_entry = config_data_type.get(attribute)
             if config_entry is None or 'termset' not in config_entry:
-                msg = "No TermSet configuration found for attribute '%s' on data_type '%s'." % (attribute, data_type)
-                raise ValueError(msg)
+                # No TermSet configuration found for this specific attribute on the data_type.
+                return empty_return_val
             return _resolve_termset(config_entry)
 
         termsets = dict()
@@ -916,8 +918,8 @@ class TypeMap:
                 termsets[attr_name] = _resolve_termset(config_entry)
 
         if not termsets:
-            msg = "No TermSet configuration found for data_type '%s'." % data_type
-            raise ValueError(msg)
+            # No TermSet configurations found for any attributes on this data_type.
+            return empty_return_val
 
         return termsets
 

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections import OrderedDict, deque
 from copy import copy
 from collections.abc import Callable
@@ -9,7 +10,7 @@ import warnings
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, BaseBuilder
 from .classgenerator import ClassGeneratorManager, CustomClassGenerator, MCIClassGenerator
 from ..container import AbstractContainer, Container, Data
-from ..term_set import TypeConfigurator
+from ..term_set import TypeConfigurator, TermSet
 from ..spec import DatasetSpec, GroupSpec, NamespaceCatalog, RefSpec
 from ..spec.spec import BaseStorageSpec
 from ..utils import docval, getargs, ExtenderMeta, get_docval
@@ -845,6 +846,80 @@ class TypeMap:
             if not isinstance(container_cls, TypeSource):
                 setattr(container_cls, spec.type_key(), data_type)
                 setattr(container_cls, 'namespace', namespace)
+
+    @docval({"name": "container_cls", "type": (type, AbstractContainer),
+             "doc": "the AbstractContainer class (or an instance of one) to look up TermSet configuration for"},
+            {"name": "attribute", "type": str,
+             "doc": ("the name of a specific attribute (i.e., the spec attribute name used as a key in the "
+                      "TermSet configuration file) to get the TermSet for. If None, returns a dict mapping all "
+                      "configured attribute names to their TermSet."),
+             "default": None},
+            returns="the configured TermSet for the given attribute, or a dict mapping attribute name to TermSet",
+            rtype="TermSet or dict")
+    def get_configured_termsets(self, **kwargs):
+        """
+        Get the configured TermSet(s) for a given container class (or instance of one).
+
+        This inspects the :py:class:`~hdmf.term_set.TypeConfigurator` currently loaded on this
+        TypeMap (``self.type_config``) and returns the TermSet(s) that have been configured for
+        the given class (and, optionally, a specific attribute of that class).
+
+        Note that the TermSet configuration file keys attributes by their *spec* attribute name
+        (i.e., the same name used as a key in the configuration file, see
+        :py:meth:`~hdmf.term_set.TypeConfigurator.get_config`), which is what should be passed
+        as ``attribute`` here.
+        """
+        container_cls, attribute = getargs('container_cls', 'attribute', kwargs)
+
+        if isinstance(container_cls, AbstractContainer):
+            container_cls = container_cls.__class__
+
+        configurator = self.type_config
+        if not configurator.paths:
+            msg = "No TermSet configuration has been loaded onto this TypeMap."
+            raise ValueError(msg)
+
+        namespace, data_type = self.get_container_cls_dt(container_cls)
+        if namespace is None:
+            msg = "Class %s is not mapped to a data_type; cannot look up TermSet configuration." % container_cls
+            raise ValueError(msg)
+
+        termset_config = configurator.config
+        if namespace not in termset_config['namespaces']:
+            msg = "No TermSet configuration found for namespace '%s'." % namespace
+            raise ValueError(msg)
+
+        config_namespace = termset_config['namespaces'][namespace]
+        if data_type not in config_namespace['data_types']:
+            msg = "No TermSet configuration found for data_type '%s' in namespace '%s'." % (data_type, namespace)
+            raise ValueError(msg)
+
+        config_data_type = config_namespace['data_types'][data_type]
+        # NOTE: the config always has exactly one loaded path at a time (see TypeConfigurator);
+        # relative termset paths in the config are resolved relative to that file's directory.
+        cur_dir = os.path.dirname(os.path.realpath(configurator.paths[0]))
+
+        def _resolve_termset(config_entry):
+            termset_path = os.path.join(cur_dir, config_entry['termset'])
+            return TermSet(term_schema_path=termset_path)
+
+        if attribute is not None:
+            config_entry = config_data_type.get(attribute)
+            if config_entry is None or 'termset' not in config_entry:
+                msg = "No TermSet configuration found for attribute '%s' on data_type '%s'." % (attribute, data_type)
+                raise ValueError(msg)
+            return _resolve_termset(config_entry)
+
+        termsets = dict()
+        for attr_name, config_entry in config_data_type.items():
+            if isinstance(config_entry, dict) and 'termset' in config_entry:
+                termsets[attr_name] = _resolve_termset(config_entry)
+
+        if not termsets:
+            msg = "No TermSet configuration found for data_type '%s'." % data_type
+            raise ValueError(msg)
+
+        return termsets
 
     @docval({"name": "container_cls", "type": type,
              "doc": "the AbstractContainer class for which the given ObjectMapper class gets used for"},

--- a/src/hdmf/container.py
+++ b/src/hdmf/container.py
@@ -211,6 +211,29 @@ class AbstractContainer(metaclass=ExtenderMeta):
         val = TermSetWrapper(value=val, termset=termset)
         return val
 
+    def get_configured_termsets(self, attribute=None):
+        """
+        Get the configured TermSet(s) for this container's type.
+
+        This delegates to :py:meth:`~hdmf.build.manager.TypeMap.get_configured_termsets` on the
+        TypeMap returned by ``self._get_type_map()``. Using the instance-bound TypeMap (rather
+        than always looking up ``hdmf.common.get_type_map()``) ensures that the correct TypeMap
+        is used even when a downstream package (e.g. PyNWB) overrides ``_get_type_map`` to use
+        its own TypeMap/TypeConfigurator.
+
+        :param attribute: The name of a specific spec attribute (e.g., 'species') to get the
+            TermSet for. If None, returns a dictionary mapping all configured attribute names to
+            their TermSet.
+
+        :return: If ``attribute`` is provided, the :py:class:`~hdmf.term_set.TermSet` configured
+            for that attribute. If ``attribute`` is None, a dict mapping attribute names to their
+            configured :py:class:`~hdmf.term_set.TermSet`.
+        :raises ValueError: If no TermSet configuration is found for this class or attribute, or
+            if no TermSet configuration has been loaded at all.
+        """
+        type_map = self._get_type_map()
+        return type_map.get_configured_termsets(self, attribute=attribute)
+
     @classmethod
     def _getter(cls, field):
         """

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -1,11 +1,23 @@
 import glob
 import os
 from collections import namedtuple
+from enum import Enum
+import difflib
+
 from .utils import docval
 import warnings
 import numpy as np
 from .data_utils import append_data, extend_data
 from ruamel.yaml import YAML
+
+
+class SuggestionStatus(str, Enum):
+    EXACT_MATCH = "exact_match"
+    ALIAS_MATCH = "alias_match"
+    TYPO_MATCH = "typo_match"
+    TYPO_ALIAS_MATCH = "typo_alias_match"
+    URI_MATCH = "uri_match"
+    MEANING_MATCH = "meaning_match"
 
 
 class TermSet:
@@ -19,11 +31,8 @@ class TermSet:
     :ivar schemasheets_folder: The path to the folder containing the LinkML TSV files
     :ivar expanded_termset_path: The path to the schema with the expanded enumerations
     """
-    def __init__(self,
-                 term_schema_path: str=None,
-                 schemasheets_folder: str=None,
-                 dynamic: bool=False
-                 ):
+
+    def __init__(self, term_schema_path: str = None, schemasheets_folder: str = None, dynamic: bool = False):
         """
         :param term_schema_path: The path to the LinkML YAML enumeration schema
         :param schemasheets_folder: The path to the folder containing the LinkML TSV files
@@ -61,38 +70,56 @@ class TermSet:
         self.sources = self.view.schema.prefixes
 
     def __repr__(self):
+        enumeration = list(self.view.all_enums())[0]
+        perm_values_dict = self.view.all_enums()[enumeration].permissible_values
         terms = list(self.view_set.keys())
 
         re = "Schema Path: %s\n" % self.term_schema_path
-        re += "Sources: " + ", ".join(list(self.sources.keys()))+"\n"
+        re += "Sources: " + ", ".join(list(self.sources.keys())) + "\n"
         re += "Terms: \n"
+
+        def format_term(term):
+            aliases = perm_values_dict[term].aliases
+            if aliases:
+                return "   - %s (aliases: %s)\n" % (term, ", ".join(aliases))
+            return "   - %s\n" % term
+
         if len(terms) > 4:
-            re += "   - %s\n" % terms[0]
-            re += "   - %s\n" % terms[1]
-            re += "   - %s\n" % terms[2]
+            re += format_term(terms[0])
+            re += format_term(terms[1])
+            re += format_term(terms[2])
             re += "   ... ... \n"
-            re += "   - %s\n" % terms[-1]
+            re += format_term(terms[-1])
         else:
             for term in terms:
-                re += "   - %s\n" % term
+                re += format_term(term)
         re += "Number of terms: %s" % len(terms)
         return re
 
     def _repr_html_(self):
+        enumeration = list(self.view.all_enums())[0]
+        perm_values_dict = self.view.all_enums()[enumeration].permissible_values
         terms = list(self.view_set.keys())
 
         re = "<b>" + "Schema Path: " + "</b>" + self.term_schema_path + "<br>"
         re += "<b>" + "Sources: " + "</b>" + ", ".join(list(self.sources.keys())) + "<br>"
         re += "<b> Terms: </b>"
+
+        def format_term_html(term):
+            aliases = perm_values_dict[term].aliases
+            if aliases:
+                return "<li> %s <i>(aliases: %s)</i> </li>" % (term, ", ".join(aliases))
+            return "<li> %s </li>" % term
+
         if len(terms) > 4:
-            re += "<li> %s </li>" % terms[0]
-            re += "<li> %s </li>" % terms[1]
-            re += "<li> %s </li>" % terms[2]
+            re += format_term_html(terms[0])
+            re += format_term_html(terms[1])
+            re += format_term_html(terms[2])
             re += "... ..."
-            re += "<li> %s </li>" % terms[-1]
+            re += format_term_html(terms[-1])
         else:
             for term in terms:
-                re += "<li> %s </li>" % term
+                re += format_term_html(term)
         re += "<i> Number of terms:</i> %s" % len(terms)
         return re
 
@@ -102,32 +129,110 @@ class TermSet:
         """
         prefix_dict = self.view.schema.prefixes
         info_tuple = namedtuple("Term_Info", ["id", "description", "meaning"])
-        description = perm_values_dict[key]['description']
-        enum_meaning = perm_values_dict[key]['meaning']
+        description = perm_values_dict[key]["description"]
+        enum_meaning = perm_values_dict[key]["meaning"]
 
         # filter for prefixes
-        marker = ':'
+        marker = ":"
         prefix = enum_meaning.split(marker, 1)[0]
         id = enum_meaning.split(marker, 1)[1]
         prefix_obj = prefix_dict[prefix]
-        prefix_reference = prefix_obj['prefix_reference']
+        prefix_reference = prefix_obj["prefix_reference"]
 
         # combine prefix and prefix_reference to make full term uri
-        meaning = prefix_reference+id
+        meaning = prefix_reference + id
 
         return info_tuple(enum_meaning, description, meaning)
 
-    @docval({'name': 'term', 'type': str, 'doc': "term to be validated"})
+    @docval({"name": "term", "type": str, "doc": "term to be validated"})
     def validate(self, **kwargs):
         """
         Validate term in dataset towards a termset.
         """
-        term = kwargs['term']
+        term = kwargs["term"]
         try:
             self[term]
             return True
         except ValueError:
             return False
+
+    @docval({"name": "term", "type": str, "doc": "term to get a suggestion for"})
+    def suggest_term(self, **kwargs):
+        """
+        Suggest a canonical term for a user-provided string.
+
+        Returns
+        -------
+        tuple of (Term_Info, SuggestionStatus, str) or None
+            A tuple containing the suggested canonical term info, a machine-readable status,
+            and a human-readable reason for the suggestion. Returns ``None`` when no suggestion is available.
+        """
+        term = kwargs["term"]
+        if not isinstance(term, str):
+            return None
+
+        stripped = term.strip()
+        if stripped == "":
+            return None
+
+        view_set_keys = list(self.view_set.keys())
+
+        # Check for exact canonical match
+        if stripped in view_set_keys:
+            return self[stripped], SuggestionStatus.EXACT_MATCH, f"'{stripped}' is a known primary term"
+
+        enumeration = list(self.view.all_enums())[0]
+        perm_values_dict = self.view.all_enums()[enumeration].permissible_values
+
+        # Check for URI or MEANING/Prefix ID match
+        # term_info.meaning contains the full URI (prefix_reference + id)
+        # term_info.id contains the MEANING (e.g. prefix:id)
+        for key in view_set_keys:
+            term_info = self[key]
+            if stripped == term_info.meaning:
+                return term_info, SuggestionStatus.URI_MATCH, f"'{stripped}' matches the URI of known term '{key}'"
+            if stripped == term_info.id:
+                return (
+                    term_info,
+                    SuggestionStatus.MEANING_MATCH,
+                    f"'{stripped}' matches the meaning ID of known term '{key}'",
+                )
+
+        # Recognized alias
+        for key, val in perm_values_dict.items():
+            if val.aliases and stripped in val.aliases:
+                return self[key], SuggestionStatus.ALIAS_MATCH, f"'{stripped}' is a recognized alias for '{key}'"
+
+        # Likely typo of a known primary term
+        close_matches = difflib.get_close_matches(stripped, view_set_keys, n=1, cutoff=0.85)
+        if close_matches:
+            canonical_name = close_matches[0]
+            return (
+                self[canonical_name],
+                SuggestionStatus.TYPO_MATCH,
+                f"'{stripped}' closely matches the known term '{canonical_name}'",
+            )
+
+        # Likely typo of an alias
+        all_aliases = []
+        alias_to_primary = {}
+        for key, val in perm_values_dict.items():
+            if val.aliases:
+                for alias in val.aliases:
+                    all_aliases.append(alias)
+                    alias_to_primary[alias] = key
+
+        if all_aliases:
+            close_aliases = difflib.get_close_matches(stripped, all_aliases, n=1, cutoff=0.85)
+            if close_aliases:
+                canonical_name = alias_to_primary[close_aliases[0]]
+                return (
+                    self[canonical_name],
+                    SuggestionStatus.TYPO_ALIAS_MATCH,
+                    f"'{stripped}' closely matches the alias '{close_aliases[0]}' for known term '{canonical_name}'",
+                )
+
+        return None
 
     @property
     def view_set(self):
@@ -139,8 +244,9 @@ class TermSet:
         perm_values_dict = self.view.all_enums()[enumeration].permissible_values
         enum_dict = {}
         for perm_value_key in perm_values_dict.keys():
-            enum_dict[perm_value_key] = self.__perm_value_key_info(perm_values_dict=perm_values_dict,
-                                                                   key=perm_value_key)
+            enum_dict[perm_value_key] = self.__perm_value_key_info(
+                perm_values_dict=perm_values_dict, key=perm_value_key
+            )
 
         return enum_dict
 
@@ -156,8 +262,28 @@ class TermSet:
             return term_info
 
         except KeyError:
-            msg = 'Term not in schema'
+            for key, val in perm_values_dict.items():
+                if val.aliases and term in val.aliases:
+                    return self.__perm_value_key_info(perm_values_dict=perm_values_dict, key=key)
+            msg = "Term not in schema"
             raise ValueError(msg)
+
+    def get_primary_term(self, term):
+        """
+        Method to retrieve the primary term name for a given term (which may be an alias).
+        """
+        enumeration = list(self.view.all_enums())[0]
+        perm_values_dict = self.view.all_enums()[enumeration].permissible_values
+
+        if term in perm_values_dict:
+            return term
+
+        for key, val in perm_values_dict.items():
+            if val.aliases and term in val.aliases:
+                return key
+
+        msg = "Term not in schema"
+        raise ValueError(msg)
 
     def __schemasheets_convert(self):
         """
@@ -168,7 +294,7 @@ class TermSet:
         try:
             from linkml_runtime.utils.schema_as_dict import schema_as_dict
             from schemasheets.schemamaker import SchemaMaker
-        except ImportError as e:   # pragma: no cover
+        except ImportError as e:  # pragma: no cover
             msg = (
                 "There is an issue with importing schemasheets. Please make sure a compatible "
                 "version of schemascheets is installed."
@@ -182,7 +308,7 @@ class TermSet:
         schemasheet_schema_path = os.path.join(self.schemasheets_folder, f"{schema_dict['name']}.yaml")
 
         with open(schemasheet_schema_path, "w") as f:
-            yaml=YAML(typ='safe')
+            yaml = YAML(typ="safe")
             yaml.dump(schema_dict, f)
 
         return schemasheet_schema_path
@@ -199,7 +325,7 @@ class TermSet:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=DeprecationWarning)
                 from oaklib.utilities.subsets.value_set_expander import ValueSetExpander
-        except ImportError:   # pragma: no cover
+        except ImportError:  # pragma: no cover
             msg = (
                 "There is an issue with importing oaklib. Please make sure a compatible "
                 "version of oaklib is installed."
@@ -215,24 +341,74 @@ class TermSet:
 
         return output_path
 
+
 class TermSetWrapper:
     """
     This class allows any HDF5 dataset or attribute to have a TermSet.
     """
-    @docval({'name': 'termset',
-             'type': TermSet,
-             'doc': 'The TermSet to be used.'},
-            {'name': 'value',
-             'type': (list, np.ndarray, dict, str, tuple),
-             'doc': 'The target item that is wrapped, either data or attribute.'},
-            {'name': 'field', 'type': str, 'default': None,
-             'doc': 'The field within a compound array.'}
-            )
+
+    @docval(
+        {"name": "termset", "type": TermSet, "doc": "The TermSet to be used."},
+        {
+            "name": "value",
+            "type": (list, np.ndarray, dict, str, tuple),
+            "doc": "The target item that is wrapped, either data or attribute.",
+        },
+        {"name": "field", "type": str, "default": None, "doc": "The field within a compound array."},
+    )
     def __init__(self, **kwargs):
-        self.__value = kwargs['value']
-        self.__termset = kwargs['termset']
-        self.__field = kwargs['field']
+        self.__value = kwargs["value"]
+        self.__termset = kwargs["termset"]
+        self.__field = kwargs["field"]
+        self.__value = self.__resolve_aliases(self.__value)
+
         self.__validate()
+
+    def __resolve_aliases(self, value):
+        if self.__field is not None:
+            if isinstance(value, dict):
+                value_copy = dict(value)
+                value_copy[self.__field] = self.__resolve_aliases_list(value[self.__field])
+                return value_copy
+            else:
+                # If it's a compound array or similar, we might need to handle it.
+                # Since the current code does `values = self.__value[self.__field]`,
+                # we assume we can just replace that field if possible.
+                # However, for numpy recarrays, modifying fields is different.
+                # To be safe and simple, let's just resolve items if it's a list/tuple/array.
+                if isinstance(value, np.ndarray):
+                    # It's a compound array
+                    value_copy = value.copy()
+                    for i in range(len(value_copy)):
+                        try:
+                            term = value_copy[self.__field][i]
+                            if isinstance(term, str):
+                                value_copy[self.__field][i] = self.__termset.get_primary_term(term)
+                        except ValueError:
+                            pass
+                    return value_copy
+                return value
+        else:
+            return self.__resolve_aliases_list(value)
+
+    def __resolve_aliases_list(self, values):
+        if isinstance(values, str):
+            try:
+                return self.__termset.get_primary_term(values)
+            except ValueError:
+                return values
+        elif isinstance(values, list):
+            return [self.__resolve_aliases_list(v) for v in values]
+        elif isinstance(values, tuple):
+            return tuple(self.__resolve_aliases_list(v) for v in values)
+        elif isinstance(values, np.ndarray):
+            if values.dtype.kind in {"U", "S", "O"}:  # string or object
+                resolved = []
+                for v in values:
+                    resolved.append(self.__resolve_aliases_list(v))
+                return np.array(resolved, dtype=values.dtype)
+            return values
+        return values
 
     def __validate(self):
         if self.__field is not None:
@@ -251,8 +427,8 @@ class TermSetWrapper:
             validation = self.__termset.validate(term=term)
             if not validation:
                 bad_values.append(term)
-        if len(bad_values)!=0:
-            msg = ('"%s" is not in the term set.' % ', '.join([str(value) for value in bad_values]))
+        if len(bad_values) != 0:
+            msg = '"%s" is not in the term set.' % ", ".join([str(value) for value in bad_values])
             raise ValueError(msg)
 
     @property
@@ -269,7 +445,7 @@ class TermSetWrapper:
 
     @property
     def dtype(self):
-        return self.__getattr__('dtype')
+        return self.__getattr__("dtype")
 
     def __getattr__(self, val):
         """
@@ -312,7 +488,7 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            if self.__field is not None: # compound array
+            if self.__field is not None:  # compound array
                 values = arg[self.__field]
             else:
                 msg = "Array needs to be a structured array with compound dtype. If this does not apply, use extend."
@@ -322,8 +498,8 @@ class TermSetWrapper:
 
         bad_values = self.__multi_validation(values)
 
-        if len(bad_values)!=0:
-            msg = ('"%s" is not in the term set.' % ', '.join([str(value) for value in bad_values]))
+        if len(bad_values) != 0:
+            msg = '"%s" is not in the term set.' % ", ".join([str(value) for value in bad_values])
             raise ValueError(msg)
 
         self.__value = append_data(self.__value, arg)
@@ -334,7 +510,7 @@ class TermSetWrapper:
         the wrapper.
         """
         if isinstance(arg, np.ndarray):
-            if self.__field is not None: # compound array
+            if self.__field is not None:  # compound array
                 values = arg[self.__field]
             else:
                 values = arg
@@ -343,11 +519,12 @@ class TermSetWrapper:
 
         bad_data = self.__multi_validation(values)
 
-        if len(bad_data)==0:
+        if len(bad_data) == 0:
             self.__value = extend_data(self.__value, arg)
         else:
-            msg = ('"%s" is not in the term set.' % ', '.join([str(item) for item in bad_data]))
+            msg = '"%s" is not in the term set.' % ", ".join([str(item) for item in bad_data])
             raise ValueError(msg)
+
 
 class TypeConfigurator:
     """
@@ -355,7 +532,8 @@ class TypeConfigurator:
     When toggled on, every instance of a configuration file supported data type will be validated
     according to the corresponding TermSet.
     """
-    @docval({'name': 'paths', 'type': list, 'doc': 'Paths to configuration files.', 'default': None})
+
+    @docval({"name": "paths", "type": list, "doc": "Paths to configuration files.", "default": None})
     def __init__(self, **kwargs):
         self.config = None
         self.paths = []
@@ -363,56 +541,56 @@ class TypeConfigurator:
             for p in kwargs["paths"]:
                 self.load_type_config(p)
 
-    @docval({'name': 'data_type', 'type': str,
-             'doc': 'The desired data type within the configuration file.'},
-            {'name': 'namespace', 'type': str,
-             'doc': 'The namespace for the data type.'})
+    @docval(
+        {"name": "data_type", "type": str, "doc": "The desired data type within the configuration file."},
+        {"name": "namespace", "type": str, "doc": "The namespace for the data type."},
+    )
     def get_config(self, data_type, namespace):
         """
         Return the config for that data type in the given namespace.
         """
         try:
-            namespace_config = self.config['namespaces'][namespace]
+            namespace_config = self.config["namespaces"][namespace]
         except KeyError:
-            msg = 'The namespace %s was not found within the configuration.' % namespace
+            msg = "The namespace %s was not found within the configuration." % namespace
             raise ValueError(msg)
 
         try:
-            type_config = namespace_config['data_types'][data_type]
+            type_config = namespace_config["data_types"][data_type]
             return type_config
         except KeyError:
-            msg = '%s was not found within the configuration for that namespace.' % data_type
+            msg = "%s was not found within the configuration for that namespace." % data_type
             raise ValueError(msg)
 
-    @docval({'name': 'config_path', 'type': str, 'doc': 'Path to the configuration file.'})
+    @docval({"name": "config_path", "type": str, "doc": "Path to the configuration file."})
     def load_type_config(self, config_path):
         """
         Load the configuration file for validation on the fields defined for the objects within the file.
         """
-        with open(config_path, 'r') as config:
-            yaml = YAML(typ='safe')
+        with open(config_path, "r") as config:
+            yaml = YAML(typ="safe")
             termset_config = yaml.load(config)
-            if self.config is None: # set the initial config/load after config has been unloaded
+            if self.config is None:  # set the initial config/load after config has been unloaded
                 self.config = termset_config
-                if len(self.paths) == 0: # for loading after an unloaded config
+                if len(self.paths) == 0:  # for loading after an unloaded config
                     self.paths.append(config_path)
-            else: # append/replace to the existing config
+            else:  # append/replace to the existing config
                 if config_path in self.paths:
-                    msg = 'This configuration file path already exists within the configurator.'
+                    msg = "This configuration file path already exists within the configurator."
                     raise ValueError(msg)
                 else:
-                    for namespace in termset_config['namespaces']:
-                        if namespace not in self.config['namespaces']: # append namespace config if not present
-                            self.config['namespaces'][namespace] = termset_config['namespaces'][namespace]
-                        else: # check for any needed overrides within existing namespace configs
-                            for data_type in termset_config['namespaces'][namespace]['data_types']:
+                    for namespace in termset_config["namespaces"]:
+                        if namespace not in self.config["namespaces"]:  # append namespace config if not present
+                            self.config["namespaces"][namespace] = termset_config["namespaces"][namespace]
+                        else:  # check for any needed overrides within existing namespace configs
+                            for data_type in termset_config["namespaces"][namespace]["data_types"]:
                                 # NOTE: these two branches effectively do the same thing, but are split for clarity.
-                                if data_type in self.config['namespaces'][namespace]['data_types']:
-                                    replace_config = termset_config['namespaces'][namespace]['data_types'][data_type]
-                                    self.config['namespaces'][namespace]['data_types'][data_type] = replace_config
-                                else: # append to config
-                                    new_config = termset_config['namespaces'][namespace]['data_types'][data_type]
-                                    self.config['namespaces'][namespace]['data_types'][data_type] = new_config
+                                if data_type in self.config["namespaces"][namespace]["data_types"]:
+                                    replace_config = termset_config["namespaces"][namespace]["data_types"][data_type]
+                                    self.config["namespaces"][namespace]["data_types"][data_type] = replace_config
+                                else:  # append to config
+                                    new_config = termset_config["namespaces"][namespace]["data_types"][data_type]
+                                    self.config["namespaces"][namespace]["data_types"][data_type] = new_config
 
                     # append path to self.paths
                     self.paths.append(config_path)

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -327,8 +327,7 @@ class TermSet:
                 from oaklib.utilities.subsets.value_set_expander import ValueSetExpander
         except ImportError:  # pragma: no cover
             msg = (
-                "There is an issue with importing oaklib. Please make sure a compatible "
-                "version of oaklib is installed."
+                "There is an issue with importing oaklib. Please make sure a compatible version of oaklib is installed."
             )
             raise ImportError(msg)
         expander = ValueSetExpander()
@@ -360,55 +359,8 @@ class TermSetWrapper:
         self.__value = kwargs["value"]
         self.__termset = kwargs["termset"]
         self.__field = kwargs["field"]
-        self.__value = self.__resolve_aliases(self.__value)
 
         self.__validate()
-
-    def __resolve_aliases(self, value):
-        if self.__field is not None:
-            if isinstance(value, dict):
-                value_copy = dict(value)
-                value_copy[self.__field] = self.__resolve_aliases_list(value[self.__field])
-                return value_copy
-            else:
-                # If it's a compound array or similar, we might need to handle it.
-                # Since the current code does `values = self.__value[self.__field]`,
-                # we assume we can just replace that field if possible.
-                # However, for numpy recarrays, modifying fields is different.
-                # To be safe and simple, let's just resolve items if it's a list/tuple/array.
-                if isinstance(value, np.ndarray):
-                    # It's a compound array
-                    value_copy = value.copy()
-                    for i in range(len(value_copy)):
-                        try:
-                            term = value_copy[self.__field][i]
-                            if isinstance(term, str):
-                                value_copy[self.__field][i] = self.__termset.get_primary_term(term)
-                        except ValueError:
-                            pass
-                    return value_copy
-                return value
-        else:
-            return self.__resolve_aliases_list(value)
-
-    def __resolve_aliases_list(self, values):
-        if isinstance(values, str):
-            try:
-                return self.__termset.get_primary_term(values)
-            except ValueError:
-                return values
-        elif isinstance(values, list):
-            return [self.__resolve_aliases_list(v) for v in values]
-        elif isinstance(values, tuple):
-            return tuple(self.__resolve_aliases_list(v) for v in values)
-        elif isinstance(values, np.ndarray):
-            if values.dtype.kind in {"U", "S", "O"}:  # string or object
-                resolved = []
-                for v in values:
-                    resolved.append(self.__resolve_aliases_list(v))
-                return np.array(resolved, dtype=values.dtype)
-            return values
-        return values
 
     def __validate(self):
         if self.__field is not None:

--- a/src/hdmf/term_set.py
+++ b/src/hdmf/term_set.py
@@ -125,12 +125,13 @@ class TermSet:
 
     def __perm_value_key_info(self, perm_values_dict: dict, key: str):
         """
-        Private method to retrieve the id, description, and the meaning.
+        Private method to retrieve the id, description, meaning, and aliases.
         """
         prefix_dict = self.view.schema.prefixes
-        info_tuple = namedtuple("Term_Info", ["id", "description", "meaning"])
+        info_tuple = namedtuple("Term_Info", ["id", "description", "meaning", "aliases"])
         description = perm_values_dict[key]["description"]
         enum_meaning = perm_values_dict[key]["meaning"]
+        aliases = perm_values_dict[key].aliases if hasattr(perm_values_dict[key], "aliases") else []
 
         # filter for prefixes
         marker = ":"
@@ -142,7 +143,7 @@ class TermSet:
         # combine prefix and prefix_reference to make full term uri
         meaning = prefix_reference + id
 
-        return info_tuple(enum_meaning, description, meaning)
+        return info_tuple(enum_meaning, description, meaning, aliases)
 
     @docval({"name": "term", "type": str, "doc": "term to be validated"})
     def validate(self, **kwargs):

--- a/tests/unit/example_test_term_set_alias.yaml
+++ b/tests/unit/example_test_term_set_alias.yaml
@@ -1,0 +1,26 @@
+id: termset/species_example
+name: NWBSubjectSpeciesStarter
+version: 0.1.0
+prefixes:
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+imports:
+  - linkml:types
+default_range: string
+
+enums:
+  SubjectSpecies:
+    permissible_values:
+      Homo sapiens:
+        description: Human.
+        meaning: NCBITaxon:9606
+        aliases:
+          - human
+      Mus musculus:
+        description: House mouse.
+        meaning: NCBITaxon:10090
+        aliases:
+          - mouse
+          - house mouse
+      Drosophila persimilis:
+        description: Drosophila persimilis.
+        meaning: NCBITaxon:7234

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -445,6 +445,33 @@ class TestGlobalTypeConfig(TestCase):
         with self.assertWarns(Warning):
             ExtensionContainer(name="foo", namespace="foo_namespace", description="Homo sapiens")
 
+    def test_get_configured_termsets_instance_all(self):
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+        termsets = data.get_configured_termsets()
+        self.assertEqual(list(termsets.keys()), ["description"])
+        self.assertIsInstance(termsets["description"], TermSet)
+
+    def test_get_configured_termsets_instance_attribute(self):
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+        termset = data.get_configured_termsets(attribute="description")
+        self.assertIsInstance(termset, TermSet)
+
+    def test_get_configured_termsets_instance_attribute_not_configured(self):
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+        with self.assertRaises(ValueError):
+            data.get_configured_termsets(attribute="name")
+
+    def test_get_configured_termsets_no_config_loaded(self):
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+        unload_type_config()
+        with self.assertRaises(ValueError):
+            data.get_configured_termsets()
+
+    def test_get_configured_termsets_class_not_mapped(self):
+        container = ExtensionContainer(name="foo", namespace="foo_namespace2", description="Homo sapiens")
+        with self.assertRaises(ValueError):
+            container.get_configured_termsets()
+
 
 @pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
 class TestNonGlobalTypeConfig(TestCase):
@@ -464,6 +491,92 @@ class TestNonGlobalTypeConfig(TestCase):
 
         assert type_map1.type_config.paths == []
         assert type_map2.type_config.paths == []
+
+    def test_get_configured_termsets_uses_instance_type_map(self):
+        """A container instance's get_configured_termsets should use its own (non-global) TypeMap."""
+        from hdmf.common import get_type_map
+
+        # Build TypeMaps that know about the registered container classes (e.g. VectorData) by
+        # merging in the registrations from the global TypeMap, but with independent TermSet
+        # configurations -- mirroring how a downstream package (e.g. PyNWB) would have its own
+        # TypeMap with its own registered classes and TermSet configuration.
+        type_map1 = TypeMap()
+        type_map1.merge(get_type_map(copy=False), ns_catalog=True)
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=type_map1)
+
+        type_map2 = TypeMap()
+        type_map2.merge(get_type_map(copy=False), ns_catalog=True)
+        load_type_config(config_path="tests/unit/hdmf_config2.yaml", type_map=type_map2)
+
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+
+        # Bypass the global _get_type_map lookup and check both TypeMaps directly, mirroring
+        # how a downstream package (e.g. PyNWB) with its own TypeMap would resolve this.
+        termsets1 = type_map1.get_configured_termsets(data)
+        self.assertEqual(list(termsets1.keys()), ["description"])
+
+        with self.assertRaises(ValueError):
+            # "name" is only configured (with no termset) in hdmf_config2, not hdmf_config
+            type_map1.get_configured_termsets(data, attribute="name")
+
+        with self.assertRaises(ValueError):
+            # "description" is not configured with a termset for VectorData in hdmf_config2
+            type_map2.get_configured_termsets(data, attribute="description")
+
+        unload_type_config(type_map1)
+        unload_type_config(type_map2)
+
+
+@pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
+class TestTypeMapGetConfiguredTermsets(TestCase):
+    """Tests for TypeMap.get_configured_termsets using a class (rather than an instance).
+
+    These use the global type map (as returned by ``hdmf.common.get_type_map``) since a freshly
+    constructed ``TypeMap()`` does not have any container classes (e.g. VectorData) registered to
+    a data_type/namespace.
+    """
+
+    def setUp(self):
+        from hdmf.common import get_type_map
+        self.type_map = get_type_map(copy=False)
+
+    def tearDown(self):
+        unload_type_config(self.type_map)
+
+    def test_get_configured_termsets_class_all(self):
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
+        termsets = self.type_map.get_configured_termsets(VectorData)
+        self.assertEqual(list(termsets.keys()), ["description"])
+        self.assertIsInstance(termsets["description"], TermSet)
+
+    def test_get_configured_termsets_class_attribute(self):
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
+        termset = self.type_map.get_configured_termsets(VectorData, attribute="description")
+        self.assertIsInstance(termset, TermSet)
+
+    def test_get_configured_termsets_class_attribute_not_configured(self):
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
+        with self.assertRaises(ValueError):
+            self.type_map.get_configured_termsets(VectorData, attribute="name")
+
+    def test_get_configured_termsets_data_type_not_in_config(self):
+        load_type_config(config_path="tests/unit/hdmf_config2.yaml", type_map=self.type_map)
+        with self.assertRaises(ValueError):
+            # VectorData is configured in hdmf_config2 but with no termset entries (only "name": None)
+            self.type_map.get_configured_termsets(VectorData)
+
+    def test_get_configured_termsets_class_not_mapped_to_data_type(self):
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
+
+        class Unmapped(Container):
+            pass
+
+        with self.assertRaises(ValueError):
+            self.type_map.get_configured_termsets(Unmapped)
+
+    def test_get_configured_termsets_no_config_loaded(self):
+        with self.assertRaises(ValueError):
+            self.type_map.get_configured_termsets(VectorData)
 
 
 class TestOptionalDepsNotInstalled(TestCase):

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -458,19 +458,16 @@ class TestGlobalTypeConfig(TestCase):
 
     def test_get_configured_termsets_instance_attribute_not_configured(self):
         data = VectorData(name="foo", data=[0], description="Homo sapiens")
-        with self.assertRaises(ValueError):
-            data.get_configured_termsets(attribute="name")
+        self.assertIsNone(data.get_configured_termsets(attribute="name"))
 
     def test_get_configured_termsets_no_config_loaded(self):
         data = VectorData(name="foo", data=[0], description="Homo sapiens")
         unload_type_config()
-        with self.assertRaises(ValueError):
-            data.get_configured_termsets()
+        self.assertEqual(data.get_configured_termsets(), dict())
 
     def test_get_configured_termsets_class_not_mapped(self):
         container = ExtensionContainer(name="foo", namespace="foo_namespace2", description="Homo sapiens")
-        with self.assertRaises(ValueError):
-            container.get_configured_termsets()
+        self.assertEqual(container.get_configured_termsets(), dict())
 
 
 @pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
@@ -515,13 +512,11 @@ class TestNonGlobalTypeConfig(TestCase):
         termsets1 = type_map1.get_configured_termsets(data)
         self.assertEqual(list(termsets1.keys()), ["description"])
 
-        with self.assertRaises(ValueError):
-            # "name" is only configured (with no termset) in hdmf_config2, not hdmf_config
-            type_map1.get_configured_termsets(data, attribute="name")
+        # "name" is only configured (with no termset) in hdmf_config2, not hdmf_config
+        self.assertIsNone(type_map1.get_configured_termsets(data, attribute="name"))
 
-        with self.assertRaises(ValueError):
-            # "description" is not configured with a termset for VectorData in hdmf_config2
-            type_map2.get_configured_termsets(data, attribute="description")
+        # "description" is not configured with a termset for VectorData in hdmf_config2
+        self.assertIsNone(type_map2.get_configured_termsets(data, attribute="description"))
 
         unload_type_config(type_map1)
         unload_type_config(type_map2)
@@ -556,14 +551,12 @@ class TestTypeMapGetConfiguredTermsets(TestCase):
 
     def test_get_configured_termsets_class_attribute_not_configured(self):
         load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
-        with self.assertRaises(ValueError):
-            self.type_map.get_configured_termsets(VectorData, attribute="name")
+        self.assertIsNone(self.type_map.get_configured_termsets(VectorData, attribute="name"))
 
     def test_get_configured_termsets_data_type_not_in_config(self):
         load_type_config(config_path="tests/unit/hdmf_config2.yaml", type_map=self.type_map)
-        with self.assertRaises(ValueError):
-            # VectorData is configured in hdmf_config2 but with no termset entries (only "name": None)
-            self.type_map.get_configured_termsets(VectorData)
+        # VectorData is configured in hdmf_config2 but with no termset entries (only "name": None)
+        self.assertEqual(self.type_map.get_configured_termsets(VectorData), dict())
 
     def test_get_configured_termsets_class_not_mapped_to_data_type(self):
         load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=self.type_map)
@@ -571,12 +564,10 @@ class TestTypeMapGetConfiguredTermsets(TestCase):
         class Unmapped(Container):
             pass
 
-        with self.assertRaises(ValueError):
-            self.type_map.get_configured_termsets(Unmapped)
+        self.assertEqual(self.type_map.get_configured_termsets(Unmapped), dict())
 
     def test_get_configured_termsets_no_config_loaded(self):
-        with self.assertRaises(ValueError):
-            self.type_map.get_configured_termsets(VectorData)
+        self.assertEqual(self.type_map.get_configured_termsets(VectorData), dict())
 
 
 class TestOptionalDepsNotInstalled(TestCase):

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -281,6 +281,37 @@ class TestTermSetWrapper(TestCase):
         with self.assertRaises(ValueError):
             data_obj.extend(["bad_data"])
 
+    def test_wrapper_alias(self):
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
+
+        # single value
+        wrapper = TermSetWrapper(termset=termset, value="human")
+        self.assertEqual(wrapper.value, "human")
+
+        # list
+        wrapper_list = TermSetWrapper(termset=termset, value=["human", "house mouse"])
+        self.assertEqual(wrapper_list.value, ["human", "house mouse"])
+
+        # tuple
+        wrapper_tuple = TermSetWrapper(termset=termset, value=("human", "house mouse"))
+        self.assertEqual(wrapper_tuple.value, ("human", "house mouse"))
+
+        # numpy array
+        wrapper_array = TermSetWrapper(termset=termset, value=np.array(["human", "house mouse"]))
+        np.testing.assert_array_equal(wrapper_array.value, np.array(["human", "house mouse"]))
+
+        # append (valid alias)
+        wrapper_list.append("Mus musculus")
+        self.assertEqual(wrapper_list.value, ["human", "house mouse", "Mus musculus"])
+        wrapper_list.append("human")
+        self.assertEqual(wrapper_list.value, ["human", "house mouse", "Mus musculus", "human"])
+
+        # extend (valid alias)
+        wrapper_list.extend(["house mouse", "Homo sapiens"])
+        self.assertEqual(
+            wrapper_list.value, ["human", "house mouse", "Mus musculus", "human", "house mouse", "Homo sapiens"]
+        )
+
 
 class TestTypeConfig(TestCase):
     def setUp(self):
@@ -366,20 +397,6 @@ class ExtensionContainer(Container):
         Return the spec data type associated with this container.
         """
         return "ExtensionContainer"
-
-    def test_wrapper_alias(self):
-        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
-        wrapper = TermSetWrapper(termset=termset, value="human")
-        self.assertEqual(wrapper.value, "Homo sapiens")
-
-        wrapper_list = TermSetWrapper(termset=termset, value=["human", "house mouse"])
-        self.assertEqual(wrapper_list.value, ["Homo sapiens", "Mus musculus"])
-
-        wrapper_tuple = TermSetWrapper(termset=termset, value=("human", "house mouse"))
-        self.assertEqual(wrapper_tuple.value, ("Homo sapiens", "Mus musculus"))
-
-        wrapper_array = TermSetWrapper(termset=termset, value=np.array(["human", "house mouse"]))
-        np.testing.assert_array_equal(wrapper_array.value, np.array(["Homo sapiens", "Mus musculus"]))
 
 
 class TestGlobalTypeConfig(TestCase):

--- a/tests/unit/test_term_set.py
+++ b/tests/unit/test_term_set.py
@@ -7,8 +7,7 @@ from hdmf import Container
 from hdmf.build import TypeMap
 from hdmf.term_set import TermSet, TermSetWrapper, TypeConfigurator
 from hdmf.testing import TestCase, remove_test_file
-from hdmf.common import (VectorData, unload_type_config,
-                         get_loaded_type_config, load_type_config)
+from hdmf.common import VectorData, unload_type_config, get_loaded_type_config, load_type_config
 from hdmf.utils import popargs
 
 
@@ -24,8 +23,10 @@ try:
 except ImportError:
     REQUIREMENTS_INSTALLED = False
 
+
 class TestTermSet(TestCase):
     """Tests for TermSet"""
+
     def setUp(self):
         if not REQUIREMENTS_INSTALLED:
             self.skipTest("optional LinkML module is not installed")
@@ -34,82 +35,148 @@ class TestTermSet(TestCase):
         remove_test_file("tests/unit/test_term_set_input/schemasheets/nwb_static_enums.yaml")
 
     def test_termset_setup(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        self.assertEqual(termset.name, 'Species')
-        self.assertEqual(list(termset.sources), ['NCBITaxon'])
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        self.assertEqual(termset.name, "Species")
+        self.assertEqual(list(termset.sources), ["NCBITaxon"])
 
     def test_repr_short(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set2.yaml')
-        output = ('Schema Path: tests/unit/example_test_term_set2.yaml\nSources: NCBITaxon\nTerms: \n'
-                  '   - Homo sapiens\n   - Mus musculus\n   - Ursus arctos horribilis\nNumber of terms: 3')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set2.yaml")
+        output = (
+            "Schema Path: tests/unit/example_test_term_set2.yaml\nSources: NCBITaxon\nTerms: \n"
+            "   - Homo sapiens\n   - Mus musculus\n   - Ursus arctos horribilis\nNumber of terms: 3"
+        )
         self.assertEqual(repr(termset), output)
 
     def test_repr_html_short(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set2.yaml')
-        output = ('<b>Schema Path: </b>tests/unit/example_test_term_set2.yaml<br><b>Sources:'
-                  ' </b>NCBITaxon<br><b> Terms: </b><li> Homo sapiens </li><li> Mus musculus'
-                  ' </li><li> Ursus arctos horribilis </li><i> Number of terms:</i> 3')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set2.yaml")
+        output = (
+            "<b>Schema Path: </b>tests/unit/example_test_term_set2.yaml<br><b>Sources:"
+            " </b>NCBITaxon<br><b> Terms: </b><li> Homo sapiens </li><li> Mus musculus"
+            " </li><li> Ursus arctos horribilis </li><i> Number of terms:</i> 3"
+        )
         self.assertEqual(termset._repr_html_(), output)
 
     def test_repr_long(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        output = ('Schema Path: tests/unit/example_test_term_set.yaml\nSources: NCBITaxon\nTerms: \n'
-                  '   - Homo sapiens\n   - Mus musculus\n   - Ursus arctos horribilis\n   ... ... \n'
-                  '   - Ailuropoda melanoleuca\nNumber of terms: 5')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        output = (
+            "Schema Path: tests/unit/example_test_term_set.yaml\nSources: NCBITaxon\nTerms: \n"
+            "   - Homo sapiens\n   - Mus musculus\n   - Ursus arctos horribilis\n   ... ... \n"
+            "   - Ailuropoda melanoleuca\nNumber of terms: 5"
+        )
         self.assertEqual(repr(termset), output)
 
     def test_repr_html_long(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        output = ('<b>Schema Path: </b>tests/unit/example_test_term_set.yaml<br><b>Sources:'
-                  ' </b>NCBITaxon<br><b> Terms: </b><li> Homo sapiens </li><li> Mus musculus'
-                  ' </li><li> Ursus arctos horribilis </li>... ...<li> Ailuropoda melanoleuca'
-                  ' </li><i> Number of terms:</i> 5')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        output = (
+            "<b>Schema Path: </b>tests/unit/example_test_term_set.yaml<br><b>Sources:"
+            " </b>NCBITaxon<br><b> Terms: </b><li> Homo sapiens </li><li> Mus musculus"
+            " </li><li> Ursus arctos horribilis </li>... ...<li> Ailuropoda melanoleuca"
+            " </li><i> Number of terms:</i> 5"
+        )
         self.assertEqual(termset._repr_html_(), output)
 
     def test_view_set(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        expected = ['Homo sapiens', 'Mus musculus', 'Ursus arctos horribilis', 'Myrmecophaga tridactyla',
-                    'Ailuropoda melanoleuca']
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        expected = [
+            "Homo sapiens",
+            "Mus musculus",
+            "Ursus arctos horribilis",
+            "Myrmecophaga tridactyla",
+            "Ailuropoda melanoleuca",
+        ]
         self.assertEqual(list(termset.view_set), expected)
         self.assertIsInstance(termset.view, SchemaView)
 
     def test_termset_validate(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        self.assertEqual(termset.validate('Homo sapiens'), True)
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        self.assertEqual(termset.validate("Homo sapiens"), True)
 
     def test_termset_validate_false(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        self.assertEqual(termset.validate('missing_term'), False)
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        self.assertEqual(termset.validate("missing_term"), False)
 
     def test_get_item(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
-        self.assertEqual(termset['Homo sapiens'].id, 'NCBITaxon:9606')
-        self.assertEqual(termset['Homo sapiens'].description, 'the species is human')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
+        self.assertEqual(termset["Homo sapiens"].id, "NCBITaxon:9606")
+        self.assertEqual(termset["Homo sapiens"].description, "the species is human")
         self.assertEqual(
-            termset['Homo sapiens'].meaning,
-            'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606'
+            termset["Homo sapiens"].meaning,
+            "https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606",
         )
 
+    def test_termset_alias_validate(self):
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
+        self.assertEqual(termset.validate(term="human"), True)
+        self.assertEqual(termset.validate(term="mouse"), True)
+        self.assertEqual(termset.validate(term="house mouse"), True)
+
+    def test_termset_alias_get_item(self):
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
+        self.assertEqual(termset["human"].id, "NCBITaxon:9606")
+        self.assertEqual(termset["house mouse"].id, "NCBITaxon:10090")
+
     def test_get_item_key_error(self):
-        termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
         with self.assertRaises(ValueError):
-            termset['Homo Ssapiens']
+            termset["Homo Ssapiens"]
 
     def test_schema_sheets_and_path_provided_error(self):
         folder = os.path.join(CUR_DIR, "test_term_set_input", "schemasheets")
         with self.assertRaises(ValueError):
-            TermSet(term_schema_path='tests/unit/example_test_term_set.yaml', schemasheets_folder=folder)
+            TermSet(term_schema_path="tests/unit/example_test_term_set.yaml", schemasheets_folder=folder)
+
+    def test_suggest_term(self):
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
+        from hdmf.term_set import SuggestionStatus
+
+        # Exact match
+        term_info, status, reason = termset.suggest_term(term="Homo sapiens")
+        self.assertEqual(status, SuggestionStatus.EXACT_MATCH)
+        self.assertEqual(term_info.id, "NCBITaxon:9606")
+
+        # Alias match
+        term_info, status, reason = termset.suggest_term(term="human")
+        self.assertEqual(status, SuggestionStatus.ALIAS_MATCH)
+        self.assertEqual(term_info.id, "NCBITaxon:9606")
+
+        # Typo match
+        term_info, status, reason = termset.suggest_term(term="Homo sapien")
+        self.assertEqual(status, SuggestionStatus.TYPO_MATCH)
+        self.assertEqual(term_info.id, "NCBITaxon:9606")
+
+        # Typo alias match
+        term_info, status, reason = termset.suggest_term(term="humann")
+        self.assertEqual(status, SuggestionStatus.TYPO_ALIAS_MATCH)
+        self.assertEqual(term_info.id, "NCBITaxon:9606")
+
+        # URI match
+        term_info, status, reason = termset.suggest_term(term="http://purl.obolibrary.org/obo/NCBITaxon_9606")
+        self.assertEqual(status, SuggestionStatus.URI_MATCH)
+
+        # Meaning match
+        term_info, status, reason = termset.suggest_term(term="NCBITaxon:9606")
+        self.assertEqual(status, SuggestionStatus.MEANING_MATCH)
+
+        # None match
+        self.assertIsNone(termset.suggest_term(term="Random Term"))
+        self.assertIsNone(termset.suggest_term(term=""))
 
     def test_view_set_sheets(self):
         folder = os.path.join(CUR_DIR, "test_term_set_input", "schemasheets")
         termset = TermSet(schemasheets_folder=folder)
-        expected = ['ASTROCYTE', 'INTERNEURON', 'MICROGLIAL_CELL', 'MOTOR_NEURON',
-                    'OLIGODENDROCYTE', 'PYRAMIDAL_NEURON']
+        expected = [
+            "ASTROCYTE",
+            "INTERNEURON",
+            "MICROGLIAL_CELL",
+            "MOTOR_NEURON",
+            "OLIGODENDROCYTE",
+            "PYRAMIDAL_NEURON",
+        ]
         self.assertEqual(list(termset.view_set), expected)
         self.assertIsInstance(termset.view, SchemaView)
 
     def test_enum_expander(self):
-        schema_path = 'tests/unit/example_dynamic_term_set.yaml'
+        schema_path = "tests/unit/example_dynamic_term_set.yaml"
         termset = TermSet(term_schema_path=schema_path, dynamic=True)
         # check that interneuron term is in materialized schema
         self.assertIn("CL:0000099", termset.view_set)
@@ -129,7 +196,7 @@ class TestTermSet(TestCase):
         remove_test_file(f"tests/unit/expanded_{filename}.yaml")
 
     def test_enum_expander_output(self):
-        schema_path = 'tests/unit/example_dynamic_term_set.yaml'
+        schema_path = "tests/unit/example_dynamic_term_set.yaml"
         termset = TermSet(term_schema_path=schema_path, dynamic=True)
         convert_path = termset._TermSet__enum_expander()
         convert_path = os.path.normpath(convert_path)
@@ -152,79 +219,68 @@ class TestTermSet(TestCase):
 
 class TestTermSetWrapper(TestCase):
     """Tests for the TermSetWrapper"""
+
     def setUp(self):
         if not REQUIREMENTS_INSTALLED:
             self.skipTest("optional LinkML module is not installed")
 
-        self.termset = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        self.termset = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
 
-        self.wrapped_array = TermSetWrapper(value=np.array(['Homo sapiens']), termset=self.termset)
-        self.wrapped_list = TermSetWrapper(value=['Homo sapiens'], termset=self.termset)
+        self.wrapped_array = TermSetWrapper(value=np.array(["Homo sapiens"]), termset=self.termset)
+        self.wrapped_list = TermSetWrapper(value=["Homo sapiens"], termset=self.termset)
 
-        c_data = np.array([('Homo sapiens', 24)], dtype=[('species', 'U50'), ('age', 'i4')])
-        self.wrapped_comp_array = TermSetWrapper(value=c_data,
-                                                 termset=self.termset,
-                                                 field='species')
+        c_data = np.array([("Homo sapiens", 24)], dtype=[("species", "U50"), ("age", "i4")])
+        self.wrapped_comp_array = TermSetWrapper(value=c_data, termset=self.termset, field="species")
 
-        self.np_data = VectorData(
-            name='Species_1',
-            description='...',
-            data=self.wrapped_array
-        )
+        self.np_data = VectorData(name="Species_1", description="...", data=self.wrapped_array)
 
     def test_properties(self):
-        self.assertEqual(self.wrapped_array.value, ['Homo sapiens'])
+        self.assertEqual(self.wrapped_array.value, ["Homo sapiens"])
         self.assertEqual(self.wrapped_array.termset.view_set, self.termset.view_set)
-        self.assertEqual(self.wrapped_array.dtype, 'U12') # this covers __getattr__
-        self.assertEqual(self.wrapped_comp_array.field, 'species')
+        self.assertEqual(self.wrapped_array.dtype, "U12")  # this covers __getattr__
+        self.assertEqual(self.wrapped_comp_array.field, "species")
 
     def test_get_item(self):
-        self.assertEqual(self.np_data.data[0], 'Homo sapiens')
+        self.assertEqual(self.np_data.data[0], "Homo sapiens")
 
     def test_validate_error(self):
         with self.assertRaises(ValueError):
-            VectorData(name='Species_1',
-                       description='...',
-                       data=TermSetWrapper(value=['Missing Term'],
-                       termset=self.termset))
+            VectorData(
+                name="Species_1", description="...", data=TermSetWrapper(value=["Missing Term"], termset=self.termset)
+            )
 
     def test_wrapper_validate_attribute(self):
         col1 = VectorData(
-            name='Species_1',
-            description=TermSetWrapper(value='Homo sapiens',
-                                       termset=self.termset),
-            data=['Human']
+            name="Species_1", description=TermSetWrapper(value="Homo sapiens", termset=self.termset), data=["Human"]
         )
         self.assertTrue(isinstance(col1.description, TermSetWrapper))
 
     def test_wrapper_validate_dataset(self):
         col1 = VectorData(
-            name='Species_1',
-            description='...',
-            data=TermSetWrapper(value=['Homo sapiens'],
-                                termset=self.termset)
+            name="Species_1", description="...", data=TermSetWrapper(value=["Homo sapiens"], termset=self.termset)
         )
         self.assertTrue(isinstance(col1.data, TermSetWrapper))
 
     def test_wrapper_append(self):
-        data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
-        data_obj.append('Mus musculus')
-        self.assertEqual(data_obj.data.value, ['Homo sapiens', 'Mus musculus'])
+        data_obj = VectorData(name="species", description="...", data=self.wrapped_list)
+        data_obj.append("Mus musculus")
+        self.assertEqual(data_obj.data.value, ["Homo sapiens", "Mus musculus"])
 
     def test_wrapper_append_error(self):
-        data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
+        data_obj = VectorData(name="species", description="...", data=self.wrapped_list)
         with self.assertRaises(ValueError):
-            data_obj.append('bad_data')
+            data_obj.append("bad_data")
 
     def test_wrapper_extend(self):
-        data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
-        data_obj.extend(['Mus musculus'])
-        self.assertEqual(data_obj.data.value, ['Homo sapiens', 'Mus musculus'])
+        data_obj = VectorData(name="species", description="...", data=self.wrapped_list)
+        data_obj.extend(["Mus musculus"])
+        self.assertEqual(data_obj.data.value, ["Homo sapiens", "Mus musculus"])
 
     def test_wrapper_extend_error(self):
-        data_obj = VectorData(name='species', description='...', data=self.wrapped_list)
+        data_obj = VectorData(name="species", description="...", data=self.wrapped_list)
         with self.assertRaises(ValueError):
-            data_obj.extend(['bad_data'])
+            data_obj.extend(["bad_data"])
+
 
 class TestTypeConfig(TestCase):
     def setUp(self):
@@ -239,49 +295,58 @@ class TestTypeConfig(TestCase):
             get_loaded_type_config()
 
     def test_config_path(self):
-        path = 'tests/unit/hdmf_config.yaml'
+        path = "tests/unit/hdmf_config.yaml"
         tc = TypeConfigurator([path])
         self.assertEqual(tc.paths, [path])
 
     def test_get_config(self):
-        path = 'tests/unit/hdmf_config.yaml'
+        path = "tests/unit/hdmf_config.yaml"
         tc = TypeConfigurator([path])
-        self.assertEqual(tc.get_config('VectorData', 'hdmf-common'),
-                                      {'description': {'termset': 'example_test_term_set.yaml'}})
+        self.assertEqual(
+            tc.get_config("VectorData", "hdmf-common"), {"description": {"termset": "example_test_term_set.yaml"}}
+        )
 
     def test_get_config_namespace_error(self):
-        path = 'tests/unit/hdmf_config.yaml'
+        path = "tests/unit/hdmf_config.yaml"
         tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
-            tc.get_config('VectorData', 'hdmf-common11')
+            tc.get_config("VectorData", "hdmf-common11")
 
     def test_get_config_container_error(self):
-        path = 'tests/unit/hdmf_config.yaml'
+        path = "tests/unit/hdmf_config.yaml"
         tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
-            tc.get_config('VectorData11', 'hdmf-common')
+            tc.get_config("VectorData11", "hdmf-common")
 
     def test_already_loaded_path_error(self):
-        path = 'tests/unit/hdmf_config.yaml'
+        path = "tests/unit/hdmf_config.yaml"
         tc = TypeConfigurator([path])
         with self.assertRaises(ValueError):
             tc.load_type_config(config_path=path)
 
     def test_load_two_unique_configs(self):
-        path = 'tests/unit/hdmf_config.yaml'
-        path2 = 'tests/unit/hdmf_config2.yaml'
+        path = "tests/unit/hdmf_config.yaml"
+        path2 = "tests/unit/hdmf_config2.yaml"
         tc = TypeConfigurator([path])
         tc.load_type_config(config_path=path2)
-        config = {'namespaces': {'hdmf-common': {'version': '3.12.2',
-                  'data_types': {'VectorData': {'name': None},
-                  'VectorIndex': {'data': '...'},
-                  'Data': {'description': {'termset': 'example_test_term_set.yaml'}},
-                  'EnumData': {'description': {'termset': 'example_test_term_set.yaml'}}}},
-                  'foo_namespace': {'version': '...',
-                  'data_types': {'ExtensionContainer': {'description': None}}},
-                  'namespace2': {'version': 0, 'data_types':
-                  {'MythicData': {'description':
-                  {'termset': 'example_test_term_set.yaml'}}}}}}
+        config = {
+            "namespaces": {
+                "hdmf-common": {
+                    "version": "3.12.2",
+                    "data_types": {
+                        "VectorData": {"name": None},
+                        "VectorIndex": {"data": "..."},
+                        "Data": {"description": {"termset": "example_test_term_set.yaml"}},
+                        "EnumData": {"description": {"termset": "example_test_term_set.yaml"}},
+                    },
+                },
+                "foo_namespace": {"version": "...", "data_types": {"ExtensionContainer": {"description": None}}},
+                "namespace2": {
+                    "version": 0,
+                    "data_types": {"MythicData": {"description": {"termset": "example_test_term_set.yaml"}}},
+                },
+            }
+        }
         self.assertEqual(tc.paths, [path, path2])
         self.assertEqual(tc.config, config)
 
@@ -290,7 +355,7 @@ class ExtensionContainer(Container):
     __fields__ = ("description",)
 
     def __init__(self, **kwargs):
-        description, namespace = popargs('description', 'namespace', kwargs)
+        description, namespace = popargs("description", "namespace", kwargs)
         self.namespace = namespace
         super().__init__(**kwargs)
         self.description = description
@@ -302,63 +367,80 @@ class ExtensionContainer(Container):
         """
         return "ExtensionContainer"
 
+    def test_wrapper_alias(self):
+        termset = TermSet(term_schema_path="tests/unit/example_test_term_set_alias.yaml")
+        wrapper = TermSetWrapper(termset=termset, value="human")
+        self.assertEqual(wrapper.value, "Homo sapiens")
+
+        wrapper_list = TermSetWrapper(termset=termset, value=["human", "house mouse"])
+        self.assertEqual(wrapper_list.value, ["Homo sapiens", "Mus musculus"])
+
+        wrapper_tuple = TermSetWrapper(termset=termset, value=("human", "house mouse"))
+        self.assertEqual(wrapper_tuple.value, ("Homo sapiens", "Mus musculus"))
+
+        wrapper_array = TermSetWrapper(termset=termset, value=np.array(["human", "house mouse"]))
+        np.testing.assert_array_equal(wrapper_array.value, np.array(["Homo sapiens", "Mus musculus"]))
+
 
 class TestGlobalTypeConfig(TestCase):
     def setUp(self):
         if not REQUIREMENTS_INSTALLED:
             self.skipTest("optional LinkML module is not installed")
-        load_type_config(config_path='tests/unit/hdmf_config.yaml')
+        load_type_config(config_path="tests/unit/hdmf_config.yaml")
 
     def tearDown(self):
         unload_type_config()
 
     def test_load_config(self):
         config = get_loaded_type_config()
-        self.assertEqual(config,
-        {'namespaces': {'hdmf-common': {'version': '3.12.2',
-         'data_types': {'VectorData':
-        {'description': {'termset': 'example_test_term_set.yaml'}},
-         'VectorIndex': {'data': '...'}}}, 'foo_namespace':
-        {'version': '...', 'data_types':
-        {'ExtensionContainer': {'description': None}}}}}
-)
+        self.assertEqual(
+            config,
+            {
+                "namespaces": {
+                    "hdmf-common": {
+                        "version": "3.12.2",
+                        "data_types": {
+                            "VectorData": {"description": {"termset": "example_test_term_set.yaml"}},
+                            "VectorIndex": {"data": "..."},
+                        },
+                    },
+                    "foo_namespace": {"version": "...", "data_types": {"ExtensionContainer": {"description": None}}},
+                }
+            },
+        )
 
     def test_validate_with_config(self):
-        data = VectorData(name='foo', data=[0], description='Homo sapiens')
-        self.assertEqual(data.description.value, 'Homo sapiens')
+        data = VectorData(name="foo", data=[0], description="Homo sapiens")
+        self.assertEqual(data.description.value, "Homo sapiens")
 
     def test_already_wrapped_warn(self):
-        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        terms = TermSet(term_schema_path="tests/unit/example_test_term_set.yaml")
         with self.assertWarns(Warning):
-            VectorData(name='foo',
-                       data=[0],
-                       description=TermSetWrapper(value='Homo sapiens', termset=terms))
+            VectorData(name="foo", data=[0], description=TermSetWrapper(value="Homo sapiens", termset=terms))
 
     def test_field_not_in_config(self):
         unload_type_config()
-        load_type_config(config_path='tests/unit/hdmf_config2.yaml')
+        load_type_config(config_path="tests/unit/hdmf_config2.yaml")
 
-        VectorData(name='foo', data=[0], description='Homo sapiens')
+        VectorData(name="foo", data=[0], description="Homo sapiens")
 
     def test_spec_none(self):
         with self.assertWarns(Warning):
-            ExtensionContainer(name='foo',
-                               namespace='foo_namespace',
-                               description='Homo sapiens')
+            ExtensionContainer(name="foo", namespace="foo_namespace", description="Homo sapiens")
 
 
 @pytest.mark.skipif(not REQUIREMENTS_INSTALLED, reason="optional LinkML module is not installed")
 class TestNonGlobalTypeConfig(TestCase):
     def test_two_type_maps(self):
         type_map1 = TypeMap()
-        load_type_config(config_path='tests/unit/hdmf_config.yaml', type_map=type_map1)
+        load_type_config(config_path="tests/unit/hdmf_config.yaml", type_map=type_map1)
 
         type_map2 = TypeMap()
-        load_type_config(config_path='tests/unit/hdmf_config2.yaml', type_map=type_map2)
+        load_type_config(config_path="tests/unit/hdmf_config2.yaml", type_map=type_map2)
 
         assert type_map1.type_config is not type_map2.type_config
-        assert type_map1.type_config.paths == ['tests/unit/hdmf_config.yaml']
-        assert type_map2.type_config.paths == ['tests/unit/hdmf_config2.yaml']
+        assert type_map1.type_config.paths == ["tests/unit/hdmf_config.yaml"]
+        assert type_map2.type_config.paths == ["tests/unit/hdmf_config2.yaml"]
 
         unload_type_config(type_map1)
         unload_type_config(type_map2)
@@ -368,7 +450,6 @@ class TestNonGlobalTypeConfig(TestCase):
 
 
 class TestOptionalDepsNotInstalled(TestCase):
-
     def setUp(self):
         if REQUIREMENTS_INSTALLED:
             self.skipTest("optional modules are installed")


### PR DESCRIPTION
## Motivation

Fix #1564 Support aliases in term sets. 

- [X] Updated `TermSet.__getitem__` to support look-up using alias terms
- [X] Updated `TermSet__repr__`  and `TermSet._repr_html_` to include aliases in the representation
- [X] Added `TermSet.suggest_term` to suggest a close matching term for a given term. Added `SuggestionStatus` enum to indicate the reason for the suggestion. 
- [X] Added `TermSet.get_primary_term` to look up the corresponding primary term using exact match for aliases
- [X] Added `TypeMap.get_configured_termsets` method to make it easy to get the TermSets's configured for this typemap
- [X] Added `AbstractContainer.get_configured_termsets` convenience method to simplify retrieving configured TermSet's for a particular container instance
- [X] Updated unit tests 
- [x] Update tutorials to describe the use of aliases 

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
