### PR TITLE
Keep a live class mapped when a second class registers for its data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # HDMF Changelog
 
-## HDMF 6.3.0 (Upcoming)
-
-### Fixed
-- Fixed containers being silently written as a registered ancestor, with the fields their own type declares dropped, after a second class object is registered for the same `(namespace, data_type)`. `register_container_type` now removes only a `TypeSource` placeholder from the class-to-data-type map instead of any previous class, so containers built before a module re-import keep their type. @h-mayorquin [#1575](https://github.com/hdmf-dev/hdmf/pull/1575)
-
 ## HDMF 6.2.1 (Upcoming)
 
 ### Fixed
+- Fixed containers being silently written as a registered ancestor, with the fields their own type declares dropped, after a second class object is registered for the same `(namespace, data_type)`. `register_container_type` now removes only a `TypeSource` placeholder from the class-to-data-type map instead of any previous class, so containers built before a module re-import keep their type. @h-mayorquin [#1575](https://github.com/hdmf-dev/hdmf/pull/1575)
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # HDMF Changelog
 
+## HDMF 6.3.0 (Upcoming)
+
+### Fixed
+- Fixed containers being silently written as a registered ancestor, with the fields their own type declares dropped, after a second class object is registered for the same `(namespace, data_type)`. `register_container_type` now removes only a `TypeSource` placeholder from the class-to-data-type map instead of any previous class, so containers built before a module re-import keep their type. @h-mayorquin [#1575](https://github.com/hdmf-dev/hdmf/pull/1575)
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/src/hdmf/build/manager.py
+++ b/src/hdmf/build/manager.py
@@ -830,10 +830,13 @@ class TypeMap:
         self.__ns_dt_to_container_cls.setdefault(namespace, dict())
         previous_cls = self.__ns_dt_to_container_cls[namespace].get(data_type)
         self.__ns_dt_to_container_cls[namespace][data_type] = container_cls
-        # Remove the previous reverse-map entry only if it belongs to this (namespace, data_type).
-        # A class can appear in multiple namespaces' forward maps (e.g. via include_namespace),
-        # so we must not remove an entry that belongs to a different namespace.
-        if previous_cls is not None and self.__container_cls_to_ns_dt.get(previous_cls) == (namespace, data_type):
+        # Remove the previous reverse-map entry only if it is a TypeSource placeholder for this
+        # (namespace, data_type). A real class is never removed: re-importing a module that defines a
+        # class with @register_class registers a second class object for the same data type, and
+        # containers built before that are still instances of the first one. Dropping its entry would
+        # send them up the MRO to a registered ancestor and write them as that ancestor.
+        previous_is_placeholder = isinstance(previous_cls, TypeSource)
+        if previous_is_placeholder and self.__container_cls_to_ns_dt.get(previous_cls) == (namespace, data_type):
             self.__container_cls_to_ns_dt.pop(previous_cls)
         # Only set the reverse map and class attributes on first registration. Base namespaces
         # are loaded before extensions (topological sort in NamespaceCatalog._order_deps), so

--- a/tests/unit/build_tests/test_io_manager.py
+++ b/tests/unit/build_tests/test_io_manager.py
@@ -913,6 +913,39 @@ class TestRegisterContainerTypeCrossNamespace(TestCase):
         self.assertEqual(ns, 'ns1')
         self.assertEqual(dt, 'Bar')
 
+    def test_reregistration_keeps_the_previous_class_mapped(self):
+        """A live class must keep its data type when a second class object registers for the same type.
+
+        Re-importing a module that defines a class with @register_class builds a second class object for
+        the same data type. Containers created before that are still instances of the first one, so it
+        must keep its entry in the class-to-data-type map, otherwise the build walks up the MRO and
+        writes them as a registered ancestor with the subtype's own fields dropped.
+        """
+        base_spec = GroupSpec(doc='A base type with no datasets', data_type_def='Base')
+        sub_spec = GroupSpec(
+            doc='A subtype that declares a dataset',
+            data_type_def='Sub',
+            data_type_inc='Base',
+            datasets=[DatasetSpec(doc='the payload', name='payload', dtype='text')],
+        )
+        create_load_namespace_yaml('ns1', [base_spec, sub_spec], self.test_dir, {}, self.type_map)
+        Base = self.type_map.get_dt_container_cls('Base', 'ns1')
+        Sub = self.type_map.get_dt_container_cls('Sub', 'ns1')
+        container = Sub(name='thing', payload='important text')
+
+        class SubReimported(Base):
+            pass
+
+        self.type_map.register_container_type('ns1', 'Sub', SubReimported)
+
+        ns, dt = self.type_map.get_container_cls_dt(Sub)
+        self.assertEqual(ns, 'ns1')
+        self.assertEqual(dt, 'Sub')
+
+        builder = BuildManager(self.type_map).build(container, source='test.h5')
+        self.assertEqual(builder.attributes['data_type'], 'Sub')
+        self.assertIn('payload', builder.datasets)
+
     def test_typesource_replacement_updates_reverse_map(self):
         """Replacing a TypeSource with a real class in the same namespace must update the reverse map."""
         bar_spec = GroupSpec(doc='A test group spec', data_type_def='Bar')


### PR DESCRIPTION
A concrete proposal for the first of the two directions I described in #1574. `register_container_type` dropped the previous class's entry in the class to data type map whenever a new class object registered for the same `(namespace, data_type)`, and this PR narrows that to `TypeSource` placeholders, which are never instantiated and so can never be the class of a live container.

This should close #1574.

