### PR TITLE
Materialize the elements array before mapping enum terms to their index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed `HERD.to_dataframe` raising `ValueError` on a `HERD` that holds no references. It returns an empty `DataFrame` with the usual columns. @rly [#1567](https://github.com/hdmf-dev/hdmf/pull/1567)
 - Fixed the windows-python3.14-ros3 job failing on Windows by working around the HDF5 ros3 shutdown deadlock. @rly [#1572](https://github.com/hdmf-dev/hdmf/pull/1572)
+- Fixed reading an `EnumData` from a zarr v3 store raising `ConstructError` with `unhashable type: 'numpy.ndarray'`. `_map_elements` indexed the elements dataset one item at a time and used each item as a dict key, and zarr v3 returns a 0-d array for a single index instead of a scalar. The elements are now read in one slice and iterated in memory. @h-mayorquin [#1581](https://github.com/hdmf-dev/hdmf/pull/1581)
 
 ### Changed
 - `HERD.add_ref_termset` now works on a container/attribute wrapped in a `TermSetWrapper`. `key` now also accepts a list, tuple, or array of terms. @rly [#1570](https://github.com/hdmf-dev/hdmf/pull/1570)

--- a/src/hdmf/common/table.py
+++ b/src/hdmf/common/table.py
@@ -1835,7 +1835,7 @@ def _uint_precision(elements):
 
 def _map_elements(uint, elements):
     """ Map CV terms to their uint index """
-    return {t[1]: uint(t[0]) for t in enumerate(elements)}
+    return {element: uint(index) for index, element in enumerate(elements[:])}
 
 
 @register_class('EnumData', EXP_NAMESPACE)


### PR DESCRIPTION
This comes out of the zarr v3 migration in hdmf-zarr, https://github.com/hdmf-dev/hdmf-zarr/pull/325. Zarr v3 follows the array API and `array[0]` on a 1-d array returns a 0-d array instead of a scalar. `_map_elements` uses those elements as dict keys so any `EnumData` read from a zarr v3 store throws `unhashable type: 'numpy.ndarray'`. hdmf-zarr covers this right now by unwrapping 0-d results in `HDMFZarrArray.__getitem__` and this is one of the two places that need that shim, see https://github.com/hdmf-dev/hdmf-zarr/pull/366.

This PR slices the elements once with `elements[:]` and iterates the result. A full slice comes back as a numpy array with plain scalars on every backend, and the terms are read in one call instead of one per element.

