### PR TITLE
Port the CI follow-ups from pynwb #2262

### DIFF
--- a/.github/actions/setup-python-tox/action.yml
+++ b/.github/actions/setup-python-tox/action.yml
@@ -1,10 +1,16 @@
 name: Set up Python and tox
-description: Set up the requested Python version with pip caching and install tox.
+description: Set up the requested Python version with optional pip caching and install tox.
 
 inputs:
   python-version:
     description: Python version to pass to actions/setup-python.
     required: true
+  pip-cache:
+    description: >
+      Whether to restore and save the pip download cache, as "true" or "false". Set it to "false"
+      for a build whose output is published, so every dependency is fetched from the index.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -13,7 +19,8 @@ runs:
       uses: actions/setup-python@v7.0.0
       with:
         python-version: ${{ inputs.python-version }}
-        cache: pip
+        # setup-python treats an empty string as "no caching"
+        cache: ${{ inputs.pip-cache == 'true' && 'pip' || '' }}
         cache-dependency-path: pyproject.toml
 
     - name: Install tox

--- a/.github/workflows/check_sphinx_links.yml
+++ b/.github/workflows/check_sphinx_links.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check-sphinx-links:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,6 +10,7 @@ jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,6 +11,9 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -8,6 +8,7 @@ jobs:
   deploy-release:
     name: Deploy release from tag
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment:
       name: pypi
       url: https://pypi.org/p/hdmf
@@ -22,16 +23,11 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+      - name: Set up Python and tox
+        uses: $/.github/actions/setup-python-tox
         with:
           python-version: '3.14'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-          python -m pip list
