### PR TITLE
Support `TermSetWrapper`-wrapped fields and term sequences in `add_ref_termset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.2.1 (Upcoming)
+
+### Changed
+- `HERD.add_ref_termset` works on a container/attribute wrapped in a `TermSetWrapper`. The bulk-add path (no `key` given) reads the terms off the wrapper, for both a sequence and a scalar value, and `termset` defaults to the wrapper's own `TermSet`, so a single wrapped field needs only `container` and `attribute`. `key` also accepts a list, tuple, or array of terms. @rly [#1568](https://github.com/hdmf-dev/hdmf/issues/1568) [#1569](https://github.com/hdmf-dev/hdmf/issues/1569)
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/src/hdmf/common/resources.py
+++ b/src/hdmf/common/resources.py
@@ -455,10 +455,12 @@ class HERD(Container):
              'doc': 'The attribute of the container for the external reference.', 'default': None},
             {'name': 'field', 'type': str, 'default': '',
              'doc': ('The field of the compound data type using an external resource.')},
-            {'name': 'key', 'type': (str, Key), 'default': None,
-             'doc': 'The name of the key or the Key object from the KeyTable for the key to add a resource for.'},
-            {'name': 'termset', 'type': TermSet,
-             'doc': 'The TermSet to be used if the container/attribute does not have one.'}
+            {'name': 'key', 'type': (str, Key, list, tuple, np.ndarray), 'default': None,
+             'doc': ('The name of the key or the Key object from the KeyTable for the key to add a resource for, '
+                     'or a sequence of them.')},
+            {'name': 'termset', 'type': TermSet, 'default': None,
+             'doc': ('The TermSet to be used. Defaults to the TermSet of the container/attribute when it is wrapped '
+                     'in a TermSetWrapper.')}
             )
     def add_ref_termset(self, **kwargs):
         """
@@ -474,16 +476,32 @@ class HERD(Container):
         field = kwargs['field']
         termset = kwargs['termset']
 
-        # if key is provided then add_ref proceeds as normal
-        if key is not None:
-            data = [key]
-        else:
-            # if the key is not provided, proceed to "bulk add"
+        data_object = None
+        if container is not None:
             if attribute is None:
                 data_object = container
             else:
                 data_object = getattr(container, attribute)
-            if isinstance(data_object, (Data, DataIO)):
+
+        if termset is None:
+            # a wrapped container/attribute carries the TermSet its data was validated against
+            if isinstance(data_object, TermSetWrapper):
+                termset = data_object.termset
+            else:
+                msg = ("No TermSet was provided and the container/attribute is not wrapped in a TermSetWrapper. "
+                       "Please provide a TermSet.")
+                raise ValueError(msg)
+
+        # if key is provided then add_ref proceeds as normal
+        if key is not None:
+            data = [key] if isinstance(key, (str, Key)) else key
+        else:
+            # if the key is not provided, proceed to "bulk add"
+            if isinstance(data_object, TermSetWrapper):
+                value = data_object.value
+                # a wrapped scalar becomes a one-element list for a simple iteration downstream
+                data = value if isinstance(value, (list, tuple, np.ndarray)) else [value]
+            elif isinstance(data_object, (Data, DataIO)):
                 data = data_object.data
             elif isinstance(data_object, (list, tuple, np.ndarray)):
                 data = data_object

--- a/tests/unit/common/test_resources.py
+++ b/tests/unit/common/test_resources.py
@@ -528,6 +528,83 @@ class TestHERD(TestCase):
         self.assertEqual(er.objects.data, [(0, col1.object_id, 'VectorData', '', '')])
 
     @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_termset_key_sequence(self):
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        er = HERD()
+        em = HERDManagerContainer()
+
+        col1 = VectorData(name='Species_Data',
+                          description='species from NCBI and Ensemble',
+                          data=['Homo sapiens', 'Mus musculus', 'Ursus arctos horribilis'])
+
+        species = DynamicTable(name='species', description='My species', columns=[col1],)
+        species.parent = em
+
+        er.add_ref_termset(
+                    container=species,
+                    attribute='Species_Data',
+                    key=['Homo sapiens', 'Mus musculus'],
+                    termset=terms
+                   )
+        # the third term of the column is not referenced, so the sequence selected a subset
+        self.assertEqual(er.keys.data, [('Homo sapiens',), ('Mus musculus',)])
+        self.assertEqual(er.entities.data, [('NCBITaxon:9606',
+        'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606'),
+        ('NCBITaxon:10090',
+         'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090')])
+        self.assertEqual(er.objects.data, [(0, col1.object_id, 'VectorData', '', '')])
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_termset_wrapped_attribute(self):
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        er = HERD()
+        em = HERDManagerContainer()
+
+        col1 = VectorData(name='Species_Data',
+                          description='species from NCBI and Ensemble',
+                          data=TermSetWrapper(value=['Homo sapiens', 'Mus musculus'], termset=terms))
+        col1.parent = em
+
+        er.add_ref_termset(container=col1, attribute='data')
+        self.assertEqual(er.keys.data, [('Homo sapiens',), ('Mus musculus',)])
+        self.assertEqual(er.entities.data, [('NCBITaxon:9606',
+        'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=9606'),
+        ('NCBITaxon:10090',
+         'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090')])
+        self.assertEqual(er.objects.data, [(0, col1.object_id, 'VectorData', '', '')])
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_termset_wrapped_scalar(self):
+        terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
+        er = HERD()
+        em = HERDManagerContainer()
+
+        col1 = VectorData(name='Species_Data',
+                          description=TermSetWrapper(value='Mus musculus', termset=terms),
+                          data=['Homo sapiens'])
+        col1.parent = em
+
+        er.add_ref_termset(container=col1, attribute='description')
+        self.assertEqual(er.keys.data, [('Mus musculus',)])
+        self.assertEqual(er.entities.data, [('NCBITaxon:10090',
+        'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10090')])
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
+    def test_add_ref_termset_no_termset_error(self):
+        er = HERD()
+
+        col1 = VectorData(name='Species_Data',
+                          description='species from NCBI and Ensemble',
+                          data=['Homo sapiens'])
+
+        species = DynamicTable(name='species', description='My species', columns=[col1],)
+
+        with self.assertRaisesWith(ValueError,
+                                   "No TermSet was provided and the container/attribute is not wrapped in a "
+                                   "TermSetWrapper. Please provide a TermSet."):
+            er.add_ref_termset(container=species, attribute='Species_Data')
+
+    @unittest.skipIf(not LINKML_INSTALLED, "optional LinkML module is not installed")
     def test_add_ref_termset_missing_terms(self):
         terms = TermSet(term_schema_path='tests/unit/example_test_term_set.yaml')
         er = HERD()


### PR DESCRIPTION
Fix #1568
Fix #1569

Both issues are in the same few lines of `HERD.add_ref_termset`, so they are fixed together.

- The bulk-add path reads the terms off a `TermSetWrapper`, for a sequence value and a scalar one.
- `termset` defaults to the wrapper's own `TermSet`.
- `key` accepts a list, tuple, or array in addition to a `str`/`Key`.

A single wrapped field now needs only `container` and `attribute`. Unwrapped containers/attributes still require an explicit `termset`, and a plain `str` attribute still raises the unsupported-data-object `ValueError`.

## How to test the behavior?

Four tests in `tests/unit/common/test_resources.py`, all of which fail on `dev`: `test_add_ref_termset_wrapped_attribute`, `test_add_ref_termset_wrapped_scalar`, `test_add_ref_termset_key_sequence`, and `test_add_ref_termset_no_termset_error`.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

🤖 Generated with [Claude Code](https://claude.com/claude-code)