### PR TITLE
Return an empty DataFrame from `HERD.to_dataframe` when there are no references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.2.1 (Upcoming)
+
+### Fixed
+- Fixed `HERD.to_dataframe` raising `ValueError: No objects to concatenate` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. A `HERD` is in this state before any reference is added, and also after `HERD.add_ref_termset` finds none of its terms in the `TermSet` and returns them all as `missing_terms`. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HDMF 6.2.1 (Upcoming)
 
 ### Fixed
-- Fixed `HERD.to_dataframe` raising `ValueError: No objects to concatenate` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. A `HERD` is in this state before any reference is added, and also after `HERD.add_ref_termset` finds none of its terms in the `TermSet` and returns them all as `missing_terms`. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
+- Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 
 ## HDMF 6.2.0 (August 19, 2026)
 

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -863,12 +863,17 @@ class HERD(Container):
         Convert the data from the keys, resources, entities, objects, and object_keys tables
         to a single joint dataframe. I.e., here data is being denormalized, e.g., keys that
         are used across multiple entities or objects will duplicated across the corresponding
-        rows.
+        rows. A HERD that holds no references yields an empty DataFrame with the same columns and dtypes.
 
         Returns: :py:class:`~pandas.DataFrame` with all data merged into a single, flat, denormalized table.
 
         """
         use_categories = popargs('use_categories', kwargs)
+        column_labels = [('files', 'file_object_id'),
+                         ('objects', 'objects_idx'), ('objects', 'object_id'), ('objects', 'files_idx'),
+                         ('objects', 'object_type'), ('objects', 'relative_path'), ('objects', 'field'),
+                         ('keys', 'keys_idx'), ('keys', 'key'),
+                         ('entities', 'entities_idx'), ('entities', 'entity_id'), ('entities', 'entity_uri')]
         # Step 1: Combine the entities, keys, and entity_keys table
         ent_key_df = self.entity_keys.to_dataframe()
         entities_mapped_df = self.entities.to_dataframe().iloc[ent_key_df['entities_idx']].reset_index(drop=True)
@@ -887,38 +892,39 @@ class HERD(Container):
                                               axis=1,
                                               verify_integrity=False)
         # Step 3: merge the combined entities_df and object_keys_df DataFrames
-        result_df = pd.concat(
-            # Create for each row in the objects_keys table a DataFrame with all corresponding data from all tables
-            objs=[pd.merge(
-                    # Find all entities that correspond to the row i of the object_keys_table
-                    ent_key_df[ent_key_df['keys_idx'] == object_keys_df['keys_idx'].iloc[i]].reset_index(drop=True),
-                    # Get a DataFrame for row i of the objects_keys_table
-                    file_object_object_key_df.iloc[[i, ]],
-                    # Merge the entities and object_keys on the keys_idx column so that the values from the single
-                    # object_keys_table row are copied across all corresponding rows in the entities table
-                    on='keys_idx')
-                  for i in range(len(object_keys_df))],
-            # Concatenate the rows of the objs
-            axis=0,
-            verify_integrity=False)
-        # Step 4: Clean up the index and sort columns by table type and name
-        result_df.reset_index(inplace=True, drop=True)
-        # ADD files
-        file_id_col = []
-        files_df = self.files.to_dataframe()
-        for idx in result_df['files_idx']:
-            file_id_val = files_df.iloc[int(idx)]['file_object_id']
-            file_id_col.append(file_id_val)
+        if len(object_keys_df) == 0:
+            # A HERD with no object-key relationships has no rows to merge, so build the empty frame directly
+            result_df = pd.DataFrame(columns=[c[1] for c in column_labels])
+        else:
+            result_df = pd.concat(
+                # Create for each row in the objects_keys table a DataFrame with all corresponding data
+                # from all tables
+                objs=[pd.merge(
+                        # Find all entities that correspond to the row i of the object_keys_table
+                        ent_key_df[ent_key_df['keys_idx'] == object_keys_df['keys_idx'].iloc[i]]
+                        .reset_index(drop=True),
+                        # Get a DataFrame for row i of the objects_keys_table
+                        file_object_object_key_df.iloc[[i, ]],
+                        # Merge the entities and object_keys on the keys_idx column so that the values from the
+                        # single object_keys_table row are copied across all corresponding rows in the entities table
+                        on='keys_idx')
+                      for i in range(len(object_keys_df))],
+                # Concatenate the rows of the objs
+                axis=0,
+                verify_integrity=False)
+            # Step 4: Clean up the index and sort columns by table type and name
+            result_df.reset_index(inplace=True, drop=True)
+            # ADD files
+            file_id_col = []
+            files_df = self.files.to_dataframe()
+            for idx in result_df['files_idx']:
+                file_id_val = files_df.iloc[int(idx)]['file_object_id']
+                file_id_col.append(file_id_val)
 
-        result_df['file_object_id'] = file_id_col
-        column_labels = [('files', 'file_object_id'),
-                         ('objects', 'objects_idx'), ('objects', 'object_id'), ('objects', 'files_idx'),
-                         ('objects', 'object_type'), ('objects', 'relative_path'), ('objects', 'field'),
-                         ('keys', 'keys_idx'), ('keys', 'key'),
-                         ('entities', 'entities_idx'), ('entities', 'entity_id'), ('entities', 'entity_uri')]
-        # sort the columns based on our custom order
-        result_df = result_df.reindex(labels=[c[1] for c in column_labels],
-                                      axis=1)
+            result_df['file_object_id'] = file_id_col
+            # sort the columns based on our custom order
+            result_df = result_df.reindex(labels=[c[1] for c in column_labels],
+                                          axis=1)
         result_df = result_df.astype({'keys_idx': 'uint32',
                                       'objects_idx': 'uint32',
                                       'files_idx': 'uint32',
@@ -930,13 +936,11 @@ class HERD(Container):
         return result_df
 
     def __flattened_dataframe_or_none(self):
-        """Return the flattened ``to_dataframe()`` view, or None when there are no references.
+        """Return the flattened ``to_dataframe()`` view, or None when it cannot be built.
 
-        ``to_dataframe`` raises when the HERD holds no object-key relationships and may fail if the
-        backing file is closed. The repr methods use this helper so they never raise on display.
+        ``to_dataframe`` may fail if the backing file is closed. The repr methods use this helper so
+        they never raise on display.
         """