+          pip-cache: 'false'  # the distributions published from this job are built from a cold cache
 
       - name: Run tox tests
         run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -38,6 +38,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload below apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --installpkg dist/*-none-any.whl
@@ -50,6 +57,9 @@ jobs:
         # Publishes to PyPI via OIDC trusted publishing. The hdmf project on PyPI must have a trusted
         # publisher configured for the hdmf-dev/hdmf repository, the deploy_release.yml workflow, and the
         # pypi environment.
+        # This action validates the distributions with the twine and packaging versions pinned in its
+        # requirements/runtime.txt. When bumping it, set the twine pin in the "Check distribution
+        # metadata" steps of this workflow, run_tests.yml, and run_all_tests.yml to match.
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           skip-existing: true

--- a/.github/workflows/project_action.yml
+++ b/.github/workflows/project_action.yml
@@ -12,6 +12,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: GitHub App token
         id: generate_token

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,6 +8,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -78,6 +78,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --installpkg dist/*-none-any.whl

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
   push:
-    tags:  # run only on new tags that follow semver
-      - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
+    tags:  # run only on new tags that follow semver MAJOR.MINOR.PATCH
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -18,6 +18,7 @@ jobs:
     # configurations based on the github event, so this job is duplicated for the most part
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -64,7 +65,7 @@ jobs:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python and tox
-        uses: ./.github/actions/setup-python-tox
+        uses: $/.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -88,6 +89,7 @@ jobs:
   run-all-gallery-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     defaults:
       run:
         shell: bash
@@ -118,7 +120,7 @@ jobs:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python and tox
-        uses: ./.github/actions/setup-python-tox
+        uses: $/.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
 

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -16,6 +16,7 @@ jobs:
   run-coverage:
     name: ${{ matrix.os }}, opt reqs ${{ matrix.opt_req }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     # TODO handle forks
     # run pipeline on either a push event or a PR event on a fork
     # if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
@@ -70,6 +71,9 @@ jobs:
           pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
+        # CODECOV_TOKEN is not exposed to a pull request from a fork, so the upload is skipped
+        # there and the tests above still run.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         # immutable release (see .github/zizmor.yml for the policy exception)
         uses: codecov/codecov-action@v7.0.0
         with:
@@ -81,6 +85,7 @@ jobs:
   run-ros3-coverage:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash -l {0}  # necessary for conda
@@ -126,6 +131,9 @@ jobs:
           python -m pytest --cov --cov-report=xml --cov-report=term tests/unit/test_io_hdf5_streaming.py
 
       - name: Upload coverage to Codecov
+        # CODECOV_TOKEN is not exposed to a pull request from a fork, so the upload is skipped
+        # there and the tests above still run.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         # immutable release (see .github/zizmor.yml for the policy exception)
         uses: codecov/codecov-action@v7.0.0
         with:

--- a/.github/workflows/run_hdmf_zarr_tests.yml
+++ b/.github/workflows/run_hdmf_zarr_tests.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   run-hdmf-zarr-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -54,6 +54,7 @@ permissions:
 jobs:
   generate-extension-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -87,6 +88,7 @@ jobs:
   run-nwb-extension-tests:
     needs: generate-extension-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: run-nwb-extension-tests - ${{ matrix.extension.name }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.extension.name }}

--- a/.github/workflows/run_nwb_extension_tests.yml
+++ b/.github/workflows/run_nwb_extension_tests.yml
@@ -55,6 +55,9 @@ jobs:
   generate-extension-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/run_pynwb_tests.yml
+++ b/.github/workflows/run_pynwb_tests.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   run-pynwb-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -60,6 +60,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --installpkg dist/*-none-any.whl

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,6 +14,7 @@ jobs:
   run-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
@@ -44,9 +45,11 @@ jobs:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python and tox
-        uses: ./.github/actions/setup-python-tox
+        uses: $/.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
+          # the leg that uploads wheels feeds the "latest" pre-release, so it builds from a cold cache
+          pip-cache: ${{ matrix.upload-wheels && 'false' || 'true' }}
 
       - name: Run tox tests
         run: |
@@ -71,10 +74,12 @@ jobs:
         with:
           name: distributions
           path: dist
+          retention-days: 1  # the deploy-dev job consumes this within the same run
 
   run-gallery-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     defaults:
       run:
         shell: bash
@@ -98,7 +103,7 @@ jobs:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python and tox
-        uses: ./.github/actions/setup-python-tox
+        uses: $/.github/actions/setup-python-tox
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -111,6 +116,7 @@ jobs:
     needs: [run-tests, run-gallery-tests]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -147,6 +153,7 @@ jobs:
   run-ros3-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash -l {0}  # necessary for conda

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,20 +17,21 @@ jobs:
   zizmor:
     name: Run zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v7.0.0
-        with:
-          python-version: '3.14'
-
       - name: Run zizmor
-        env:
-          GH_TOKEN: ${{ github.token }}  # lets zizmor run its online audits against the GitHub API
-        run: |
-          python -m pip install zizmor==1.26.1
-          zizmor --persona regular .github/
+        # The action carries the zizmor version it runs, pinned by container image digest, so
+        # Dependabot keeps zizmor current by bumping the action.
+        # immutable release (see .github/zizmor.yml for the policy exception)
+        uses: zizmorcore/zizmor-action@v0.6.3
+        with:
+          # advanced security requires a permission change and another action and is unnecessary
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,4 +13,5 @@ rules:
         actions/create-github-app-token: ref-pin
         actions/setup-python: ref-pin
         pypa/gh-action-pypi-publish: ref-pin
+        zizmorcore/zizmor-action: ref-pin
         "*": hash-pin

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 !.vscode/extensions.json
 .history
 
+### Coding Agents ###
+.claude/
+
 ### HDMF ###
 
 # Auto-generated apidocs RST files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
+- Fixed the tag filter on the "Run all tests" workflow, which was written as a regular expression and so matched no tag. The full test matrix now runs when a release tag is pushed. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
 
 ### Changed
 - `HERD.add_ref_termset` now works on a container/attribute wrapped in a `TermSetWrapper`. `key` now also accepts a list, tuple, or array of terms. @rly [#1570](https://github.com/hdmf-dev/hdmf/pull/1570)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Internal improvements
 - Tidied the GitHub Actions CI, following [NeurodataWithoutBorders/pynwb#2262](https://github.com/NeurodataWithoutBorders/pynwb/pull/2262): per-job timeouts, self-repository action references, pip caching off for published builds, a Codecov upload that no longer fails on pull requests from forks, and zizmor run through its own action so Dependabot keeps it current. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
+- Added a `twine check --strict` gate on the built distributions, with twine pinned to the version the PyPI publish action bundles, so a metadata problem fails CI rather than the release upload. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
 
 ## HDMF 6.2.0 (August 19, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Changed
 - `HERD.add_ref_termset` now works on a container/attribute wrapped in a `TermSetWrapper`. `key` now also accepts a list, tuple, or array of terms. @rly [#1570](https://github.com/hdmf-dev/hdmf/pull/1570)
 
+### Internal improvements
+- Tidied the GitHub Actions CI, following [NeurodataWithoutBorders/pynwb#2262](https://github.com/NeurodataWithoutBorders/pynwb/pull/2262): per-job timeouts, self-repository action references, pip caching off for published builds, a Codecov upload that no longer fails on pull requests from forks, and zizmor run through its own action so Dependabot keeps it current. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
+
 ## HDMF 6.2.0 (August 19, 2026)
 
 ### Documentation and tutorial enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `HERD.add_ref_termset` now works on a container/attribute wrapped in a `TermSetWrapper`. `key` now also accepts a list, tuple, or array of terms. @rly [#1570](https://github.com/hdmf-dev/hdmf/pull/1570)
 
 ### Internal improvements
-- Tidied the GitHub Actions CI, following [NeurodataWithoutBorders/pynwb#2262](https://github.com/NeurodataWithoutBorders/pynwb/pull/2262): per-job timeouts, self-repository action references, pip caching off for published builds, a Codecov upload that no longer fails on pull requests from forks, and zizmor run through its own action so Dependabot keeps it current. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
+- Tidied the GitHub Actions CI, following [NeurodataWithoutBorders/pynwb#2262](https://github.com/NeurodataWithoutBorders/pynwb/pull/2262): per-job timeouts and concurrency groups, self-repository action references, pip caching off for published builds, a Codecov upload that no longer fails on pull requests from forks, and zizmor run through its own action so Dependabot keeps it current. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
 - Added a `twine check --strict` gate on the built distributions, with twine pinned to the version the PyPI publish action bundles, so a metadata problem fails CI rather than the release upload. @rly [#1577](https://github.com/hdmf-dev/hdmf/pull/1577)
 
 ## HDMF 6.2.0 (August 19, 2026)


### PR DESCRIPTION
## Motivation

Brings hdmf in line with the CI work in [NeurodataWithoutBorders/pynwb#2262](https://github.com/NeurodataWithoutBorders/pynwb/pull/2262), which started as a port of #1518 and picked up several follow-ups along the way. The `permissions`, action pins, `persist-credentials`, Dependabot config and zizmor policy already match between the two repos; this is the remainder.

Three points that are not self-evident from the diff:

- **`uses: $/...`** is GitHub's [self-repository syntax](https://github.blog/changelog/2026-07-01-reference-same-repository-actions-with-self-repository-syntax/), GA since 2026-07-30 and requiring runner ≥ 2.336.0 (hosted runners are on 2.337.0). It resolves to the running commit with no checkout, and satisfies zizmor's `self-repository` audit, which is new in 1.30 and reports the current `./` refs. `actionlint` 1.7.12 predates it and calls it malformed; we do not run actionlint in CI. It is exercised and passing on pynwb#2262.
- **zizmor-action carries its own zizmor**, pinned by container image digest, so Dependabot bumps both together. The `zizmor==1.26.1` pin inside a `run:` step was the one pin in `.github/` that Dependabot could not see. `advanced-security: false` keeps the job at `contents: read`.
- **Timeouts** are set at roughly 3× the maximum runtime measured over the last three successful runs of each workflow.

Also fixes a separate, pre-existing bug found while comparing the two repos: `run_all_tests.yml` wrote its tag filter as a regular expression, but GitHub matches tag filters as globs, so it matched no tag. The run history confirms it, with zero `push` events in the last 40 runs, meaning the full test matrix has never run on a release tag. It now uses the same pattern `deploy_release.yml` already uses, which is what pynwb settled on in NeurodataWithoutBorders/pynwb#2246.

One item from pynwb#2262 is deliberately **not** ported: shallow-cloning the downstream repos in `run_pynwb_tests.yml` and `run_hdmf_zarr_tests.yml`. Both use `hatch-vcs` with `dynamic = ["version"]`, so `--depth 1` would strip the tags they derive their version from. It was safe in pynwb only because nwbinspector pins its version statically.

## How to test the behavior?

```
uvx zizmor@1.30.0 --persona regular .github/
```

Passes with no findings, offline and online. The rest is exercised by this PR's own CI.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
