### PR TITLE
Update  ObjectMapper.__apply_string_type to support Zarr-V3 arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
-- Fixed  `ObjectMapper.__apply_string_type` to allow for Zarr V3 array-like objects. @oruebel [#1580](https://github.com/hdmf-dev/hdmf/pull/1580)
+- Fixed `ObjectMapper.__apply_string_type` to support zarr v3 arrays and other array-like objects that lack `__iter__`, and to convert rank-0 arrays as scalars. This affects `text`, `ascii`, and `isodatetime` specs that declare a shape or dims. @oruebel [#1580](https://github.com/hdmf-dev/hdmf/pull/1580)
 - Fixed reading an `EnumData` from a zarr v3 store raising `ConstructError` with `unhashable type: 'numpy.ndarray'`. `_map_elements` indexed the elements dataset one item at a time and used each item as a dict key, and zarr v3 returns a 0-d array for a single index instead of a scalar. The elements are now read in one slice and iterated in memory. @h-mayorquin [#1581](https://github.com/hdmf-dev/hdmf/pull/1581)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
+- Fixed  `ObjectMapper.__apply_string_type` to allow for Zarr V3 array-like objects. @oruebel [#1580](https://github.com/hdmf-dev/hdmf/pull/1580)
 
 ### Changed
 - `HERD.add_ref_termset` now works on a container/attribute wrapped in a `TermSetWrapper`. `key` now also accepts a list, tuple, or array of terms. @rly [#1570](https://github.com/hdmf-dev/hdmf/pull/1570)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
-- Fixed `ObjectMapper.__apply_string_type` to support zarr v3 arrays and other array-like objects that lack `__iter__`, and to convert rank-0 arrays as scalars. This affects `text`, `ascii`, and `isodatetime` specs that declare a shape or dims. @oruebel [#1580](https://github.com/hdmf-dev/hdmf/pull/1580)
+- Fixed `ObjectMapper.__apply_string_type` to support zarr v3 arrays and other array-like objects that lack `__iter__`, and to convert rank-0 arrays as scalars. This affects `text` and `isodatetime` specs that declare a shape or dims. @oruebel [#1580](https://github.com/hdmf-dev/hdmf/pull/1580)
 - Fixed reading an `EnumData` from a zarr v3 store raising `ConstructError` with `unhashable type: 'numpy.ndarray'`. `_map_elements` indexed the elements dataset one item at a time and used each item as a dict key, and zarr v3 returns a 0-d array for a single index instead of a scalar. The elements are now read in one slice and iterated in memory. @h-mayorquin [#1581](https://github.com/hdmf-dev/hdmf/pull/1581)
 
 ### Changed

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -724,7 +724,7 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # NOTE: if a user passes a h5py.Dataset that is not wrapped with a hdmf.utils.StrDataset,
             # then this conversion may not be correct. Users should unpack their string h5py.Datasets
             # into a numpy array (or wrap them in StrDataset) before passing them to a container object.
-            if hasattr(value, '__iter__') and not isinstance(value, (str, bytes)):
+            if (hasattr(value, '__iter__') or is_array_like(value)) and not isinstance(value, (str, bytes)):
                 return [__apply_string_type(item, string_type) for item in value]
             else:
                 return string_type(value)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -724,8 +724,10 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # NOTE: if a user passes a h5py.Dataset that is not wrapped with a hdmf.utils.StrDataset,
             # then this conversion may not be correct. Users should unpack their string h5py.Datasets
             # into a numpy array (or wrap them in StrDataset) before passing them to a container object.
-            if ((hasattr(value, '__iter__') or is_array_like(value)) and not isinstance(value, (str, bytes))
-                    and getattr(value, 'ndim', None) != 0):
+            if is_array_like(value) and value.ndim == 0:
+                # Array-API-conforming libraries such as zarr v3 return 0-d arrays from scalar indexing.
+                value = value[()]
+            if (hasattr(value, '__iter__') or is_array_like(value)) and not isinstance(value, (str, bytes)):
                 return [__apply_string_type(item, string_type) for item in value]
             else:
                 return string_type(value)

--- a/src/hdmf/build/objectmapper.py
+++ b/src/hdmf/build/objectmapper.py
@@ -724,7 +724,8 @@ class ObjectMapper(metaclass=ExtenderMeta):
             # NOTE: if a user passes a h5py.Dataset that is not wrapped with a hdmf.utils.StrDataset,
             # then this conversion may not be correct. Users should unpack their string h5py.Datasets
             # into a numpy array (or wrap them in StrDataset) before passing them to a container object.
-            if (hasattr(value, '__iter__') or is_array_like(value)) and not isinstance(value, (str, bytes)):
+            if ((hasattr(value, '__iter__') or is_array_like(value)) and not isinstance(value, (str, bytes))
+                    and getattr(value, 'ndim', None) != 0):
                 return [__apply_string_type(item, string_type) for item in value]
             else:
                 return string_type(value)

--- a/tests/unit/build_tests/test_convert_dtype.py
+++ b/tests/unit/build_tests/test_convert_dtype.py
@@ -4,13 +4,21 @@ import h5py
 import unittest
 
 from hdmf.backends.hdf5 import H5DataIO
-from hdmf.build import ObjectMapper
+from hdmf.build import ObjectMapper, BuildManager, TypeMap
+from hdmf.container import Container
 from hdmf.data_utils import DataChunkIterator
 from hdmf.spec import DatasetSpec, RefSpec, DtypeSpec
 from hdmf.testing import TestCase
 from hdmf.utils import ZARR_INSTALLED, StrDataset
 
 H5PY_3 = h5py.__version__.startswith('3')
+
+
+class DataContainer(Container):
+
+    def __init__(self, data):
+        super().__init__(name='test_container')
+        self.data = data
 
 class TestConvertDtype(TestCase):
 
@@ -588,6 +596,31 @@ class TestConvertDtype(TestCase):
         self.assertEqual(list(ret), [b'2020-11-10T00:00:00', b'2020-11-11T00:00:00'])
         self.assertEqual(ret_dtype, 'ascii')
 
+    def test_get_attr_value_isodatetime_spec_ndarray_object(self):
+        """0-d ndarray elements from an object array should be converted as scalars."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        value = np.array([
+            np.array('2020-11-10T00:00:00', dtype=object),
+            np.array('2020-11-11T00:00:00', dtype=object),
+        ], dtype=object)
+        mapper.map_spec('data', spec)
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, ['2020-11-10T00:00:00', '2020-11-11T00:00:00'])
+
+    def test_get_attr_value_isodatetime_spec_0d_ndarray_object(self):
+        """A top-level 0-d ndarray should be converted to a scalar string."""
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        mapper.map_spec('data', spec)
+        value = np.array('2020-11-10T00:00:00', dtype=object)
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, '2020-11-10T00:00:00')
+
     def test_isodatetime_spec_ndarray_string(self):
         """ndarray of pre-formatted ISO strings takes the non-object astype('S') branch."""
         spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
@@ -613,6 +646,32 @@ class TestConvertDtype(TestCase):
         ret, ret_dtype = ObjectMapper.convert_dtype(spec, value)
         self.assertIs(type(ret), zarr.Array)
         self.assertEqual(ret_dtype, 'ascii')
+
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_get_attr_value_isodatetime_spec_zarr_array(self):
+        """0-d arrays from zarr scalar indexing should be converted as scalars."""
+        import zarr
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        mapper.map_spec('data', spec)
+        value = zarr.array(['2020-11-10T00:00:00', '2020-11-11T00:00:00'])
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, ['2020-11-10T00:00:00', '2020-11-11T00:00:00'])
+
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_get_attr_value_isodatetime_spec_0d_zarr_array(self):
+        """A top-level 0-d zarr array should be converted to a scalar string."""
+        import zarr
+        spec = DatasetSpec(doc='an example dataset', dtype='isodatetime', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        mapper.map_spec('data', spec)
+        value = zarr.array('2020-11-10T00:00:00')
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, '2020-11-10T00:00:00')
 
     @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_zarr_array_spec_vlen_utf8(self):

--- a/tests/unit/build_tests/test_convert_dtype.py
+++ b/tests/unit/build_tests/test_convert_dtype.py
@@ -20,6 +20,7 @@ class DataContainer(Container):
         super().__init__(name='test_container')
         self.data = data
 
+
 class TestConvertDtype(TestCase):
 
     def test_value_none(self):
@@ -672,6 +673,30 @@ class TestConvertDtype(TestCase):
         ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
 
         self.assertEqual(ret, '2020-11-10T00:00:00')
+
+    def test_get_attr_value_text_spec_0d_ndarray_object(self):
+        """A top-level 0-d ndarray for a text spec is converted to a scalar string."""
+        spec = DatasetSpec(doc='an example dataset', dtype='text', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        mapper.map_spec('data', spec)
+        value = np.array('Alice', dtype=object)
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, 'Alice')
+
+    @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
+    def test_get_attr_value_text_spec_zarr_array(self):
+        """A zarr array for a text spec is converted elementwise to strings."""
+        import zarr
+        spec = DatasetSpec(doc='an example dataset', dtype='text', name='data', dims=(None,))
+        mapper = ObjectMapper(spec)
+        mapper.map_spec('data', spec)
+        value = zarr.array(['Alice', 'Bob'])
+
+        ret = mapper.get_attr_value(spec=spec, container=DataContainer(value), manager=BuildManager(TypeMap()))
+
+        self.assertEqual(ret, ['Alice', 'Bob'])
 
     @unittest.skipIf(not ZARR_INSTALLED, "Zarr is not installed")
     def test_zarr_array_spec_vlen_utf8(self):


### PR DESCRIPTION
## Motivation

Fix #1579 

Support Zarr.array without requiring `__iter__`

Updated  ObjectMapper.__apply_string_type e string conversion check to accept objects that are array-like, even if they lack __iter__.

## How to test the behavior?

Run `python test-galler.py` on https://github.com/hdmf-dev/hdmf-zarr/pull/366

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [X] Does the PR clearly describe the problem and the solution?
- [X] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf/blob/dev/docs/CONTRIBUTING.rst)?
- [X] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