-        if len(self.object_keys) == 0:
-            return None
         try:
             return self.to_dataframe()
         except Exception:

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -131,9 +131,36 @@ class TestHERD(TestCase):
                                           'entities_idx': 'uint32'})
         pd.testing.assert_frame_equal(result_df, expected_df)
 
+    def populated_herd(self):
+        """Return a HERD holding a single reference."""
+        er = HERD()
+        file = HERDManagerContainer(name='file')
+        container = Container(name='Container')
+        container.parent = file
+        er.add_ref(container=container,
+                   key='Mus musculus',
+                   entity_id='NCBI:txid10090',
+                   entity_uri='https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=10090')
+        return er
+
+    def test_to_dataframe_empty(self):
+        # An empty HERD yields an empty frame whose columns match those of a populated one
+        populated_df = self.populated_herd().to_dataframe()
+        result_df = HERD().to_dataframe()
+        self.assertEqual(len(result_df), 0)
+        self.assertListEqual(list(result_df.columns), list(populated_df.columns))
+        for col in ('keys_idx', 'objects_idx', 'files_idx', 'entities_idx'):
+            self.assertEqual(result_df[col].dtype, populated_df[col].dtype)
+
+    def test_to_dataframe_empty_use_categories(self):
+        populated_df = self.populated_herd().to_dataframe(use_categories=True)
+        result_df = HERD().to_dataframe(use_categories=True)
+        self.assertEqual(len(result_df), 0)
+        self.assertListEqual(list(result_df.columns), list(populated_df.columns))
+
     def test_repr_empty(self):
         er = HERD()
-        # repr and HTML repr must not raise on an empty HERD (to_dataframe raises when empty)
+        # repr and HTML repr must not raise on an empty HERD
         self.assertIn('0 key(s)', repr(er))
         html = er._repr_html_()
         self.assertIn('No external resource references', html)


### PR DESCRIPTION
## Motivation

`HERD.to_dataframe()` raises `ValueError: No objects to concatenate` on a HERD that holds no references:

```python
from hdmf.common.resources import HERD
HERD().to_dataframe()
# ValueError: No objects to concatenate
```

Step 3 of `to_dataframe` builds one merged frame per row of the `object_keys` table and hands the list to `pd.concat`. With no rows, that list is empty and `pd.concat` raises.

An empty HERD is not an exotic state. It is what you get before adding any reference, and it is also what `HERD.add_ref_termset` leaves behind when none of the terms are found in the `TermSet`: the terms come back in the returned `missing_terms` dict, nothing is added, and the natural next step of inspecting the HERD then raises. The repr methods already worked around this with an explicit emptiness check in `__flattened_dataframe_or_none`.

## How to test the behavior?

`to_dataframe` now returns an empty `DataFrame` carrying the same columns as a populated one, in the same order, with the four index columns still typed `uint32`. `use_categories=True` still produces the two-level `MultiIndex`.

Two tests in `tests/unit/common/test_resources.py`, `test_to_dataframe_empty` and `test_to_dataframe_empty_use_categories`, compare an empty HERD's frame against one built from a populated HERD, so they fail if the columns drift apart. Both fail with `ValueError: No objects to concatenate` without the fix.

The emptiness check in `__flattened_dataframe_or_none` is gone, since `to_dataframe` handles the case itself. The helper keeps its `try`/`except` for a HERD whose backing file is closed.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
