### PR TITLE
Work around HDF5 ros3 shutdown deadlock on Windows CI

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -129,6 +129,7 @@ jobs:
   run-ros3-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20  # backstop so a hang costs minutes rather than the 6 hour job limit
     defaults:
       run:
         shell: bash -l {0}  # necessary for conda
@@ -173,4 +174,4 @@ jobs:
 
       - name: Run ros3 tests  # TODO include gallery tests after they are written
         run: |
-          python -m pytest tests/unit/test_io_hdf5_streaming.py
+          python scripts/test_ros3.py tests/unit/test_io_hdf5_streaming.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.2.1 (Upcoming)
+
+### Changed
+- Worked around the HDF5 ros3 shutdown deadlock on Windows ([HDFGroup/hdf5#6560](https://github.com/HDFGroup/hdf5/issues/6560)), which left the `windows-python3.14-ros3` job of the daily "Run all tests" workflow hanging for the full 6 hour GitHub Actions limit after its tests had passed. The ros3 tests run through `scripts/test_ros3.py`, which runs pytest as a child process and terminates it once it has reported an exit code without exiting, and the job carries a `timeout-minutes` backstop. @rly [#1571](https://github.com/hdmf-dev/hdmf/issues/1571)
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/scripts/test_ros3.py
+++ b/scripts/test_ros3.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Run the ros3 tests and recover from the HDF5 ros3 shutdown deadlock on Windows.
+
+The ros3 tests pass and then the interpreter hangs at shutdown, so the job burns the full
+GitHub Actions runtime limit. This script runs pytest in a child process. Once the child has
+reported its exit code but has not exited, the parent terminates it and propagates the code.
+The parent holds no HDF5 state, so it is free of the loader lock the child is stuck on.
+
+Arguments are passed through to pytest.
+
+See https://github.com/hdmf-dev/hdmf/issues/1571 and
+https://github.com/HDFGroup/hdf5/issues/6560
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+CHILD_ENV_VAR = "HDMF_ROS3_EXITCODE_FILE"
+RESULT_GRACE = 30       # seconds to allow a clean exit after the child reports its result
+STARTUP_TIMEOUT = 1800  # fail if the child never reports a result
+
+
+def read_exitcode(path: str) -> int | None:
+    """Return the exit code the child recorded, or None if it has not recorded one yet."""
+    try:
+        with open(path) as f:
+            content = f.read().strip()
+    except OSError:
+        return None
+    if not content:
+        return None
+    try:
+        return int(content)
+    except ValueError:
+        return None
+
+
+def run_tests(args: list[str]) -> int:
+    """Run pytest, record the exit code where the parent can see it, and return it."""
+    import pytest
+
+    code = int(pytest.main(args))
+    with open(os.environ[CHILD_ENV_VAR], "w") as f:
+        f.write(str(code))
+    return code
+
+
+def supervise(args: list[str]) -> int:
+    """Run the tests in a child process and return its exit code, killing it if it hangs."""
+    fd, result_path = tempfile.mkstemp(prefix="hdmf_ros3_exitcode_")
+    os.close(fd)
+    env = dict(os.environ, **{CHILD_ENV_VAR: result_path})
+    proc = subprocess.Popen([sys.executable, os.path.abspath(__file__)] + args, env=env)
+
+    start = time.monotonic()
+    reported = None
+    reported_at = None
+    try:
+        while True:
+            rc = proc.poll()
+            if rc is not None:
+                return rc
+
+            if reported_at is None:
+                reported = read_exitcode(result_path)
+                if reported is not None:
+                    reported_at = time.monotonic()
+
+            if reported_at is not None and time.monotonic() - reported_at > RESULT_GRACE:
+                print("pytest reported exit code %d but did not exit within %ds; terminating it"
+                      % (reported, RESULT_GRACE), flush=True)
+                proc.kill()
+                proc.wait()
+                return reported
+
+            if reported_at is None and time.monotonic() - start > STARTUP_TIMEOUT:
+                print("pytest did not report an exit code within %ds; terminating it"
+                      % STARTUP_TIMEOUT, flush=True)
+                proc.kill()
+                proc.wait()
+                return 1
+
+            time.sleep(1)
+    finally:
+        try:
+            os.remove(result_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    if CHILD_ENV_VAR in os.environ:
+        sys.exit(run_tests(sys.argv[1:]))
+    sys.exit(supervise(sys.argv[1:]))


### PR DESCRIPTION
Fix #1571

This is an upstream HDF5 defect, filed at https://github.com/HDFGroup/hdf5/issues/6560. This PR is a CI-side workaround so the daily job goes green while it is resolved upstream. It mirrors the PyNWB workaround in NeurodataWithoutBorders/pynwb#2229.

Backing the workaround out once HDF5 ships the fix is tracked in #1573.

## Changes

- `scripts/test_ros3.py`: runs pytest as a child process; once the child reports its exit code but fails to exit, terminates it from the parent (which holds no HDF5 state and so is not subject to the loader-lock deadlock) and propagates the reported code. A no-op on platforms that exit cleanly.
- `run_all_tests.yml`: the ros3 job runs through the wrapper and gets `timeout-minutes: 20` as a backstop.

The ros3 jobs in `run_tests.yml` and `run_coverage.yml` are Linux-only, so they are untouched.

## How to test the behavior?

Exit-code passthrough, against a test file that hangs at interpreter shutdown the way the ros3 tests do (`atexit` handler sleeping for an hour):

| case | exit code | elapsed |
| --- | --- | --- |
| tests pass, child exits cleanly | 0 | normal |
| tests fail, child exits cleanly | 1 | normal |
| tests pass, child hangs | 0 | grace period, not the hang |
| tests fail, child hangs | 1 | grace period, not the hang |

The hang cases are killed after `RESULT_GRACE` seconds instead of running to the job limit, and the real pass/fail outcome is preserved.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
